### PR TITLE
Add CMS plugin for section management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Fastify app using a plugin-based structure under `src/plugins/`:
 - **`users/`** — routes prefixed `/users` (change password, delete account)
 - **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`). Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote. All mutations return updated `{ plus, minus }` counts
 - **`author/`** — routes prefixed `/author`. `GET /` returns author biography text (sourced from `news` table, id=1). No auth required
+- **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations additionally require `canEditContent` right (bit 12). Split into sub-plugins: `sectionRoutes.ts` (section types + sections CRUD + reorder), `sectionThingRoutes.ts` (things within sections CRUD + reorder). Shared hook in `hooks.ts`. Section settings map between API format (`{ showAll, reverseOrder }`) and DB format (`{ show_all, things_order }`); stored as `NULL` when all defaults. Reordering things uses two-phase UPDATE with high offset to avoid unique constraint conflicts on `thing_position_in_section`. DELETE section cascades thing_identifiers but refuses if external redirects (`r_redirect_thing_identifier_id`) point into the section
 
 Each route plugin is split into: `*.ts` (handler), `schemas.ts`, `queries.ts`, `databaseHelpers.ts`.
 

--- a/api.http
+++ b/api.http
@@ -158,6 +158,80 @@ Authorization: Bearer {{login.response.body.accessToken}}
 DELETE {{host}}/auth/passkeys/1
 Authorization: Bearer {{login.response.body.accessToken}}
 
+### ---- CMS: Section Types ----
+
+### List section types (requires editor role)
+GET {{host}}/cms/section-types
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### ---- CMS: Sections ----
+
+### List all sections (requires editor role)
+GET {{host}}/cms/sections
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Create a section (requires editor + canEditContent)
+POST {{host}}/cms/sections
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "identifier": "newsec",
+  "title": "New Section",
+  "typeId": 1
+}
+
+### Update a section (requires editor + canEditContent)
+PUT {{host}}/cms/sections/10
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "title": "Updated Title",
+  "settings": { "showAll": true, "reverseOrder": false }
+}
+
+### Delete a section (requires editor + canEditContent, must have no things)
+DELETE {{host}}/cms/sections/10
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Reorder sections (requires editor + canEditContent)
+PUT {{host}}/cms/sections/reorder
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "sectionIds": [10, 11, 12]
+}
+
+### ---- CMS: Things in Section ----
+
+### List things in a section (requires editor role)
+GET {{host}}/cms/sections/10/things
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Add a thing to a section (requires editor + canEditContent)
+POST {{host}}/cms/sections/10/things
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "thingId": 1
+}
+
+### Remove a thing from a section (requires editor + canEditContent)
+DELETE {{host}}/cms/sections/10/things/1
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Reorder things in a section (requires editor + canEditContent)
+PUT {{host}}/cms/sections/10/things/reorder
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "thingIds": [3, 1, 2]
+}
+
 ### ---- Votes ----
 
 ### Cast or update a vote (requires auth + canVote)

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -241,9 +241,78 @@ else
     FAIL=$((FAIL + 2))
 fi
 
-# 10. Voting
+# 10. CMS (requires editor role + canEditContent right)
 bold ""
-bold "10. Voting"
+bold "10. CMS"
+
+# Promote test user to editor group (r_group_id=2) via direct DB query
+# Parse CONNECTION_STRING from .env: mysql://user:password@host:port/schema
+DB_CONN=$(grep '^CONNECTION_STRING=' .env | sed 's/^CONNECTION_STRING=//')
+DB_USER=$(echo "$DB_CONN" | sed 's|mysql://||;s|:.*||')
+DB_PASS=$(echo "$DB_CONN" | sed 's|mysql://[^:]*:||;s|@.*||')
+DB_HOST=$(echo "$DB_CONN" | sed 's|.*@||;s|:.*||')
+DB_PORT=$(echo "$DB_CONN" | sed 's|.*:||;s|/.*||')
+DB_NAME=$(echo "$DB_CONN" | sed 's|.*/||')
+
+mysql -u "$DB_USER" -p"$DB_PASS" -h "$DB_HOST" -P "$DB_PORT" "$DB_NAME" -e \
+    "UPDATE auth_user SET r_group_id = 2 WHERE login = '${TEST_LOGIN}'" 2>/dev/null
+
+# Re-login to get updated JWT with editor role
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+assert_status "POST /auth/login (as editor)" 200 "$RESPONSE_STATUS"
+
+ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
+
+if [ -n "$ACCESS_TOKEN" ]; then
+    # Read-only CMS endpoints (editor role sufficient)
+    parse_response "$(request GET /cms/section-types "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/section-types" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request GET /cms/sections "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/sections" 200 "$RESPONSE_STATUS"
+
+    # Mutation without canEditContent right — should be 403
+    parse_response "$(request POST /cms/sections "{\"identifier\":\"smtest\",\"title\":\"Smoke\",\"typeId\":1}" "$ACCESS_TOKEN")"
+    assert_status "POST /cms/sections (no canEditContent)" 403 "$RESPONSE_STATUS"
+
+    # Grant canEditContent (bit 12) to the test user
+    mysql -u "$DB_USER" -p"$DB_PASS" -h "$DB_HOST" -P "$DB_PORT" "$DB_NAME" -e \
+        "UPDATE auth_user SET rights = rights | (1 << 12) WHERE login = '${TEST_LOGIN}'" 2>/dev/null
+
+    # Re-login to get updated JWT with canEditContent
+    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+
+    # Create section
+    parse_response "$(request POST /cms/sections "{\"identifier\":\"smtest\",\"title\":\"Smoke Test\",\"typeId\":1}" "$ACCESS_TOKEN")"
+    assert_status "POST /cms/sections (create)" 201 "$RESPONSE_STATUS"
+    SECTION_DB_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "$SECTION_DB_ID" ]; then
+        # Update section
+        parse_response "$(request PUT "/cms/sections/${SECTION_DB_ID}" "{\"title\":\"Smoke Updated\",\"settings\":{\"showAll\":true,\"reverseOrder\":false}}" "$ACCESS_TOKEN")"
+        assert_status "PUT /cms/sections/:id (update)" 200 "$RESPONSE_STATUS"
+
+        # List things (empty)
+        parse_response "$(request GET "/cms/sections/${SECTION_DB_ID}/things" "" "$ACCESS_TOKEN")"
+        assert_status "GET /cms/sections/:id/things" 200 "$RESPONSE_STATUS"
+
+        # Delete section (empty, should succeed)
+        parse_response "$(request DELETE "/cms/sections/${SECTION_DB_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/sections/:id" 204 "$RESPONSE_STATUS"
+    else
+        red "  SKIP  CMS section CRUD (could not extract section ID)"
+        FAIL=$((FAIL + 3))
+    fi
+else
+    red "  SKIP  CMS (no access token after editor promotion)"
+    FAIL=$((FAIL + 7))
+fi
+
+# 11. Voting
+bold ""
+bold "11. Voting"
 
 if [ -n "$ACCESS_TOKEN" ]; then
     # Cast a vote
@@ -262,9 +331,9 @@ else
     FAIL=$((FAIL + 3))
 fi
 
-# 11. Logout
+# 12. Logout
 bold ""
-bold "11. Logout"
+bold "12. Logout"
 
 if [ -n "$REFRESH_TOKEN" ]; then
     parse_response "$(request POST /auth/logout "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
@@ -278,9 +347,9 @@ else
     FAIL=$((FAIL + 2))
 fi
 
-# 12. Cleanup — delete the test user
+# 13. Cleanup — delete the test user
 bold ""
-bold "12. Cleanup"
+bold "13. Cleanup"
 
 # Login fresh for deletion
 parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { authNotifierPlugin } from './plugins/authNotifier/authNotifier.js';
 import { votesPlugin } from './plugins/votes/votes.js';
 import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
 import { authorPlugin } from './plugins/author/author.js';
+import { cmsPlugin } from './plugins/cms/cms.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -50,6 +51,7 @@ fastify.register(usersPlugin, { prefix: '/users' });
 fastify.register(votesPlugin, { prefix: '/things' });
 fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
 fastify.register(authorPlugin, { prefix: '/author' });
+fastify.register(cmsPlugin, { prefix: '/cms' });
 
 async function main() {
 	await fastify.listen({

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -4,6 +4,9 @@ import type { thingSchema } from './schemas.js';
 
 type ThingBase = z.infer<typeof thingSchema>;
 
+export const splitLines = (value: string): string[] =>
+	value.replaceAll('\r', '').split('\n');
+
 export const parseJSON = (value: string | null): unknown => {
 	if (!value) {
 		return undefined;
@@ -20,7 +23,7 @@ export const mapThingBaseRow = (row: MySQLRowDataPacket) => ({
 	id: row.id as number,
 	categoryId: row.categoryId,
 	title: row.title ?? undefined as string | undefined,
-	firstLines: (row.firstLines ?? undefined) ? (row.firstLines as string).replaceAll('\r', '').split('\n') : undefined,
+	firstLines: (row.firstLines ?? undefined) ? splitLines(row.firstLines as string) : undefined,
 	startDate: row.startDate ?? undefined as string | undefined,
 	finishDate: row.finishDate ?? undefined as string | undefined,
 	lastModified: row.lastModified ?? undefined as string | undefined,

--- a/src/plugins/auth/auth.test.ts
+++ b/src/plugins/auth/auth.test.ts
@@ -80,7 +80,7 @@ describe('POST /auth/login', () => {
 		expect(body.refreshToken).toBeDefined();
 		expect(body.user.id).toBe(1);
 		expect(body.user.login).toBe('testuser');
-		expect(body.user.rights).toEqual({ canVote: true });
+		expect(body.user.rights).toEqual({ canVote: true, canEditContent: false });
 	});
 
 	it('returns 401 for wrong password', async () => {

--- a/src/plugins/auth/jwt.test.ts
+++ b/src/plugins/auth/jwt.test.ts
@@ -15,7 +15,7 @@ describe('JWT access tokens', () => {
 			isAdmin: false,
 			isEditor: true,
 			tokenVersion: 1,
-			rights: { canVote: true },
+			rights: { canVote: true, canEditContent: false },
 		};
 
 		const token = await signAccessToken(payload, secret);
@@ -26,11 +26,11 @@ describe('JWT access tokens', () => {
 		expect(decoded.isAdmin).toBe(false);
 		expect(decoded.isEditor).toBe(true);
 		expect(decoded.tokenVersion).toBe(1);
-		expect(decoded.rights).toEqual({ canVote: true });
+		expect(decoded.rights).toEqual({ canVote: true, canEditContent: false });
 	});
 
 	it('rejects a token with wrong secret', async () => {
-		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false } };
+		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false, canEditContent: false } };
 		const token = await signAccessToken(payload, secret);
 		const wrongSecret = new TextEncoder().encode('wrong-secret-that-is-at-least-32-chars-long');
 

--- a/src/plugins/auth/rights.test.ts
+++ b/src/plugins/auth/rights.test.ts
@@ -12,32 +12,54 @@ import {
 describe('resolveRights', () => {
 	// Bits 3..10 rule: (!group) && user
 	it('canVote: false when neither side has bit 3', () => {
-		expect(resolveRights(0, 0)).toEqual({ canVote: false });
+		expect(resolveRights(0, 0)).toEqual({ canVote: false, canEditContent: false });
 	});
 
 	it('canVote: true when user opts in (group has no bit 3)', () => {
-		expect(resolveRights(8, 0)).toEqual({ canVote: true });
+		expect(resolveRights(8, 0)).toEqual({ canVote: true, canEditContent: false });
 	});
 
 	it('canVote: false when group blocks (group has bit 3, user does not)', () => {
-		expect(resolveRights(0, 8)).toEqual({ canVote: false });
+		expect(resolveRights(0, 8)).toEqual({ canVote: false, canEditContent: false });
 	});
 
 	it('canVote: false when group blocks (both sides have bit 3)', () => {
-		expect(resolveRights(8, 8)).toEqual({ canVote: false });
+		expect(resolveRights(8, 8)).toEqual({ canVote: false, canEditContent: false });
 	});
 
 	it('resolves default new user rights (24 = can_vote + can_comment)', () => {
-		expect(resolveRights(24, 0)).toEqual({ canVote: true });
+		expect(resolveRights(24, 0)).toEqual({ canVote: true, canEditContent: false });
+	});
+
+	// Bits 11..15 rule: XOR (group default, user override)
+	it('canEditContent: true when group has bit 12 (editors group = 30720)', () => {
+		expect(resolveRights(24, 30720).canEditContent).toBe(true);
+	});
+
+	it('canEditContent: false when user overrides group bit 12 off', () => {
+		// XOR: both have bit 12 → false
+		expect(resolveRights(24 | 4096, 30720).canEditContent).toBe(false);
+	});
+
+	it('canEditContent: true when user overrides with bit 12 (group has no bit 12)', () => {
+		expect(resolveRights(4096, 0).canEditContent).toBe(true);
+	});
+
+	it('canEditContent: false when neither side has bit 12', () => {
+		expect(resolveRights(0, 0).canEditContent).toBe(false);
 	});
 
 	// Banned override
 	it('zeros all rights when user is banned (bit 2)', () => {
-		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false });
+		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false, canEditContent: false });
 	});
 
 	it('zeros all rights when group is banned (bit 2)', () => {
-		expect(resolveRights(8, 4)).toEqual({ canVote: false });
+		expect(resolveRights(8, 4)).toEqual({ canVote: false, canEditContent: false });
+	});
+
+	it('zeros canEditContent when banned even if group has bit 12', () => {
+		expect(resolveRights(4, 30720).canEditContent).toBe(false);
 	});
 });
 

--- a/src/plugins/auth/rights.ts
+++ b/src/plugins/auth/rights.ts
@@ -3,10 +3,12 @@ const RIGHT_BITS = {
 	passwordResetRequested: 1,
 	banned: 2,
 	canVote: 3,
+	canEditContent: 12,
 } as const;
 
 export interface ResolvedRights {
 	canVote: boolean;
+	canEditContent: boolean;
 }
 
 const hasBit = (value: number, bit: number): boolean => (value & (1 << bit)) !== 0;
@@ -36,6 +38,7 @@ export const resolveRights = (userRights: number, groupRights: number): Resolved
 
 	return {
 		canVote: resolveBit(g, u, RIGHT_BITS.canVote),
+		canEditContent: resolveBit(g, u, RIGHT_BITS.canEditContent),
 	};
 };
 

--- a/src/plugins/auth/schemas.ts
+++ b/src/plugins/auth/schemas.ts
@@ -7,6 +7,7 @@ const loginSchema = z.string()
 
 export const resolvedRightsSchema = z.object({
 	canVote: z.boolean(),
+	canEditContent: z.boolean(),
 });
 
 export const userInfoSchema = z.object({

--- a/src/plugins/bookmarks/databaseHelpers.ts
+++ b/src/plugins/bookmarks/databaseHelpers.ts
@@ -1,5 +1,6 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
 import { withConnection } from '../../lib/databaseHelpers.js';
+import { splitLines } from '../../lib/mappers.js';
 import {
 	getBookmarksQuery,
 	resolveThingIdQuery,
@@ -26,7 +27,7 @@ const mapBookmarkRow = (row: MySQLRowDataPacket): BookmarkRow => ({
 	positionInSection: row.positionInSection as number,
 	title: (row.title as string) ?? null,
 	firstLines: row.firstLines
-		? (row.firstLines as string).replaceAll('\r', '').split('\n')
+		? splitLines(row.firstLines as string)
 		: null,
 });
 

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { authPlugin } from '../auth/auth.js';
+import { cmsPlugin } from './cms.js';
+import { signAccessToken } from '../auth/jwt.js';
+
+const JWT_SECRET = 'test-jwt-secret-that-is-at-least-32-characters-long';
+const secret = new TextEncoder().encode(JWT_SECRET);
+
+beforeEach(() => {
+	vi.stubEnv('JWT_SECRET', JWT_SECRET);
+	vi.stubEnv('JWT_ACCESS_TOKEN_TTL', '900');
+	vi.stubEnv('JWT_REFRESH_TOKEN_TTL', '2592000');
+	vi.stubEnv('ACTIVATION_KEY_TTL', '86400');
+	vi.stubEnv('RESET_KEY_TTL', '3600');
+});
+
+function createMockMysql(...responses: Record<string, unknown>[][]): MySQLPromisePool {
+	let callIndex = 0;
+
+	return {
+		getConnection: vi.fn().mockImplementation(() =>
+			Promise.resolve({
+				query: vi.fn().mockImplementation(() => Promise.resolve([responses[callIndex++] ?? []])),
+				beginTransaction: vi.fn().mockResolvedValue(undefined),
+				commit: vi.fn().mockResolvedValue(undefined),
+				rollback: vi.fn().mockResolvedValue(undefined),
+				release: vi.fn(),
+			})
+		),
+	} as unknown as MySQLPromisePool;
+}
+
+async function buildApp(mysql: MySQLPromisePool) {
+	const app = Fastify({ logger: false });
+
+	app.setValidatorCompiler(validatorCompiler);
+	app.setSerializerCompiler(serializerCompiler);
+	app.decorate('mysql', mysql);
+	app.register(authPlugin);
+	app.register(cmsPlugin, { prefix: '/cms' });
+
+	return app;
+}
+
+const getEditorToken = async (canEditContent = true) =>
+	signAccessToken({
+		sub: 1,
+		login: 'editor',
+		isAdmin: false,
+		isEditor: true,
+		tokenVersion: 0,
+		rights: { canVote: true, canEditContent },
+	}, secret);
+
+const getNonEditorToken = async () =>
+	signAccessToken({
+		sub: 2,
+		login: 'user',
+		isAdmin: false,
+		isEditor: false,
+		tokenVersion: 0,
+		rights: { canVote: true, canEditContent: false },
+	}, secret);
+
+const sectionRow = {
+	id: 10,
+	identifier: 'nstran',
+	title: 'Test Section',
+	description: null,
+	annotationText: null,
+	annotationAuthor: null,
+	typeId: 1,
+	redirectSectionId: null,
+	settings: null,
+	order: 1,
+};
+
+// --- Auth tests ---
+
+describe('CMS auth', () => {
+	it('returns 401 without auth token', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({ method: 'GET', url: '/cms/sections' });
+
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns 403 for non-editor user', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getNonEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().message).toBe('Editor access required');
+	});
+
+	it('allows GET for editor without canEditContent right', async () => {
+		const app = await buildApp(createMockMysql([sectionRow]));
+		const token = await getEditorToken(false);
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	it('returns 403 for mutation without canEditContent right', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getEditorToken(false);
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { identifier: 'test', title: 'Test', typeId: 1 },
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().message).toBe('Missing required right: canEditContent');
+	});
+});
+
+// --- Section types ---
+
+describe('GET /cms/section-types', () => {
+	it('returns section types', async () => {
+		const types = [{ id: 0, title: 'Deprecated' }, { id: 1, title: 'Normal' }];
+		const app = await buildApp(createMockMysql(types));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/section-types',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual(types);
+	});
+});
+
+// --- Sections CRUD ---
+
+describe('GET /cms/sections', () => {
+	it('returns non-deprecated sections', async () => {
+		const app = await buildApp(createMockMysql([sectionRow]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const sections = response.json();
+		expect(sections).toHaveLength(1);
+		expect(sections[0].id).toBe(10);
+		expect(sections[0].settings).toBeNull();
+	});
+
+	it('maps settings correctly', async () => {
+		const row = { ...sectionRow, settings: '{"show_all":true,"things_order":-1}' };
+		const app = await buildApp(createMockMysql([row]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.json()[0].settings).toEqual({ showAll: true, reverseOrder: true });
+	});
+
+	it('maps default settings to reverseOrder false', async () => {
+		const row = { ...sectionRow, settings: '{"show_all":false,"things_order":1}' };
+		const app = await buildApp(createMockMysql([row]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.json()[0].settings).toEqual({ showAll: false, reverseOrder: false });
+	});
+});
+
+describe('POST /cms/sections', () => {
+	it('creates a section', async () => {
+		// Responses: maxOrder query, insert query, getCmsSectionById query
+		const createdRow = { ...sectionRow, id: 99 };
+		const app = await buildApp(createMockMysql(
+			[{ maxOrder: 5 }],
+			[{ insertId: 99 }],
+			[createdRow],
+		));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { identifier: 'newsec', title: 'New Section', typeId: 1 },
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().id).toBe(99);
+	});
+
+	it('rejects invalid identifier', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/sections',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { identifier: 'INVALID', title: 'Test', typeId: 1 },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+});
+
+describe('DELETE /cms/sections/:id', () => {
+	it('refuses deletion when section has incoming redirects', async () => {
+		// Responses: getCmsSectionById, getExternalRedirectsToSection
+		const app = await buildApp(createMockMysql(
+			[sectionRow],
+			[{ fromSectionId: 2, fromSectionIdentifier: 'stran', fromThingId: 5 }],
+		));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/sections/10',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().error).toContain('incoming redirects');
+	});
+
+	it('returns 404 for non-existent section', async () => {
+		const app = await buildApp(createMockMysql([]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/sections/999',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+});
+
+// --- Things in section ---
+
+describe('GET /cms/sections/:id/things', () => {
+	it('returns things in section', async () => {
+		const thingRow = { thingId: 1, position: 1, title: 'Poem', firstLines: 'Line 1\nLine 2' };
+		// Responses: getCmsSectionById, getCmsThingsInSection
+		const app = await buildApp(createMockMysql([sectionRow], [thingRow]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/sections/10/things',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const things = response.json();
+		expect(things).toHaveLength(1);
+		expect(things[0].firstLines).toEqual(['Line 1', 'Line 2']);
+	});
+});
+
+describe('POST /cms/sections/:id/things', () => {
+	it('returns 404 when thing does not exist', async () => {
+		// Responses: getCmsSectionById, thingExists (empty = not found)
+		const app = await buildApp(createMockMysql([sectionRow], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/sections/10/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { thingId: 999 },
+		});
+
+		expect(response.statusCode).toBe(404);
+		expect(response.json().error).toBe('Thing not found');
+	});
+});
+
+describe('PUT /cms/sections/:id/things/reorder', () => {
+	it('rejects mismatched thing IDs', async () => {
+		// Responses: getCmsSectionById, getSectionThingIds
+		const app = await buildApp(createMockMysql(
+			[sectionRow],
+			[{ thingId: 1 }, { thingId: 2 }],
+		));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/sections/10/things/reorder',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { thingIds: [1, 3] },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().error).toContain('must match');
+	});
+});

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -1,0 +1,21 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { sectionRoutes } from './sectionRoutes.js';
+import { sectionThingRoutes } from './sectionThingRoutes.js';
+
+const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
+	if (!request.user?.isEditor) {
+		return reply.code(403).send({ error: 'forbidden', message: 'Editor access required' });
+	}
+};
+
+export async function cmsPlugin(fastify: FastifyInstance) {
+	fastify.log.info('[PLUGIN] Registering: cms...');
+
+	fastify.addHook('onRequest', fastify.verifyJwt);
+	fastify.addHook('onRequest', requireEditorRole);
+
+	fastify.register(sectionRoutes);
+	fastify.register(sectionThingRoutes);
+
+	fastify.log.info('[PLUGIN] Registered: cms');
+}

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -1,0 +1,328 @@
+import type { MySQLPromisePool, MySQLResultSetHeader, MySQLRowDataPacket } from '@fastify/mysql';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { parseJSON, splitLines } from '../../lib/mappers.js';
+import {
+	sectionTypesQuery,
+	cmsSectionsQuery,
+	cmsSectionByIdQuery,
+	createSectionQuery,
+	updateSectionQuery,
+	deleteSectionQuery,
+	deleteAllThingsInSectionQuery,
+	externalRedirectsToSectionQuery,
+	updateSectionOrderQuery,
+	shiftSectionOrdersQuery,
+	maxSectionOrderQuery,
+	allSectionRedirectsQuery,
+	cmsSectionThingsQuery,
+	addThingToSectionQuery,
+	maxThingPositionQuery,
+	shiftThingPositionsQuery,
+	removeThingFromSectionQuery,
+	updateThingPositionQuery,
+	thingExistsQuery,
+	sectionThingIdsQuery,
+} from './queries.js';
+
+// --- Settings mapping ---
+
+interface DbSettings { show_all?: boolean; things_order?: number }
+interface ApiSettings { showAll: boolean; reverseOrder: boolean }
+
+const dbSettingsToApi = (json: string | null): ApiSettings | null => {
+	const parsed = parseJSON(json) as DbSettings | undefined;
+	if (!parsed) return null;
+	return {
+		showAll: parsed.show_all ?? false,
+		reverseOrder: (parsed.things_order ?? 1) < 0,
+	};
+};
+
+const apiSettingsToDb = (settings: ApiSettings | null | undefined): string | null => {
+	if (!settings) return null;
+	if (!settings.showAll && !settings.reverseOrder) return null;
+	const db: DbSettings = {};
+	if (settings.showAll) db.show_all = true;
+	if (settings.reverseOrder) db.things_order = -1;
+	return JSON.stringify(db);
+};
+
+// --- Section row mapper ---
+
+export interface CmsSection {
+	id: number;
+	identifier: string;
+	title: string;
+	description: string | null;
+	annotationText: string | null;
+	annotationAuthor: string | null;
+	typeId: number;
+	redirectSectionId: number | null;
+	settings: ApiSettings | null;
+	order: number;
+}
+
+const mapCmsSectionRow = (row: MySQLRowDataPacket): CmsSection => ({
+	id: row.id as number,
+	identifier: row.identifier as string,
+	title: row.title as string,
+	description: (row.description as string) ?? null,
+	annotationText: (row.annotationText as string) ?? null,
+	annotationAuthor: (row.annotationAuthor as string) ?? null,
+	typeId: row.typeId as number,
+	redirectSectionId: (row.redirectSectionId as number) ?? null,
+	settings: dbSettingsToApi(row.settings as string | null),
+	order: row.order as number,
+});
+
+// --- Section types ---
+
+export interface SectionType {
+	id: number;
+	title: string;
+}
+
+export const getSectionTypes = async (mysql: MySQLPromisePool): Promise<SectionType[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(sectionTypesQuery);
+		return rows.map((row) => ({ id: row.id as number, title: row.title as string }));
+	});
+
+// --- Sections CRUD ---
+
+export const getCmsSections = async (mysql: MySQLPromisePool): Promise<CmsSection[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(cmsSectionsQuery);
+		return rows.map(mapCmsSectionRow);
+	});
+
+export const getCmsSectionById = async (mysql: MySQLPromisePool, id: number): Promise<CmsSection | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(cmsSectionByIdQuery, [id]);
+		return rows.length > 0 ? mapCmsSectionRow(rows[0]) : null;
+	});
+
+export const createSection = async (
+	mysql: MySQLPromisePool,
+	data: { identifier: string; title: string; description: string | null; annotationText: string | null; annotationAuthor: string | null; typeId: number; redirectSectionId: number | null; settings: ApiSettings | null; order?: number },
+): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			let order: number;
+
+			if (data.order !== undefined) {
+				await connection.query(shiftSectionOrdersQuery, [data.order]);
+				order = data.order;
+			} else {
+				const [rows] = await connection.query<MySQLRowDataPacket[]>(maxSectionOrderQuery);
+				order = (rows[0].maxOrder as number) + 1;
+			}
+
+			const [result] = await connection.query<MySQLResultSetHeader>(createSectionQuery, [
+				data.identifier,
+				data.title,
+				data.description,
+				data.annotationText,
+				data.annotationAuthor,
+				data.typeId,
+				data.redirectSectionId,
+				apiSettingsToDb(data.settings),
+				order,
+			]);
+
+			await connection.commit();
+			return result.insertId;
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+
+export const updateSection = async (
+	mysql: MySQLPromisePool,
+	id: number,
+	data: { title?: string; description?: string | null; annotationText?: string | null; annotationAuthor?: string | null; typeId?: number; redirectSectionId?: number | null; settings?: ApiSettings | null; order?: number },
+	current: CmsSection,
+): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			await connection.query(updateSectionQuery, [
+				data.title ?? current.title,
+				data.description !== undefined ? data.description : current.description,
+				data.annotationText !== undefined ? data.annotationText : current.annotationText,
+				data.annotationAuthor !== undefined ? data.annotationAuthor : current.annotationAuthor,
+				data.typeId ?? current.typeId,
+				data.redirectSectionId !== undefined ? data.redirectSectionId : current.redirectSectionId,
+				data.settings !== undefined ? apiSettingsToDb(data.settings) : apiSettingsToDb(current.settings),
+				id,
+			]);
+
+			if (data.order !== undefined && data.order !== current.order) {
+				await connection.query(shiftSectionOrdersQuery, [data.order]);
+				await connection.query(updateSectionOrderQuery, [data.order, id]);
+			}
+
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+
+export interface ExternalRedirect {
+	fromSectionId: number;
+	fromSectionIdentifier: string;
+	fromThingId: number;
+}
+
+export const getExternalRedirectsToSection = async (mysql: MySQLPromisePool, sectionId: number): Promise<ExternalRedirect[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(externalRedirectsToSectionQuery, [sectionId, sectionId]);
+		return rows.map((r) => ({
+			fromSectionId: r.fromSectionId as number,
+			fromSectionIdentifier: r.fromSectionIdentifier as string,
+			fromThingId: r.fromThingId as number,
+		}));
+	});
+
+export const deleteSection = async (mysql: MySQLPromisePool, id: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			await connection.query(deleteAllThingsInSectionQuery, [id]);
+			await connection.query(deleteSectionQuery, [id]);
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+// --- Redirect loop detection ---
+
+export const hasRedirectLoop = async (mysql: MySQLPromisePool, editedSectionId: number, targetRedirectId: number): Promise<boolean> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(allSectionRedirectsQuery);
+		const redirectMap = new Map(rows.map((r) => [r.id as number, r.redirectSectionId as number | null]));
+
+		let current: number | null = targetRedirectId;
+		const visited = new Set<number>();
+
+		while (current !== null) {
+			if (current === editedSectionId) return true;
+			if (visited.has(current)) return false;
+			visited.add(current);
+			current = redirectMap.get(current) ?? null;
+		}
+
+		return false;
+	});
+
+// --- Section reorder ---
+
+export const reorderSections = async (mysql: MySQLPromisePool, sectionIds: number[]): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			for (let i = 0; i < sectionIds.length; i++) {
+				await connection.query(updateSectionOrderQuery, [i + 1, sectionIds[i]]);
+			}
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+// --- Things in section ---
+
+export interface CmsSectionThing {
+	thingId: number;
+	position: number;
+	title: string | null;
+	firstLines: string[] | null;
+}
+
+const mapCmsThingRow = (row: MySQLRowDataPacket): CmsSectionThing => ({
+	thingId: row.thingId as number,
+	position: row.position as number,
+	title: (row.title as string) ?? null,
+	firstLines: row.firstLines
+		? splitLines(row.firstLines as string)
+		: null,
+});
+
+export const getCmsThingsInSection = async (mysql: MySQLPromisePool, sectionId: number): Promise<CmsSectionThing[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(cmsSectionThingsQuery, [sectionId]);
+		return rows.map(mapCmsThingRow);
+	});
+
+export const addThingToSection = async (mysql: MySQLPromisePool, sectionId: number, thingId: number, position?: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			let pos: number;
+
+			if (position !== undefined) {
+				await connection.query(shiftThingPositionsQuery, [sectionId, position]);
+				pos = position;
+			} else {
+				const [rows] = await connection.query<MySQLRowDataPacket[]>(maxThingPositionQuery, [sectionId]);
+				pos = (rows[0].maxPosition as number) + 1;
+			}
+
+			await connection.query(addThingToSectionQuery, [sectionId, pos, thingId]);
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+export const removeThingFromSection = async (mysql: MySQLPromisePool, sectionId: number, thingId: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(removeThingFromSectionQuery, [sectionId, thingId]);
+	});
+};
+
+export const reorderThingsInSection = async (mysql: MySQLPromisePool, sectionId: number, thingIds: number[]): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			const offset = 10000;
+
+			// Phase 1: move to high offset to avoid unique constraint conflicts
+			for (let i = 0; i < thingIds.length; i++) {
+				await connection.query(updateThingPositionQuery, [offset + i + 1, sectionId, thingIds[i]]);
+			}
+
+			// Phase 2: set final positions
+			for (let i = 0; i < thingIds.length; i++) {
+				await connection.query(updateThingPositionQuery, [i + 1, sectionId, thingIds[i]]);
+			}
+
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+export const thingExists = async (mysql: MySQLPromisePool, thingId: number): Promise<boolean> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingExistsQuery, [thingId]);
+		return rows.length > 0;
+	});
+
+export const getSectionThingIds = async (mysql: MySQLPromisePool, sectionId: number): Promise<number[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(sectionThingIdsQuery, [sectionId]);
+		return rows.map((row) => row.thingId as number);
+	});

--- a/src/plugins/cms/hooks.ts
+++ b/src/plugins/cms/hooks.ts
@@ -1,0 +1,7 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+export const requireCanEditContent = async (request: FastifyRequest, reply: FastifyReply) => {
+	if (!request.user?.rights.canEditContent) {
+		return reply.code(403).send({ error: 'forbidden', message: 'Missing required right: canEditContent' });
+	}
+};

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -1,0 +1,142 @@
+// --- Section types ---
+
+export const sectionTypesQuery = `
+	SELECT id, title FROM section_type WHERE id > 0 ORDER BY id;
+`;
+
+// --- Sections ---
+
+export const cmsSectionsQuery = `
+	SELECT
+		s.id,
+		s.identifier,
+		s.title,
+		s.description,
+		s.annotation_text             AS annotationText,
+		s.annotation_author           AS annotationAuthor,
+		s.r_section_type_id           AS typeId,
+		s.r_redirect_section_id       AS redirectSectionId,
+		s.settings,
+		s.\`order\`
+	FROM section s
+	WHERE s.r_section_type_id > 0
+	ORDER BY s.\`order\`, s.id;
+`;
+
+export const cmsSectionByIdQuery = `
+	SELECT
+		s.id,
+		s.identifier,
+		s.title,
+		s.description,
+		s.annotation_text             AS annotationText,
+		s.annotation_author           AS annotationAuthor,
+		s.r_section_type_id           AS typeId,
+		s.r_redirect_section_id       AS redirectSectionId,
+		s.settings,
+		s.\`order\`
+	FROM section s
+	WHERE s.id = ?;
+`;
+
+export const createSectionQuery = `
+	INSERT INTO section (identifier, title, description, annotation_text, annotation_author, r_section_type_id, r_redirect_section_id, settings, \`order\`)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+`;
+
+export const updateSectionQuery = `
+	UPDATE section
+	SET title = ?, description = ?, annotation_text = ?, annotation_author = ?,
+		r_section_type_id = ?, r_redirect_section_id = ?, settings = ?
+	WHERE id = ?;
+`;
+
+export const deleteSectionQuery = `
+	DELETE FROM section WHERE id = ?;
+`;
+
+export const deleteAllThingsInSectionQuery = `
+	DELETE FROM thing_identifier WHERE r_section_id = ?;
+`;
+
+export const externalRedirectsToSectionQuery = `
+	SELECT
+		ext.r_section_id AS fromSectionId,
+		s.identifier AS fromSectionIdentifier,
+		ext.r_thing_id AS fromThingId
+	FROM thing_identifier ext
+	JOIN thing_identifier target ON ext.r_redirect_thing_identifier_id = target.id
+	JOIN section s ON ext.r_section_id = s.id
+	WHERE target.r_section_id = ? AND ext.r_section_id != ?;
+`;
+
+export const updateSectionOrderQuery = `
+	UPDATE section SET \`order\` = ? WHERE id = ?;
+`;
+
+export const shiftSectionOrdersQuery = `
+	UPDATE section SET \`order\` = \`order\` + 1
+	WHERE r_section_type_id > 0 AND \`order\` >= ?;
+`;
+
+export const maxSectionOrderQuery = `
+	SELECT COALESCE(MAX(\`order\`), 0) AS maxOrder
+	FROM section WHERE r_section_type_id > 0;
+`;
+
+// For redirect loop detection
+export const allSectionRedirectsQuery = `
+	SELECT id, r_redirect_section_id AS redirectSectionId
+	FROM section;
+`;
+
+// --- Things in section ---
+
+export const cmsSectionThingsQuery = `
+	SELECT
+		ti.r_thing_id                  AS thingId,
+		ti.thing_position_in_section   AS position,
+		t.title,
+		t.first_lines                  AS firstLines
+	FROM thing_identifier ti
+	JOIN thing t ON ti.r_thing_id = t.id
+	WHERE ti.r_section_id = ?
+	ORDER BY ti.thing_position_in_section;
+`;
+
+export const addThingToSectionQuery = `
+	INSERT INTO thing_identifier (r_section_id, thing_position_in_section, r_thing_id)
+	VALUES (?, ?, ?);
+`;
+
+export const maxThingPositionQuery = `
+	SELECT COALESCE(MAX(thing_position_in_section), 0) AS maxPosition
+	FROM thing_identifier WHERE r_section_id = ?;
+`;
+
+export const shiftThingPositionsQuery = `
+	UPDATE thing_identifier
+	SET thing_position_in_section = thing_position_in_section + 1
+	WHERE r_section_id = ? AND thing_position_in_section >= ?;
+`;
+
+export const removeThingFromSectionQuery = `
+	DELETE FROM thing_identifier WHERE r_section_id = ? AND r_thing_id = ?;
+`;
+
+export const updateThingPositionQuery = `
+	UPDATE thing_identifier
+	SET thing_position_in_section = ?
+	WHERE r_section_id = ? AND r_thing_id = ?;
+`;
+
+export const thingExistsQuery = `
+	SELECT id FROM thing WHERE id = ?;
+`;
+
+export const sectionThingIdsQuery = `
+	SELECT r_thing_id AS thingId
+	FROM thing_identifier
+	WHERE r_section_id = ?
+	ORDER BY thing_position_in_section;
+`;

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+// --- Section types reference ---
+
+export const sectionTypeItem = z.object({
+	id: z.number().int(),
+	title: z.string(),
+});
+
+export const sectionTypesResponse = z.array(sectionTypeItem);
+
+// --- CMS section settings ---
+
+export const cmsSectionSettings = z.object({
+	showAll: z.boolean(),
+	reverseOrder: z.boolean(),
+});
+
+// --- CMS section ---
+
+export const cmsSectionItem = z.object({
+	id: z.number().int(),
+	identifier: z.string(),
+	title: z.string(),
+	description: z.string().nullable(),
+	annotationText: z.string().nullable(),
+	annotationAuthor: z.string().nullable(),
+	typeId: z.number().int(),
+	redirectSectionId: z.number().int().nullable(),
+	settings: cmsSectionSettings.nullable(),
+	order: z.number().int(),
+});
+
+export const cmsSectionsResponse = z.array(cmsSectionItem);
+
+// --- Section params ---
+
+export const sectionIdParam = z.object({
+	id: z.coerce.number().int().positive(),
+});
+
+// --- Create section ---
+
+export const createSectionRequest = z.object({
+	identifier: z.string().regex(/^[a-z][a-z0-9]{1,6}$/),
+	title: z.string().min(1).max(45),
+	description: z.string().nullable().default(null),
+	annotationText: z.string().nullable().default(null),
+	annotationAuthor: z.string().max(100).nullable().default(null),
+	typeId: z.number().int().min(1).max(3),
+	redirectSectionId: z.number().int().nullable().default(null),
+	settings: cmsSectionSettings.nullable().default(null),
+	order: z.number().int().positive().optional(),
+});
+
+// --- Update section ---
+
+export const updateSectionRequest = z.object({
+	title: z.string().min(1).max(45).optional(),
+	description: z.string().nullable().optional(),
+	annotationText: z.string().nullable().optional(),
+	annotationAuthor: z.string().max(100).nullable().optional(),
+	typeId: z.number().int().min(1).max(3).optional(),
+	redirectSectionId: z.number().int().nullable().optional(),
+	settings: cmsSectionSettings.nullable().optional(),
+	order: z.number().int().positive().optional(),
+});
+
+// --- Reorder sections ---
+
+export const reorderSectionsRequest = z.object({
+	sectionIds: z.array(z.number().int().positive()),
+});
+
+// --- Things in section ---
+
+export const cmsSectionThingItem = z.object({
+	thingId: z.number().int(),
+	position: z.number().int(),
+	title: z.string().nullable(),
+	firstLines: z.array(z.string()).nullable(),
+});
+
+export const cmsSectionThingsResponse = z.array(cmsSectionThingItem);
+
+export const thingInSectionParams = z.object({
+	id: z.coerce.number().int().positive(),
+	thingId: z.coerce.number().int().positive(),
+});
+
+// --- Add thing to section ---
+
+export const addThingRequest = z.object({
+	thingId: z.number().int().positive(),
+	position: z.number().int().positive().optional(),
+});
+
+// --- Reorder things in section ---
+
+export const reorderThingsRequest = z.object({
+	thingIds: z.array(z.number().int().positive()),
+});
+
+// --- Inferred types ---
+
+export type SectionIdParam = z.infer<typeof sectionIdParam>;
+export type CreateSectionRequest = z.infer<typeof createSectionRequest>;
+export type UpdateSectionRequest = z.infer<typeof updateSectionRequest>;
+export type ReorderSectionsRequest = z.infer<typeof reorderSectionsRequest>;
+export type ThingInSectionParams = z.infer<typeof thingInSectionParams>;
+export type AddThingRequest = z.infer<typeof addThingRequest>;
+export type ReorderThingsRequest = z.infer<typeof reorderThingsRequest>;

