### PR TITLE
Add optional title field to audio attachment schema

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -25,6 +25,7 @@ export const thingSchema = z.object({
 		attachments: z.optional(z.object({
 			audio: z.optional(z.array(z.object({
 				preload: z.optional(z.enum(['none'])),
+				title: z.optional(z.string()),
 				sources: z.array(z.object({ src: z.string(), type: z.enum(['audio/mpeg']) })),
 			}))),
 		})),


### PR DESCRIPTION
Adds an optional `title` field to the audio attachment object in `thingSchema`.