### PR TITLE
Simplify reorder endpoints to plain array body

### DIFF
--- a/api.http
+++ b/api.http
@@ -200,9 +200,7 @@ PUT {{host}}/cms/sections/reorder
 Content-Type: application/json
 Authorization: Bearer {{login.response.body.accessToken}}
 
-{
-  "sectionIds": [10, 11, 12]
-}
+[10, 11, 12]
 
 ### ---- CMS: Things in Section ----
 
@@ -228,9 +226,7 @@ PUT {{host}}/cms/sections/10/things/reorder
 Content-Type: application/json
 Authorization: Bearer {{login.response.body.accessToken}}
 
-{
-  "thingIds": [3, 1, 2]
-}
+[3, 1, 2]
 
 ### ---- Votes ----
 

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -323,7 +323,7 @@ describe('PUT /cms/sections/:id/things/reorder', () => {
 			method: 'PUT',
 			url: '/cms/sections/10/things/reorder',
 			headers: { authorization: `Bearer ${token}` },
-			payload: { thingIds: [1, 3] },
+			payload: [1, 3],
 		});
 
 		expect(response.statusCode).toBe(400);

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -68,9 +68,7 @@ export const updateSectionRequest = z.object({
 
 // --- Reorder sections ---
 
-export const reorderSectionsRequest = z.object({
-	sectionIds: z.array(z.number().int().positive()),
-});
+export const reorderSectionsRequest = z.array(z.number().int().positive());
 
 // --- Things in section ---
 
@@ -97,9 +95,7 @@ export const addThingRequest = z.object({
 
 // --- Reorder things in section ---
 
-export const reorderThingsRequest = z.object({
-	thingIds: z.array(z.number().int().positive()),
-});
+export const reorderThingsRequest = z.array(z.number().int().positive());
 
 // --- Inferred types ---
 

--- a/src/plugins/cms/sectionRoutes.ts
+++ b/src/plugins/cms/sectionRoutes.ts
@@ -211,8 +211,8 @@ export async function sectionRoutes(fastify: FastifyInstance) {
 		},
 		handler: async (request, reply) => {
 			try {
-				await reorderSections(fastify.mysql, request.body.sectionIds);
-				request.log.info({ count: request.body.sectionIds.length }, 'Sections reordered');
+				await reorderSections(fastify.mysql, request.body);
+				request.log.info({ count: request.body.length }, 'Sections reordered');
 				return await getCmsSections(fastify.mysql);
 			} catch (error) {
 				request.log.error(error);

--- a/src/plugins/cms/sectionThingRoutes.ts
+++ b/src/plugins/cms/sectionThingRoutes.ts
@@ -148,15 +148,15 @@ export async function sectionThingRoutes(fastify: FastifyInstance) {
 				}
 
 				const currentThingIds = await getSectionThingIds(fastify.mysql, request.params.id);
-				const requestedIds = new Set(request.body.thingIds);
+				const requestedIds = new Set(request.body);
 				const currentIds = new Set(currentThingIds);
 
 				if (requestedIds.size !== currentIds.size || ![...requestedIds].every((id) => currentIds.has(id))) {
 					return reply.code(400).send({ error: 'Thing IDs must match the current set of things in the section' });
 				}
 
-				await reorderThingsInSection(fastify.mysql, request.params.id, request.body.thingIds);
-				request.log.info({ sectionId: request.params.id, count: request.body.thingIds.length }, 'Things reordered');
+				await reorderThingsInSection(fastify.mysql, request.params.id, request.body);
+				request.log.info({ sectionId: request.params.id, count: request.body.length }, 'Things reordered');
 				return await getCmsThingsInSection(fastify.mysql, request.params.id);
 			} catch (error) {
 				request.log.error(error);


### PR DESCRIPTION
## Summary
- Change reorder request body from `{ sectionIds: [...] }` / `{ thingIds: [...] }` to plain `[...]` arrays
- Simpler, more consistent API surface

## Test plan
- [x] 87 tests pass
- [x] Build and lint clean