### PR TITLE
Pin @fastify/static to 9.1.0 for swagger-ui compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -807,30 +807,6 @@
 				"mime": "^3"
 			}
 		},
-		"node_modules/@fastify/static": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.1.tgz",
-			"integrity": "sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/accept-negotiator": "^2.0.0",
-				"@fastify/send": "^4.0.0",
-				"content-disposition": "^1.0.1",
-				"fastify-plugin": "^5.0.0",
-				"fastq": "^1.17.1",
-				"glob": "^13.0.0"
-			}
-		},
 		"node_modules/@fastify/swagger": {
 			"version": "9.7.0",
 			"resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.7.0.tgz",
@@ -875,6 +851,30 @@
 				"openapi-types": "^12.1.3",
 				"rfdc": "^1.3.1",
 				"yaml": "^2.4.1"
+			}
+		},
+		"node_modules/@fastify/swagger-ui/node_modules/@fastify/static": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.0.tgz",
+			"integrity": "sha512-EPRNQYqEYEYTK8yyGbcM0iHpyJaupb94bey5O6iCQfLTADr02kaZU+qeHSdd9H9TiMwTBVkrMa59V8CMbn3avQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/accept-negotiator": "^2.0.0",
+				"@fastify/send": "^4.0.0",
+				"content-disposition": "^1.0.1",
+				"fastify-plugin": "^5.0.0",
+				"fastq": "^1.17.1",
+				"glob": "^13.0.0"
 			}
 		},
 		"node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
 		"pino-pretty": "^13.1.3",
 		"zod": "^4.3.6"
 	},
+	"overrides": {
+		"@fastify/swagger-ui": {
+			"@fastify/static": "9.1.0"
+		}
+	},
 	"devDependencies": {
 		"@tsconfig/node24": "^24.0.0",
 		"@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
## Summary
- Pin `@fastify/static` to 9.1.0 via npm overrides for `@fastify/swagger-ui`
- The 9.1.1 security fix (path traversal) breaks swagger-ui asset serving — CSS and JS files return 404 at `/docs`
- Remove this override once `@fastify/swagger-ui` releases a compatible version

## Test plan
- [ ] `npm test` passes
- [ ] `/docs` loads correctly with all CSS/JS assets