### PR TITLE
Add bookmarks API endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { authRoutesPlugin } from './plugins/auth/authRoutes.js';
 import { usersPlugin } from './plugins/users/users.js';
 import { authNotifierPlugin } from './plugins/authNotifier/authNotifier.js';
 import { votesPlugin } from './plugins/votes/votes.js';
+import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -44,6 +45,7 @@ fastify.register(thingsOfTheDayPlugin, { prefix: '/things-of-the-day' });
 fastify.register(authRoutesPlugin, { prefix: '/auth' });
 fastify.register(usersPlugin, { prefix: '/users' });
 fastify.register(votesPlugin, { prefix: '/things' });
+fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
 
 async function main() {
 	await fastify.listen({

--- a/src/plugins/bookmarks/bookmarks.ts
+++ b/src/plugins/bookmarks/bookmarks.ts
@@ -1,0 +1,202 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import {
+	getBookmarks,
+	resolveThingId,
+	addBookmark,
+	removeBookmark,
+	reorderBookmarks,
+	bulkAddBookmarks,
+	type ResolvedThing,
+} from './databaseHelpers.js';
+import {
+	addBookmarkRequest,
+	removeBookmarkRequest,
+	reorderRequest,
+	bulkAddRequest,
+	bookmarkResponse,
+	type BookmarkItem,
+	type ReorderRequest,
+	type BulkAddRequest,
+} from './schemas.js';
+
+async function resolveOrFail(fastify: FastifyInstance, sectionIdentifier: string, positionInSection: number): Promise<ResolvedThing> {
+	const resolved = await resolveThingId(fastify.mysql, sectionIdentifier, positionInSection);
+
+	if (resolved === null) {
+		const error = new Error(`Thing not found: ${sectionIdentifier}:${positionInSection}`);
+		(error as NodeJS.ErrnoException).code = 'NOT_FOUND';
+		throw error;
+	}
+
+	return resolved;
+}
+
+function isNotFoundError(error: unknown): boolean {
+	return error instanceof Error && (error as NodeJS.ErrnoException).code === 'NOT_FOUND';
+}
+
+export async function bookmarksPlugin(fastify: FastifyInstance) {
+	fastify.log.info('[PLUGIN] Registering: bookmarks...');
+
+	fastify.addHook('onRequest', fastify.verifyJwt);
+
+	fastify.get('/', {
+		schema: {
+			description: 'Get user bookmarks',
+			tags: ['Bookmarks'],
+			response: {
+				200: bookmarkResponse,
+				401: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request) => {
+			const userId = request.user!.sub;
+			return await getBookmarks(fastify.mysql, userId);
+		},
+	});
+
+	fastify.post('/', {
+		schema: {
+			description: 'Add a bookmark',
+			tags: ['Bookmarks'],
+			body: addBookmarkRequest,
+			response: {
+				200: bookmarkResponse,
+				401: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: BookmarkItem }>, reply) => {
+			const userId = request.user!.sub;
+			const { sectionId, positionInSection } = request.body;
+
+			try {
+				const resolved = await resolveOrFail(fastify, sectionId, positionInSection);
+				await addBookmark(fastify.mysql, userId, resolved.thingId, resolved.sectionId);
+				request.log.info({ userId, sectionId, positionInSection }, 'Bookmark added');
+				return await getBookmarks(fastify.mysql, userId);
+			} catch (error) {
+				if (isNotFoundError(error)) {
+					return reply.code(404).send({ error: (error as Error).message });
+				}
+
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.delete('/', {
+		schema: {
+			description: 'Remove a bookmark',
+			tags: ['Bookmarks'],
+			body: removeBookmarkRequest,
+			response: {
+				200: bookmarkResponse,
+				401: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: BookmarkItem }>, reply) => {
+			const userId = request.user!.sub;
+			const { sectionId, positionInSection } = request.body;
+
+			try {
+				const resolved = await resolveOrFail(fastify, sectionId, positionInSection);
+				await removeBookmark(fastify.mysql, userId, resolved.thingId, resolved.sectionId);
+				request.log.info({ userId, sectionId, positionInSection }, 'Bookmark removed');
+				return await getBookmarks(fastify.mysql, userId);
+			} catch (error) {
+				if (isNotFoundError(error)) {
+					return reply.code(404).send({ error: (error as Error).message });
+				}
+
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put('/order', {
+		schema: {
+			description: 'Reorder bookmarks',
+			tags: ['Bookmarks'],
+			body: reorderRequest,
+			response: {
+				200: bookmarkResponse,
+				401: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: ReorderRequest }>, reply) => {
+			const userId = request.user!.sub;
+
+			try {
+				const items: ResolvedThing[] = [];
+
+				for (const bookmark of request.body.bookmarks) {
+					items.push(await resolveOrFail(fastify, bookmark.sectionId, bookmark.positionInSection));
+				}
+
+				await reorderBookmarks(fastify.mysql, userId, items);
+				request.log.info({ userId, count: items.length }, 'Bookmarks reordered');
+				return await getBookmarks(fastify.mysql, userId);
+			} catch (error) {
+				if (isNotFoundError(error)) {
+					return reply.code(404).send({ error: (error as Error).message });
+				}
+
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.post('/bulk', {
+		schema: {
+			description: 'Bulk-add bookmarks (for migration from localStorage)',
+			tags: ['Bookmarks'],
+			body: bulkAddRequest,
+			response: {
+				200: bookmarkResponse,
+				401: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: BulkAddRequest }>, reply) => {
+			const userId = request.user!.sub;
+
+			try {
+				const items: ResolvedThing[] = [];
+
+				for (const bookmark of request.body.bookmarks) {
+					const resolved = await resolveThingId(fastify.mysql, bookmark.sectionId, bookmark.positionInSection);
+
+					if (resolved !== null) {
+						items.push(resolved);
+					} else {
+						request.log.warn({ userId, sectionId: bookmark.sectionId, positionInSection: bookmark.positionInSection }, 'Bookmark skipped: thing not found');
+					}
+				}
+
+				if (items.length > 0) {
+					await bulkAddBookmarks(fastify.mysql, userId, items);
+					request.log.info({ userId, count: items.length }, 'Bookmarks bulk-added');
+				}
+
+				return await getBookmarks(fastify.mysql, userId);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.log.info('[PLUGIN] Registered: bookmarks');
+}

--- a/src/plugins/bookmarks/databaseHelpers.ts
+++ b/src/plugins/bookmarks/databaseHelpers.ts
@@ -1,0 +1,95 @@
+import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import {
+	getBookmarksQuery,
+	resolveThingIdQuery,
+	addBookmarkQuery,
+	deleteBookmarkQuery,
+	deleteAllBookmarksQuery,
+	insertBookmarkWithOrderQuery,
+} from './queries.js';
+
+export interface BookmarkRow {
+	sectionId: string;
+	positionInSection: number;
+	title: string | null;
+	firstLines: string[] | null;
+}
+
+export interface ResolvedThing {
+	thingId: number;
+	sectionId: number;
+}
+
+const mapBookmarkRow = (row: MySQLRowDataPacket): BookmarkRow => ({
+	sectionId: row.sectionId as string,
+	positionInSection: row.positionInSection as number,
+	title: (row.title as string) ?? null,
+	firstLines: row.firstLines
+		? (row.firstLines as string).replaceAll('\r', '').split('\n')
+		: null,
+});
+
+export const getBookmarks = async (mysql: MySQLPromisePool, userId: number): Promise<BookmarkRow[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(getBookmarksQuery, [userId]);
+		return rows.map(mapBookmarkRow);
+	});
+
+export const resolveThingId = async (
+	mysql: MySQLPromisePool,
+	sectionIdentifier: string,
+	positionInSection: number,
+): Promise<ResolvedThing | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(resolveThingIdQuery, [sectionIdentifier, positionInSection]);
+		return rows.length > 0
+			? { thingId: rows[0].thingId as number, sectionId: rows[0].sectionId as number }
+			: null;
+	});
+
+export const addBookmark = async (mysql: MySQLPromisePool, userId: number, thingId: number, sectionId: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(addBookmarkQuery, [userId, thingId, sectionId, userId]);
+	});
+};
+
+export const removeBookmark = async (mysql: MySQLPromisePool, userId: number, thingId: number, sectionId: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(deleteBookmarkQuery, [userId, thingId, sectionId]);
+	});
+};
+
+export const reorderBookmarks = async (mysql: MySQLPromisePool, userId: number, items: ResolvedThing[]): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+
+		try {
+			await connection.query(deleteAllBookmarksQuery, [userId]);
+
+			for (let i = 0; i < items.length; i++) {
+				await connection.query(insertBookmarkWithOrderQuery, [userId, items[i].thingId, items[i].sectionId, i]);
+			}
+
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+export const bulkAddBookmarks = async (mysql: MySQLPromisePool, userId: number, items: ResolvedThing[]): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(
+			'SELECT COALESCE(MAX(order_index), -1) AS maxOrder FROM bookmark WHERE r_user_id = ?',
+			[userId],
+		);
+		let nextOrder = (rows[0].maxOrder as number) + 1;
+
+		for (const item of items) {
+			await connection.query(insertBookmarkWithOrderQuery, [userId, item.thingId, item.sectionId, nextOrder]);
+			nextOrder++;
+		}
+	});
+};

--- a/src/plugins/bookmarks/queries.ts
+++ b/src/plugins/bookmarks/queries.ts
@@ -1,0 +1,35 @@
+export const getBookmarksQuery = `
+	SELECT
+		v.section_identifier        AS sectionId,
+		v.thing_position_in_section AS positionInSection,
+		v.thing_title               AS title,
+		v.thing_first_lines         AS firstLines
+	FROM bookmark b
+	JOIN v_things_info v ON b.r_thing_id = v.thing_id AND v.section_id = b.r_section_id
+	WHERE b.r_user_id = ?
+	ORDER BY b.order_index;
+`;
+
+export const resolveThingIdQuery = `
+	SELECT ti.r_thing_id AS thingId, ti.r_section_id AS sectionId
+	FROM thing_identifier ti
+	JOIN section s ON ti.r_section_id = s.id
+	WHERE s.identifier = ? AND ti.thing_position_in_section = ?;
+`;
+
+export const addBookmarkQuery = `
+	INSERT INTO bookmark (r_user_id, r_thing_id, r_section_id, order_index)
+	VALUES (?, ?, ?, (SELECT COALESCE(MAX(order_index), -1) + 1 FROM bookmark AS b WHERE b.r_user_id = ?));
+`;
+
+export const deleteBookmarkQuery = `
+	DELETE FROM bookmark WHERE r_user_id = ? AND r_thing_id = ? AND r_section_id = ?;
+`;
+
+export const deleteAllBookmarksQuery = `
+	DELETE FROM bookmark WHERE r_user_id = ?;
+`;
+
+export const insertBookmarkWithOrderQuery = `
+	INSERT IGNORE INTO bookmark (r_user_id, r_thing_id, r_section_id, order_index) VALUES (?, ?, ?, ?);
+`;

--- a/src/plugins/bookmarks/schemas.ts
+++ b/src/plugins/bookmarks/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const bookmarkItem = z.object({
+	sectionId: z.string(),
+	positionInSection: z.coerce.number().int().nonnegative(),
+});
+
+export const bookmarkResponseItem = z.object({
+	sectionId: z.string(),
+	positionInSection: z.number().int(),
+	title: z.string().nullable(),
+	firstLines: z.array(z.string()).nullable(),
+});
+
+export const bookmarkResponse = z.array(bookmarkResponseItem);
+
+export const addBookmarkRequest = bookmarkItem;
+
+export const removeBookmarkRequest = bookmarkItem;
+
+export const reorderRequest = z.object({
+	bookmarks: z.array(bookmarkItem),
+});
+
+export const bulkAddRequest = z.object({
+	bookmarks: z.array(bookmarkItem),
+});
+
+export type BookmarkItem = z.infer<typeof bookmarkItem>;
+export type ReorderRequest = z.infer<typeof reorderRequest>;
+export type BulkAddRequest = z.infer<typeof bulkAddRequest>;


### PR DESCRIPTION
## Summary
- New `bookmark` table (user-specific, with section context and ordering)
- CRUD endpoints: GET/POST/DELETE `/bookmarks`, PUT `/bookmarks/order`
- Bulk-add endpoint POST `/bookmarks/bulk` for migrating localStorage bookmarks on login
- Things resolved via `thing_identifier` JOIN `section` (lightweight, avoids full view)
- Unique constraint per `(user, section, thing)` — same thing bookmarkable from different sections

## Test plan
- [ ] Run migration `00c_bookmarks.sql` on fresh DB
- [ ] Test all 5 endpoints with valid JWT
- [ ] Verify duplicate add is handled (INSERT IGNORE)
- [ ] Verify reorder persists correctly (DELETE + re-INSERT in transaction)
- [ ] Verify bulk-add skips invalid bookmarks with warning log