### PR TITLE
Add GET /author endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Fastify app using a plugin-based structure under `src/plugins/`:
 - **`thingsOfTheDay/`** — routes prefixed `/things-of-the-day`
 - **`users/`** — routes prefixed `/users` (change password, delete account)
 - **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`). Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote. All mutations return updated `{ plus, minus }` counts
+- **`author/`** — routes prefixed `/author`. `GET /` returns author biography text (sourced from `news` table, id=1). No auth required
 
 Each route plugin is split into: `*.ts` (handler), `schemas.ts`, `queries.ts`, `databaseHelpers.ts`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { usersPlugin } from './plugins/users/users.js';
 import { authNotifierPlugin } from './plugins/authNotifier/authNotifier.js';
 import { votesPlugin } from './plugins/votes/votes.js';
 import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
+import { authorPlugin } from './plugins/author/author.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -48,6 +49,7 @@ fastify.register(passkeyRoutesPlugin, { prefix: '/auth' });
 fastify.register(usersPlugin, { prefix: '/users' });
 fastify.register(votesPlugin, { prefix: '/things' });
 fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
+fastify.register(authorPlugin, { prefix: '/author' });
 
 async function main() {
 	await fastify.listen({

--- a/src/plugins/author/author.ts
+++ b/src/plugins/author/author.ts
@@ -1,0 +1,36 @@
+import type { FastifyInstance } from 'fastify';
+import { getAuthor } from './databaseHelpers.js';
+import { authorResponse } from './schemas.js';
+import { errorResponse } from '../../lib/schemas.js';
+
+export async function authorPlugin(fastify: FastifyInstance) {
+	fastify.log.info('[PLUGIN] Registering: author...');
+
+	fastify.get('/', {
+		schema: {
+			description: 'Get author information.',
+			tags: ['Author'],
+			response: {
+				200: authorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const author = await getAuthor(fastify.mysql);
+
+				if (!author) {
+					return reply.code(404).send({ error: 'Author information not found' });
+				}
+
+				return author;
+			} catch (error) {
+				request.log.error(error);
+				reply.status(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.log.info('[PLUGIN] Registered: author');
+}

--- a/src/plugins/author/databaseHelpers.ts
+++ b/src/plugins/author/databaseHelpers.ts
@@ -1,0 +1,15 @@
+import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
+import { authorQuery } from './queries.js';
+import type { Author } from './schemas.js';
+import { withConnection } from '../../lib/databaseHelpers.js';
+
+export const getAuthor = async (mysql: MySQLPromisePool): Promise<Author | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(authorQuery);
+
+		if (rows.length === 0) {
+			return null;
+		}
+
+		return { text: rows[0].text };
+	});

--- a/src/plugins/author/queries.ts
+++ b/src/plugins/author/queries.ts
@@ -1,0 +1,5 @@
+export const authorQuery = `
+	SELECT news_text AS text
+	FROM v_news_info
+	WHERE news_id = 1;
+`;

--- a/src/plugins/author/schemas.ts
+++ b/src/plugins/author/schemas.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const authorResponse = z.object({
+	text: z.string(),
+});
+
+export type Author = z.infer<typeof authorResponse>;


### PR DESCRIPTION
## Summary
- Add `GET /author` endpoint that returns author biography text
- Sourced from `news` table (id=1), decoupled from news endpoints
- Returns `{ text }` on success, 404 if not found
- Update CLAUDE.md with author plugin docs

## Test plan
- [ ] Verify `GET /author` returns author bio text
- [ ] Verify 404 when news id=1 is missing