### PR TITLE
Add user vote to thing responses

### DIFF
--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -30,4 +30,5 @@ export const mapThingBaseRow = (row: MySQLRowDataPacket) => ({
 	info: parseJSON(row.info) as ThingBase['info'],
 	notes: parseJSON(row.notes) as ThingBase['notes'],
 	votes: { plus: row.votesPlus as number, minus: row.votesMinus as number },
+	...(row.userVote !== undefined && { userVote: row.userVote as number | null }),
 });

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -16,3 +16,7 @@ export const thingFields = `
 	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote > 0) AS votesPlus,
 	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote < 0) AS votesMinus
 `;
+
+export const userVoteField = `
+	(SELECT vote FROM vote WHERE r_thing_id = thing_id AND r_user_id = ?) AS userVote
+`;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -33,4 +33,5 @@ export const thingSchema = z.object({
 		plus: z.number().int().min(0),
 		minus: z.number().int().min(0),
 	}),
+	userVote: z.optional(z.number().int().min(-1).max(1).nullable()),
 });

--- a/src/plugins/auth/auth.ts
+++ b/src/plugins/auth/auth.ts
@@ -7,6 +7,7 @@ import type { ResolvedRights } from './rights.js';
 declare module 'fastify' {
 	interface FastifyInstance {
 		verifyJwt: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+		optionalVerifyJwt: (request: FastifyRequest) => Promise<void>;
 		requireRight: (right: keyof ResolvedRights) => (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 	}
 	interface FastifyRequest {
@@ -58,6 +59,22 @@ const authPlugin = fastifyPlugin(async (fastify: FastifyInstance) => {
 			request.user = await verifyAccessToken(token, secret);
 		} catch {
 			return reply.code(401).send({ error: 'unauthorized', message: 'Invalid or expired token' });
+		}
+	});
+
+	fastify.decorate('optionalVerifyJwt', async (request: FastifyRequest) => {
+		const authorization = request.headers.authorization;
+
+		if (!authorization?.startsWith('Bearer ')) {
+			return;
+		}
+
+		const token = authorization.substring(7);
+
+		try {
+			request.user = await verifyAccessToken(token, secret);
+		} catch {
+			// invalid token — proceed as unauthenticated
 		}
 	});
 

--- a/src/plugins/sections/databaseHelpers.ts
+++ b/src/plugins/sections/databaseHelpers.ts
@@ -1,5 +1,5 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
-import { sectionByIdQuery, sectionsQuery, sectionThingsQuery } from './queries.js';
+import { sectionByIdQuery, sectionsQuery, sectionThingsQuery, sectionThingsWithUserVoteQuery } from './queries.js';
 import type { Section, Thing } from './schemas.js';
 import { mapThingBaseRow, parseJSON } from '../../lib/mappers.js';
 import { withConnection } from '../../lib/databaseHelpers.js';
@@ -45,8 +45,14 @@ const mapThingRow = (row: MySQLRowDataPacket): Thing => ({
 	position: row.position,
 });
 
-export const getSectionThings = async (mysql: MySQLPromisePool, id: string): Promise<Thing[]> =>
+export const getSectionThings = async (mysql: MySQLPromisePool, id: string, userId?: number): Promise<Thing[]> =>
 	withConnection(mysql, async (connection) => {
+		if (userId) {
+			const [things] = await connection.query<MySQLRowDataPacket[]>(sectionThingsWithUserVoteQuery, [userId, id]);
+
+			return things.map(mapThingRow);
+		}
+
 		const [things] = await connection.query<MySQLRowDataPacket[]>(sectionThingsQuery, [id]);
 
 		return things.map(mapThingRow);

--- a/src/plugins/sections/queries.ts
+++ b/src/plugins/sections/queries.ts
@@ -1,4 +1,4 @@
-import { thingFields } from '../../lib/queries.js';
+import { thingFields, userVoteField } from '../../lib/queries.js';
 
 const sectionFields = `
 	section_identifier   AS id,
@@ -30,6 +30,13 @@ const extendedThingFields = `
 
 export const sectionThingsQuery = `
 	SELECT ${extendedThingFields}
+	FROM v_things_info
+	WHERE section_identifier = ?;
+`;
+
+export const sectionThingsWithUserVoteQuery = `
+	SELECT ${extendedThingFields},
+	${userVoteField}
 	FROM v_things_info
 	WHERE section_identifier = ?;
 `;

--- a/src/plugins/sections/sections.test.ts
+++ b/src/plugins/sections/sections.test.ts
@@ -29,6 +29,8 @@ function buildApp(mysql: MySQLPromisePool) {
 	app.setValidatorCompiler(validatorCompiler);
 	app.setSerializerCompiler(serializerCompiler);
 	app.decorate('mysql', mysql);
+	app.decorateRequest('user', null);
+	app.decorate('optionalVerifyJwt', async () => {});
 	app.register(sectionsPlugin, { prefix: '/sections' });
 
 	return app;

--- a/src/plugins/sections/sections.ts
+++ b/src/plugins/sections/sections.ts
@@ -7,6 +7,8 @@ import { errorResponse } from '../../lib/schemas.js';
 export async function sectionsPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: sections...');
 
+	fastify.addHook('onRequest', fastify.optionalVerifyJwt);
+
 	fastify.get('/', {
 		schema: {
 			description: 'List all sections.',
@@ -45,7 +47,9 @@ export async function sectionsPlugin(fastify: FastifyInstance) {
 					return reply.code(404).send();
 				}
 
-				return await getSectionThings(fastify.mysql, request.params.id);
+				const userId = request.user?.sub;
+
+				return await getSectionThings(fastify.mysql, request.params.id, userId);
 			} catch (error) {
 				request.log.error(error);
 				reply.status(500).send({ error: 'Internal server error' });

--- a/src/plugins/thingsOfTheDay/databaseHelpers.ts
+++ b/src/plugins/thingsOfTheDay/databaseHelpers.ts
@@ -1,5 +1,5 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
-import { thingsForDateQuery, thingsOfTheDayFallbackQuery } from './queries.js';
+import { thingsForDateQuery, thingsForDateWithUserVoteQuery, thingsOfTheDayFallbackQuery, thingsOfTheDayFallbackWithUserVoteQuery } from './queries.js';
 import type { ThingsOfTheDay } from './schemas.js';
 import { mapThingBaseRow } from '../../lib/mappers.js';
 import { withConnection } from '../../lib/databaseHelpers.js';
@@ -29,12 +29,16 @@ const groupByThingId = (rows: MySQLRowDataPacket[]): ThingsOfTheDay[] => {
 	return Array.from(map.values());
 };
 
-export const getThingsOfTheDay = async (mysql: MySQLPromisePool): Promise<ThingsOfTheDay[]> =>
+export const getThingsOfTheDay = async (mysql: MySQLPromisePool, userId?: number): Promise<ThingsOfTheDay[]> =>
 	withConnection(mysql, async (connection) => {
-		let [rows] = await connection.query<MySQLRowDataPacket[]>(thingsForDateQuery);
+		let [rows] = userId
+			? await connection.query<MySQLRowDataPacket[]>(thingsForDateWithUserVoteQuery, [userId])
+			: await connection.query<MySQLRowDataPacket[]>(thingsForDateQuery);
 
 		if (rows.length === 0) {
-			[rows] = await connection.query<MySQLRowDataPacket[]>(thingsOfTheDayFallbackQuery);
+			[rows] = userId
+				? await connection.query<MySQLRowDataPacket[]>(thingsOfTheDayFallbackWithUserVoteQuery, [userId])
+				: await connection.query<MySQLRowDataPacket[]>(thingsOfTheDayFallbackQuery);
 		}
 
 		return groupByThingId(rows);

--- a/src/plugins/thingsOfTheDay/queries.ts
+++ b/src/plugins/thingsOfTheDay/queries.ts
@@ -1,4 +1,4 @@
-import { thingFields } from '../../lib/queries.js';
+import { thingFields, userVoteField } from '../../lib/queries.js';
 
 const extendedThingFields = `
 	${thingFields},
@@ -18,8 +18,34 @@ export const thingsForDateQuery = `
 	ORDER BY thing_finish_date DESC;
 `;
 
+export const thingsForDateWithUserVoteQuery = `
+	SELECT ${extendedThingFields},
+	${userVoteField}
+	FROM v_things_info
+	JOIN thing ON thing.id = v_things_info.thing_id
+	WHERE thing.exclude_from_daily = FALSE
+		AND (SUBSTRING(thing_finish_date, 6) = DATE_FORMAT(CURDATE(), '%m-%d')
+		     OR (SUBSTRING(thing_finish_date, 6, 2) = DATE_FORMAT(CURDATE(), '%m') AND SUBSTRING(thing_finish_date, 9) = '00'
+		         AND CURDATE() = LAST_DAY(CURDATE())))
+	ORDER BY thing_finish_date DESC;
+`;
+
 export const thingsOfTheDayFallbackQuery = `
 	SELECT ${extendedThingFields}
+	FROM v_things_info
+	JOIN (
+		SELECT id
+		FROM thing
+		WHERE exclude_from_daily = FALSE
+			AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(CURDATE(), '%m')
+		ORDER BY RAND(TO_DAYS(CURDATE()))
+		LIMIT 1
+	) AS chosen ON v_things_info.thing_id = chosen.id;
+`;
+
+export const thingsOfTheDayFallbackWithUserVoteQuery = `
+	SELECT ${extendedThingFields},
+	${userVoteField}
 	FROM v_things_info
 	JOIN (
 		SELECT id

--- a/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
+++ b/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
@@ -27,6 +27,8 @@ function buildApp(mysql: MySQLPromisePool) {
 	app.setValidatorCompiler(validatorCompiler);
 	app.setSerializerCompiler(serializerCompiler);
 	app.decorate('mysql', mysql);
+	app.decorateRequest('user', null);
+	app.decorate('optionalVerifyJwt', async () => {});
 	app.register(thingsOfTheDayPlugin, { prefix: '/things-of-the-day' });
 
 	return app;

--- a/src/plugins/thingsOfTheDay/thingsOfTheDay.ts
+++ b/src/plugins/thingsOfTheDay/thingsOfTheDay.ts
@@ -6,6 +6,8 @@ import { errorResponse } from '../../lib/schemas.js';
 export async function thingsOfTheDayPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: thingsOfTheDay...');
 
+	fastify.addHook('onRequest', fastify.optionalVerifyJwt);
+
 	fastify.get('/', {
 		schema: {
 			description: 'Get things matching today\'s date, or a random daily selection as fallback.',
@@ -16,7 +18,9 @@ export async function thingsOfTheDayPlugin(fastify: FastifyInstance) {
 			},
 		}, handler: async (request, reply) => {
 			try {
-				return await getThingsOfTheDay(fastify.mysql);
+				const userId = request.user?.sub;
+
+				return await getThingsOfTheDay(fastify.mysql, userId);
 			} catch (error) {
 				request.log.error(error);
 				reply.status(500).send({ error: 'Internal server error' });


### PR DESCRIPTION
## Summary
- Add `optionalVerifyJwt` hook that parses JWT without failing on missing/invalid tokens
- Sections and things-of-the-day endpoints now include `userVote` field when authenticated
- No breaking changes — `userVote` is optional, absent for unauthenticated requests

## Test plan
- [ ] All 64 tests pass
- [ ] `GET /sections/:id` without auth returns things without `userVote`
- [ ] `GET /sections/:id` with valid Bearer token returns things with `userVote` (1, -1, or null)
- [ ] `GET /things-of-the-day` same behavior