### PR TITLE
Add cross-service request tracing via X-Request-Id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
@@ -14,6 +15,11 @@ const fastify: FastifyInstance = Fastify({
 	logger: process.env.NODE_ENV === 'production'
 		? true
 		: { transport: { target: 'pino-pretty' } },
+	genReqId: (req) => (req.headers['x-request-id'] as string) || randomUUID(),
+});
+
+fastify.addHook('onSend', async (request, reply) => {
+	reply.header('X-Request-Id', request.id);
 });
 
 fastify.setValidatorCompiler(validatorCompiler);


### PR DESCRIPTION
## Summary
- Use incoming `X-Request-Id` header as Pino request ID (`genReqId`), fall back to random UUID for direct API calls
- Echo `X-Request-Id` in response headers for debugging
- All `request.log.*` calls automatically include the correlated ID

Companion to mellonis/www.mellonis.ru@b6236a4 which generates request IDs in www and forwards them via `ApiClient`.

## Test plan
- [ ] Verify API logs include `reqId` matching the `X-Request-Id` sent by www
- [ ] Verify direct API calls (no header) get a generated UUID
- [ ] Verify response includes `X-Request-Id` header