### PR TITLE
Use unified run.sh instead of per-service wrapper script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,4 +78,4 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
         run: |
           ssh -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST \
-            "IMAGE=$IMAGE $SSH_TARGET/run-poetry.api.sh"
+            "IMAGE=$IMAGE $SSH_TARGET/run.sh poetry-api"


### PR DESCRIPTION
Calls `run.sh poetry-api` directly instead of the removed `run-poetry.api.sh` wrapper.

Part of the run script consolidation in `mellonis/poetry-shared`.