### PR TITLE
Update dependencies and fix @fastify/static vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -787,9 +787,9 @@
 			}
 		},
 		"node_modules/@fastify/static": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.0.0.tgz",
-			"integrity": "sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.1.tgz",
+			"integrity": "sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==",
 			"funding": [
 				{
 					"type": "github",
@@ -1314,17 +1314,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-			"integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+			"integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.1",
-				"@typescript-eslint/type-utils": "8.58.1",
-				"@typescript-eslint/utils": "8.58.1",
-				"@typescript-eslint/visitor-keys": "8.58.1",
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/type-utils": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1337,7 +1337,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.1",
+				"@typescript-eslint/parser": "^8.58.2",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -1353,16 +1353,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-			"integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+			"integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.1",
-				"@typescript-eslint/types": "8.58.1",
-				"@typescript-eslint/typescript-estree": "8.58.1",
-				"@typescript-eslint/visitor-keys": "8.58.1",
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1378,14 +1378,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-			"integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+			"integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.1",
-				"@typescript-eslint/types": "^8.58.1",
+				"@typescript-eslint/tsconfig-utils": "^8.58.2",
+				"@typescript-eslint/types": "^8.58.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1400,14 +1400,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-			"integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+			"integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.1",
-				"@typescript-eslint/visitor-keys": "8.58.1"
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1418,9 +1418,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-			"integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+			"integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1435,15 +1435,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-			"integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+			"integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.1",
-				"@typescript-eslint/typescript-estree": "8.58.1",
-				"@typescript-eslint/utils": "8.58.1",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1460,9 +1460,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-			"integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+			"integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1474,16 +1474,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-			"integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+			"integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.1",
-				"@typescript-eslint/tsconfig-utils": "8.58.1",
-				"@typescript-eslint/types": "8.58.1",
-				"@typescript-eslint/visitor-keys": "8.58.1",
+				"@typescript-eslint/project-service": "8.58.2",
+				"@typescript-eslint/tsconfig-utils": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1502,16 +1502,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-			"integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+			"integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.1",
-				"@typescript-eslint/types": "8.58.1",
-				"@typescript-eslint/typescript-estree": "8.58.1"
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1526,13 +1526,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-			"integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+			"integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/types": "8.58.2",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -2008,18 +2008,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+			"integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.4",
-				"@eslint/config-helpers": "^0.5.4",
-				"@eslint/core": "^1.2.0",
-				"@eslint/plugin-kit": "^0.7.0",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.5.5",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -2291,9 +2291,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "5.8.4",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-			"integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+			"version": "5.8.5",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+			"integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -3889,9 +3889,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -3903,16 +3903,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.58.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-			"integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+			"integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.58.1",
-				"@typescript-eslint/parser": "8.58.1",
-				"@typescript-eslint/typescript-estree": "8.58.1",
-				"@typescript-eslint/utils": "8.58.1"
+				"@typescript-eslint/eslint-plugin": "8.58.2",
+				"@typescript-eslint/parser": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## Summary
- Update eslint 10.2.0→10.2.1, fastify 5.8.4→5.8.5, typescript 6.0.2→6.0.3, typescript-eslint 8.58.1→8.58.2
- Fix moderate severity @fastify/static path traversal and route guard bypass (→9.1.1)

## Test plan
- [ ] `npm test` passes
- [ ] `npm audit` shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)