### PR TITLE
Add isAdmin and isEditor to JWT access token claims

### DIFF
--- a/src/plugins/auth/authRoutes.ts
+++ b/src/plugins/auth/authRoutes.ts
@@ -53,24 +53,31 @@ import {
 	type ResetPasswordRequest,
 } from './schemas.js';
 
+const GROUP_ADMINS = 1;
+const GROUP_EDITORS = 2;
+
 const issueTokens = async (
 	fastify: FastifyInstance,
 	userId: number,
 	login: string,
 	userRights: number,
 	groupRights: number,
+	groupId: number,
 	tokenVersion: number,
 ) => {
 	const rights = resolveRights(userRights, groupRights);
+	const banned = isBanned(userRights) || isBanned(groupRights);
+	const isAdmin = !banned && groupId === GROUP_ADMINS;
+	const isEditor = !banned && (groupId === GROUP_ADMINS || groupId === GROUP_EDITORS);
 	const secret = new TextEncoder().encode(process.env.JWT_SECRET!);
 
-	const payload: AccessTokenPayload = { sub: userId, login, tokenVersion, rights };
+	const payload: AccessTokenPayload = { sub: userId, login, isAdmin, isEditor, tokenVersion, rights };
 	const accessToken = await signAccessToken(payload, secret);
 	const refreshToken = generateRefreshToken();
 
 	await createRefreshToken(fastify.mysql, userId, hashRefreshToken(refreshToken));
 
-	return { accessToken, refreshToken, user: { id: userId, login, rights } };
+	return { accessToken, refreshToken, user: { id: userId, login, isAdmin, isEditor, rights } };
 };
 
 export async function authRoutesPlugin(fastify: FastifyInstance) {
@@ -124,7 +131,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				await updateLastLogin(fastify.mysql, user.userId);
 
 				request.log.info({ login, userId: user.userId }, 'Login successful');
-				return await issueTokens(fastify, user.userId, user.login, user.userRights, user.groupRights, user.tokenVersion);
+				return await issueTokens(fastify, user.userId, user.login, user.userRights, user.groupRights, user.groupId, user.tokenVersion);
 			} catch (error) {
 				request.log.error(error);
 				return reply.code(500).send({ error: 'Internal server error' });
@@ -160,7 +167,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				}
 
 				const { accessToken, refreshToken } = await issueTokens(
-					fastify, user.userId, user.login, user.userRights, user.groupRights, user.tokenVersion,
+					fastify, user.userId, user.login, user.userRights, user.groupRights, user.groupId, user.tokenVersion,
 				);
 
 				return { accessToken, refreshToken };

--- a/src/plugins/auth/jwt.test.ts
+++ b/src/plugins/auth/jwt.test.ts
@@ -12,6 +12,8 @@ describe('JWT access tokens', () => {
 		const payload = {
 			sub: 42,
 			login: 'testuser',
+			isAdmin: false,
+			isEditor: true,
 			tokenVersion: 1,
 			rights: { canVote: true },
 		};
@@ -21,12 +23,14 @@ describe('JWT access tokens', () => {
 
 		expect(decoded.sub).toBe(42);
 		expect(decoded.login).toBe('testuser');
+		expect(decoded.isAdmin).toBe(false);
+		expect(decoded.isEditor).toBe(true);
 		expect(decoded.tokenVersion).toBe(1);
 		expect(decoded.rights).toEqual({ canVote: true });
 	});
 
 	it('rejects a token with wrong secret', async () => {
-		const payload = { sub: 1, login: 'user', tokenVersion: 0, rights: { canVote: false } };
+		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false } };
 		const token = await signAccessToken(payload, secret);
 		const wrongSecret = new TextEncoder().encode('wrong-secret-that-is-at-least-32-chars-long');
 

--- a/src/plugins/auth/jwt.ts
+++ b/src/plugins/auth/jwt.ts
@@ -5,6 +5,8 @@ import type { ResolvedRights } from './rights.js';
 export interface AccessTokenPayload {
 	sub: number;
 	login: string;
+	isAdmin: boolean;
+	isEditor: boolean;
 	tokenVersion: number;
 	rights: ResolvedRights;
 }
@@ -17,6 +19,8 @@ const getAccessTokenTtl = (): string => `${process.env.JWT_ACCESS_TOKEN_TTL!}s`;
 export const signAccessToken = async (payload: AccessTokenPayload, secret: Uint8Array): Promise<string> =>
 	new SignJWT({
 		login: payload.login,
+		isAdmin: payload.isAdmin,
+		isEditor: payload.isEditor,
 		tokenVersion: payload.tokenVersion,
 		rights: payload.rights,
 	})
@@ -32,6 +36,8 @@ export const verifyAccessToken = async (token: string, secret: Uint8Array): Prom
 	return {
 		sub: Number(payload.sub),
 		login: payload.login as string,
+		isAdmin: payload.isAdmin as boolean,
+		isEditor: payload.isEditor as boolean,
 		tokenVersion: payload.tokenVersion as number,
 		rights: payload.rights as ResolvedRights,
 	};

--- a/src/plugins/users/users.test.ts
+++ b/src/plugins/users/users.test.ts
@@ -51,7 +51,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async () =>
-	signAccessToken({ sub: 1, login: 'testuser', tokenVersion: 0, rights: { canVote: true } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true } }, secret);
 
 describe('PATCH /users/:id/password', () => {
 	it('returns 401 without auth token', async () => {

--- a/src/plugins/votes/votes.test.ts
+++ b/src/plugins/votes/votes.test.ts
@@ -43,7 +43,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async (canVote = true) =>
-	signAccessToken({ sub: 1, login: 'testuser', tokenVersion: 0, rights: { canVote } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote } }, secret);
 
 describe('PUT /things/:thingId/vote', () => {
 	it('returns 401 without auth token', async () => {


### PR DESCRIPTION
Top-level payload fields derived from groupId, so consumers can make authorization decisions from the token without querying the database.