### PR TITLE
Add CORS support via @fastify/cors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,12 +41,14 @@ SMTP_LOGIN=notifier@mellonis.ru
 SMTP_PASSWORD=<password>
 SMTP_FROM_NAME=Система оповещений        # required, display name for From header
 SMTP_FROM_ADDRESS=notifier@mellonis.ru   # required, email address for From header (no fallback to SMTP_LOGIN — would leak credentials)
-ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://poetry-old2.mellonis.ru  # required, comma-separated whitelist of client origins for email links
+ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://poetry-old2.mellonis.ru  # required, comma-separated whitelist of client origins (CORS + email links)
 ```
 
 See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead.
 
 ## Architecture
+
+**CORS** is handled by `@fastify/cors`, registered in `src/index.ts` with origins from the `ALLOWED_ORIGINS` env var. Allows `GET`, `POST`, `PUT`, `PATCH`, `DELETE` methods and `Content-Type` + `Authorization` headers.
 
 Fastify app using a plugin-based structure under `src/plugins/`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@fastify/cors": "^11.2.0",
 				"@fastify/mysql": "^5.0.2",
 				"@fastify/swagger": "^9.7.0",
 				"@fastify/swagger-ui": "^5.2.5",
@@ -651,6 +652,26 @@
 				"ajv": "^8.12.0",
 				"ajv-formats": "^3.0.1",
 				"fast-uri": "^3.0.0"
+			}
+		},
+		"node_modules/@fastify/cors": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+			"integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fastify-plugin": "^5.0.0",
+				"toad-cache": "^3.7.0"
 			}
 		},
 		"node_modules/@fastify/error": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"lint": "eslint src"
 	},
 	"dependencies": {
+		"@fastify/cors": "^11.2.0",
 		"@fastify/mysql": "^5.0.2",
 		"@fastify/swagger": "^9.7.0",
 		"@fastify/swagger-ui": "^5.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
+import cors from '@fastify/cors';
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
 import { sectionsPlugin } from './plugins/sections/sections.js';
 import { databasePlugin } from './plugins/database/database.js';
@@ -11,6 +12,8 @@ import { authRoutesPlugin } from './plugins/auth/authRoutes.js';
 import { usersPlugin } from './plugins/users/users.js';
 import { authNotifierPlugin } from './plugins/authNotifier/authNotifier.js';
 import { votesPlugin } from './plugins/votes/votes.js';
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
 const fastify: FastifyInstance = Fastify({
 	logger: process.env.NODE_ENV === 'production'
@@ -26,6 +29,12 @@ fastify.addHook('onSend', async (request, reply) => {
 fastify.setValidatorCompiler(validatorCompiler);
 fastify.setSerializerCompiler(serializerCompiler);
 
+fastify.register(cors, {
+	origin: allowedOrigins,
+	methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+	allowedHeaders: ['Content-Type', 'Authorization'],
+	credentials: true,
+});
 fastify.register(databasePlugin);
 fastify.register(authPlugin);
 fastify.register(authNotifierPlugin);


### PR DESCRIPTION
## Summary
- Install and register `@fastify/cors` using the existing `ALLOWED_ORIGINS` env var
- Allow `GET`, `POST`, `PUT`, `PATCH`, `DELETE` methods with `Content-Type` + `Authorization` headers
- Update CLAUDE.md to document CORS configuration

## Test plan
- [ ] All 64 existing tests pass
- [ ] Verify preflight `OPTIONS` requests return correct CORS headers
- [ ] Verify cross-origin requests from poetry.mellonis.ru are accepted