### PR TITLE
Fix MySQL session timezone not set for pool connections

### DIFF
--- a/src/lib/databaseHelpers.ts
+++ b/src/lib/databaseHelpers.ts
@@ -7,6 +7,7 @@ export const withConnection = async <T>(
 	const connection = await mysql.getConnection();
 
 	try {
+		await connection.query("SET time_zone = '+03:00'");
 		return await fn(connection);
 	} finally {
 		connection.release();

--- a/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
+++ b/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
@@ -8,6 +8,7 @@ function createMockMysql(dateResults: Record<string, unknown>[], fallbackResults
 	return {
 		getConnection: vi.fn().mockResolvedValue({
 			query: vi.fn()
+				.mockResolvedValueOnce([]) // SET time_zone
 				.mockResolvedValueOnce([dateResults])
 				.mockResolvedValueOnce([fallbackResults]),
 			release: vi.fn(),


### PR DESCRIPTION
Fixes #44

## Summary
- Adds `SET time_zone = '+03:00'` in `withConnection` before executing any query, so `CURDATE()` returns the correct local date across all DB operations.

## Test plan
- [ ] Verify `/things-of-the-day` returns date-matched items (not the random fallback) between midnight Moscow time and midnight UTC