### PR TITLE
Add optional title field to audio attachment schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Validation and serialization use `fastify-type-provider-zod`. All Fastify route 
 
 **Type-only imports** use `import type` (or inline `type` for mixed imports).
 
+**Audio attachments** in `thingSchema` (`src/lib/schemas.ts`) — each audio item has `preload?: 'none'`, `title?: string`, and `sources` (array of `{src, type: 'audio/mpeg'}`). The `title` field is optional and used by the frontend audio player as the track display name.
+
 **Notes aggregation** uses a correlated subquery with `GROUP_CONCAT(JSON_QUOTE(text) ORDER BY id SEPARATOR ',')` wrapped in `CONCAT('[', ..., ']')` (legacy pattern — `JSON_ARRAYAGG` is available on the current MySQL 8.4.8 if refactored).
 
 **`things-of-the-day` selection** — primary query matches by `MM-DD` ignoring year via `SUBSTRING(thing_finish_date, 6)`, also handles partial dates (`YYYY-MM-00`, `YYYY-00-00`), ordered newest year first. Fallback uses `RAND(TO_DAYS(CURDATE()))` seeded by date for stable daily randomness. Results are grouped by `thing_id` in the app to collect `sections: [{id, position}]`.


### PR DESCRIPTION
## Summary

- Added `title?: string` to the audio attachment object in `thingSchema` (`src/lib/schemas.ts`) so Fastify includes it in serialized responses
- Updated `CLAUDE.md` to document the audio attachment structure

## Test plan

- [ ] API response for sections with audio includes `title` field when present in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)