### PR TITLE
Exclude current month things from fallback random selection

### DIFF
--- a/src/plugins/thingsOfTheDay/queries.ts
+++ b/src/plugins/thingsOfTheDay/queries.ts
@@ -25,6 +25,7 @@ export const thingsOfTheDayFallbackQuery = `
 		SELECT id
 		FROM thing
 		WHERE exclude_from_daily = FALSE
+			AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(CURDATE(), '%m')
 		ORDER BY RAND(TO_DAYS(CURDATE()))
 		LIMIT 1
 	) AS chosen ON v_things_info.thing_id = chosen.id;


### PR DESCRIPTION
## Summary
- Add month filter to fallback query — things whose `finish_date` falls in the current month are excluded from random picks, so they only appear on their actual date
- Companion PR: mellonis/www.mellonis.ru#5

## Test plan
- [ ] `npm test` passes
- [ ] Verify fallback still returns a random thing when no date match exists
- [ ] Confirm current-month things don't appear as random picks

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)