### PR TITLE
Add date field to GET /author response

### DIFF
--- a/src/plugins/author/databaseHelpers.ts
+++ b/src/plugins/author/databaseHelpers.ts
@@ -11,5 +11,5 @@ export const getAuthor = async (mysql: MySQLPromisePool): Promise<Author | null>
 			return null;
 		}
 
-		return { text: rows[0].text };
+		return { text: rows[0].text, date: rows[0].date };
 	});

--- a/src/plugins/author/queries.ts
+++ b/src/plugins/author/queries.ts
@@ -1,5 +1,5 @@
 export const authorQuery = `
-	SELECT news_text AS text
+	SELECT news_text AS text, news_date AS date
 	FROM v_news_info
 	WHERE news_id = 1;
 `;

--- a/src/plugins/author/schemas.ts
+++ b/src/plugins/author/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const authorResponse = z.object({
 	text: z.string(),
+	date: z.string(),
 });
 
 export type Author = z.infer<typeof authorResponse>;


### PR DESCRIPTION
## Summary
- Include `date` (from `news_date`) in the author endpoint response for sitemap `lastmod`

## Test plan
- [ ] Verify `GET /author` returns `{ text, date }`