--- a/src/plugins/cms/sectionRoutes.ts
+++ b/src/plugins/cms/sectionRoutes.ts
@@ -1,0 +1,223 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import {
+	getSectionTypes,
+	getCmsSections,
+	getCmsSectionById,
+	createSection,
+	updateSection,
+	deleteSection,
+	getExternalRedirectsToSection,
+	hasRedirectLoop,
+	reorderSections,
+} from './databaseHelpers.js';
+import {
+	sectionTypesResponse,
+	cmsSectionsResponse,
+	cmsSectionItem,
+	sectionIdParam,
+	createSectionRequest,
+	updateSectionRequest,
+	reorderSectionsRequest,
+	type SectionIdParam,
+	type CreateSectionRequest,
+	type UpdateSectionRequest,
+	type ReorderSectionsRequest,
+} from './schemas.js';
+import { requireCanEditContent } from './hooks.js';
+
+export async function sectionRoutes(fastify: FastifyInstance) {
+	fastify.get('/section-types', {
+		schema: {
+			description: 'List section types.',
+			tags: ['CMS'],
+			response: {
+				200: sectionTypesResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getSectionTypes(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.get('/sections', {
+		schema: {
+			description: 'List all sections.',
+			tags: ['CMS'],
+			response: {
+				200: cmsSectionsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getCmsSections(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.post('/sections', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Create a new section.',
+			tags: ['CMS'],
+			body: createSectionRequest,
+			response: {
+				201: cmsSectionItem,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: CreateSectionRequest }>, reply) => {
+			try {
+				const { redirectSectionId } = request.body;
+
+				if (redirectSectionId !== null) {
+					const loop = await hasRedirectLoop(fastify.mysql, 0, redirectSectionId);
+					if (loop) {
+						return reply.code(409).send({ error: 'Redirect would create a loop' });
+					}
+				}
+
+				const id = await createSection(fastify.mysql, request.body);
+				const section = await getCmsSectionById(fastify.mysql, id);
+
+				request.log.info({ sectionId: id }, 'Section created');
+				return reply.code(201).send(section);
+			} catch (error) {
+				if ((error as { code?: string }).code === 'ER_DUP_ENTRY') {
+					return reply.code(409).send({ error: 'Section identifier already exists' });
+				}
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put<{ Params: SectionIdParam; Body: UpdateSectionRequest }>('/sections/:id', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Update a section.',
+			tags: ['CMS'],
+			params: sectionIdParam,
+			body: updateSectionRequest,
+			response: {
+				200: cmsSectionItem,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const current = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				if (!current || current.typeId === 0) {
+					return reply.code(404).send({ error: 'Section not found' });
+				}
+
+				const { redirectSectionId } = request.body;
+
+				if (redirectSectionId !== undefined && redirectSectionId !== null) {
+					const loop = await hasRedirectLoop(fastify.mysql, request.params.id, redirectSectionId);
+					if (loop) {
+						return reply.code(409).send({ error: 'Redirect would create a loop' });
+					}
+				}
+
+				await updateSection(fastify.mysql, request.params.id, request.body, current);
+				const updated = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				request.log.info({ sectionId: request.params.id }, 'Section updated');
+				return updated;
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.delete<{ Params: SectionIdParam }>('/sections/:id', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Delete a section. Cascades thing_identifiers. Refuses if external redirects exist.',
+			tags: ['CMS'],
+			params: sectionIdParam,
+			response: {
+				204: z.void(),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const current = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				if (!current || current.typeId === 0) {
+					return reply.code(404).send({ error: 'Section not found' });
+				}
+
+				const redirects = await getExternalRedirectsToSection(fastify.mysql, request.params.id);
+
+				if (redirects.length > 0) {
+					const sources = redirects.map((r) => `${r.fromSectionIdentifier}:thing#${r.fromThingId}`).join(', ');
+					return reply.code(409).send({ error: `Section has incoming redirects from: ${sources}` });
+				}
+
+				await deleteSection(fastify.mysql, request.params.id);
+				request.log.info({ sectionId: request.params.id }, 'Section deleted');
+				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put<{ Body: ReorderSectionsRequest }>('/sections/reorder', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Reorder sections.',
+			tags: ['CMS'],
+			body: reorderSectionsRequest,
+			response: {
+				200: cmsSectionsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				await reorderSections(fastify.mysql, request.body.sectionIds);
+				request.log.info({ count: request.body.sectionIds.length }, 'Sections reordered');
+				return await getCmsSections(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}

--- a/src/plugins/cms/sectionThingRoutes.ts
+++ b/src/plugins/cms/sectionThingRoutes.ts
@@ -1,0 +1,167 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import {
+	getCmsSectionById,
+	getCmsThingsInSection,
+	addThingToSection,
+	removeThingFromSection,
+	reorderThingsInSection,
+	thingExists,
+	getSectionThingIds,
+} from './databaseHelpers.js';
+import {
+	sectionIdParam,
+	cmsSectionThingsResponse,
+	thingInSectionParams,
+	addThingRequest,
+	reorderThingsRequest,
+	type SectionIdParam,
+	type ThingInSectionParams,
+	type AddThingRequest,
+	type ReorderThingsRequest,
+} from './schemas.js';
+import { requireCanEditContent } from './hooks.js';
+
+export async function sectionThingRoutes(fastify: FastifyInstance) {
+	fastify.get<{ Params: SectionIdParam }>('/sections/:id/things', {
+		schema: {
+			description: 'List things in a section.',
+			tags: ['CMS'],
+			params: sectionIdParam,
+			response: {
+				200: cmsSectionThingsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const section = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				if (!section || section.typeId === 0) {
+					return reply.code(404).send({ error: 'Section not found' });
+				}
+
+				return await getCmsThingsInSection(fastify.mysql, request.params.id);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.post<{ Params: SectionIdParam; Body: AddThingRequest }>('/sections/:id/things', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Add a thing to a section.',
+			tags: ['CMS'],
+			params: sectionIdParam,
+			body: addThingRequest,
+			response: {
+				201: cmsSectionThingsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const section = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				if (!section || section.typeId === 0) {
+					return reply.code(404).send({ error: 'Section not found' });
+				}
+
+				const exists = await thingExists(fastify.mysql, request.body.thingId);
+
+				if (!exists) {
+					return reply.code(404).send({ error: 'Thing not found' });
+				}
+
+				await addThingToSection(fastify.mysql, request.params.id, request.body.thingId, request.body.position);
+				request.log.info({ sectionId: request.params.id, thingId: request.body.thingId }, 'Thing added to section');
+				const things = await getCmsThingsInSection(fastify.mysql, request.params.id);
+				return reply.code(201).send(things);
+			} catch (error) {
+				if ((error as { code?: string }).code === 'ER_DUP_ENTRY') {
+					return reply.code(409).send({ error: 'Thing already exists in this section' });
+				}
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.delete<{ Params: ThingInSectionParams }>('/sections/:id/things/:thingId', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Remove a thing from a section.',
+			tags: ['CMS'],
+			params: thingInSectionParams,
+			response: {
+				204: z.void(),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				await removeThingFromSection(fastify.mysql, request.params.id, request.params.thingId);
+				request.log.info({ sectionId: request.params.id, thingId: request.params.thingId }, 'Thing removed from section');
+				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put<{ Params: SectionIdParam; Body: ReorderThingsRequest }>('/sections/:id/things/reorder', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Reorder things within a section.',
+			tags: ['CMS'],
+			params: sectionIdParam,
+			body: reorderThingsRequest,
+			response: {
+				200: cmsSectionThingsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				400: errorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const section = await getCmsSectionById(fastify.mysql, request.params.id);
+
+				if (!section || section.typeId === 0) {
+					return reply.code(404).send({ error: 'Section not found' });
+				}
+
+				const currentThingIds = await getSectionThingIds(fastify.mysql, request.params.id);
+				const requestedIds = new Set(request.body.thingIds);
+				const currentIds = new Set(currentThingIds);
+
+				if (requestedIds.size !== currentIds.size || ![...requestedIds].every((id) => currentIds.has(id))) {
+					return reply.code(400).send({ error: 'Thing IDs must match the current set of things in the section' });
+				}
+
+				await reorderThingsInSection(fastify.mysql, request.params.id, request.body.thingIds);
+				request.log.info({ sectionId: request.params.id, count: request.body.thingIds.length }, 'Things reordered');
+				return await getCmsThingsInSection(fastify.mysql, request.params.id);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}

--- a/src/plugins/users/users.test.ts
+++ b/src/plugins/users/users.test.ts
@@ -51,7 +51,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async () =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true, canEditContent: false } }, secret);
 
 describe('PATCH /users/:id/password', () => {
 	it('returns 401 without auth token', async () => {

--- a/src/plugins/votes/votes.test.ts
+++ b/src/plugins/votes/votes.test.ts
@@ -43,7 +43,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async (canVote = true) =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote, canEditContent: false } }, secret);
 
 describe('PUT /things/:thingId/vote', () => {
 	it('returns 401 without auth token', async () => {


### PR DESCRIPTION
## Summary
- Add `canEditContent` right (bit 12) to auth system with XOR resolution rule
- New `/cms/*` plugin with two-layer auth: editor role for reads, `canEditContent` for mutations
- Section CRUD with settings mapping (`showAll`/`reverseOrder`), redirect loop detection, insert-at-position
- Thing_identifier CRUD within sections with position support and two-phase reorder
- DELETE section cascades thing_identifiers, refuses if external redirects point in
- Extract `splitLines` to shared `lib/mappers.ts`
- Add CMS endpoints to `api.http` and `smoke-test.sh`

## Test plan
- [x] 87 unit tests pass (15 new CMS + updated existing)
- [x] Build and lint clean
- [ ] Run smoke test with editor user on test env