### PR TITLE
Add optional annotation field to section response

### DIFF
--- a/src/plugins/sections/databaseHelpers.ts
+++ b/src/plugins/sections/databaseHelpers.ts
@@ -9,7 +9,7 @@ type SectionSettings = { show_all?: boolean; things_order?: 1 | 0 | -1 };
 const parseSettings = (settings: string | null): SectionSettings =>
 	(parseJSON(settings) as SectionSettings) ?? {};
 
-const mapSectionRow = ({ id, typeId, title, description, settings, thingsCount }: MySQLRowDataPacket): Section => {
+const mapSectionRow = ({ id, typeId, title, description, annotationText, annotationAuthor, settings, thingsCount }: MySQLRowDataPacket): Section => {
 	const { show_all: showAll = false, things_order: thingsOrder = 1 } = parseSettings(settings);
 
 	return {
@@ -17,6 +17,9 @@ const mapSectionRow = ({ id, typeId, title, description, settings, thingsCount }
 		typeId,
 		title,
 		description: description ?? undefined,
+		annotation: annotationText
+			? { text: annotationText, author: annotationAuthor ?? undefined }
+			: undefined,
 		settings: { showAll, thingsOrder },
 		thingsCount,
 	};

--- a/src/plugins/sections/queries.ts
+++ b/src/plugins/sections/queries.ts
@@ -1,12 +1,14 @@
 import { thingFields, userVoteField } from '../../lib/queries.js';
 
 const sectionFields = `
-	section_identifier   AS id,
-	section_type_id      AS typeId,
-	section_title        AS title,
-	section_description  AS description,
+	section_identifier        AS id,
+	section_type_id           AS typeId,
+	section_title             AS title,
+	section_description       AS description,
+	section_annotation_text   AS annotationText,
+	section_annotation_author AS annotationAuthor,
 	settings,
-	section_things_count AS thingsCount
+	section_things_count      AS thingsCount
 `;
 
 export const sectionsQuery = `

--- a/src/plugins/sections/schemas.ts
+++ b/src/plugins/sections/schemas.ts
@@ -13,12 +13,18 @@ enum SectionThingsOrder {
 	Desc = -1,
 }
 
+const annotationSchema = z.object({
+	text: z.string(),
+	author: z.optional(z.string()),
+});
+
 export const sectionsResponse = z.array(
 	z.object({
 		id: z.string(),
 		typeId: z.enum(SectionType),
 		title: z.string(),
 		description: z.optional(z.string()),
+		annotation: z.optional(annotationSchema),
 		settings: z.object({
 			showAll: z.boolean(),
 			thingsOrder: z.enum(SectionThingsOrder),

--- a/src/plugins/sections/sections.test.ts
+++ b/src/plugins/sections/sections.test.ts
@@ -41,6 +41,8 @@ const sectionRow = {
 	typeId: 1,
 	title: 'Poetry',
 	description: null,
+	annotationText: null,
+	annotationAuthor: null,
 	settings: JSON.stringify({ show_all: false, things_order: 1 }),
 	thingsCount: 2,
 };
@@ -123,6 +125,40 @@ describe('GET /sections', () => {
 		const response = await app.inject({ method: 'GET', url: '/sections' });
 
 		expect(response.json()[0].description).toBe('A poetry collection');
+	});
+
+	it('omits annotation when annotationText is null', async () => {
+		const app = buildApp(createMockMysql([sectionRow]));
+		const response = await app.inject({ method: 'GET', url: '/sections' });
+
+		expect(response.json()[0].annotation).toBeUndefined();
+	});
+
+	it('includes annotation with text and author', async () => {
+		const app = buildApp(createMockMysql([{
+			...sectionRow,
+			annotationText: 'Some epigraph text',
+			annotationAuthor: 'Some Author',
+		}]));
+		const response = await app.inject({ method: 'GET', url: '/sections' });
+
+		expect(response.json()[0].annotation).toEqual({
+			text: 'Some epigraph text',
+			author: 'Some Author',
+		});
+	});
+
+	it('includes annotation with text only when author is null', async () => {
+		const app = buildApp(createMockMysql([{
+			...sectionRow,
+			annotationText: 'Some epigraph text',
+			annotationAuthor: null,
+		}]));
+		const response = await app.inject({ method: 'GET', url: '/sections' });
+
+		expect(response.json()[0].annotation).toEqual({
+			text: 'Some epigraph text',
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- Adds optional `annotation: { text: string, author?: string }` to section response
- Omitted when no annotation text is set
- 3 new test cases added

Depends on mellonis/www.mellonis.ru DB migration (already applied to production DB).