### PR TITLE
Add GET /cms/things endpoint

### DIFF
--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -22,6 +22,7 @@ import {
 	updateThingPositionQuery,
 	thingExistsQuery,
 	sectionThingIdsQuery,
+	allThingsQuery,
 } from './queries.js';
 
 // --- Settings mapping ---
@@ -325,4 +326,10 @@ export const getSectionThingIds = async (mysql: MySQLPromisePool, sectionId: num
 	withConnection(mysql, async (connection) => {
 		const [rows] = await connection.query<MySQLRowDataPacket[]>(sectionThingIdsQuery, [sectionId]);
 		return rows.map((row) => row.thingId as number);
+	});
+
+export const getAllThings = async (mysql: MySQLPromisePool): Promise<CmsSectionThing[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(allThingsQuery);
+		return rows.map(mapCmsThingRow);
 	});

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -134,6 +134,15 @@ export const thingExistsQuery = `
 	SELECT id FROM thing WHERE id = ?;
 `;
 
+export const allThingsQuery = `
+	SELECT
+		t.id          AS thingId,
+		t.title,
+		t.first_lines AS firstLines
+	FROM thing t
+	ORDER BY t.id DESC;
+`;
+
 export const sectionThingIdsQuery = `
 	SELECT r_thing_id AS thingId
 	FROM thing_identifier

--- a/src/plugins/cms/sectionThingRoutes.ts
+++ b/src/plugins/cms/sectionThingRoutes.ts
@@ -10,6 +10,7 @@ import {
 	reorderThingsInSection,
 	thingExists,
 	getSectionThingIds,
+	getAllThings,
 } from './databaseHelpers.js';
 import {
 	sectionIdParam,
@@ -25,6 +26,27 @@ import {
 import { requireCanEditContent } from './hooks.js';
 
 export async function sectionThingRoutes(fastify: FastifyInstance) {
+	fastify.get('/things', {
+		schema: {
+			description: 'List all published things.',
+			tags: ['CMS'],
+			response: {
+				200: cmsSectionThingsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getAllThings(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
 	fastify.get<{ Params: SectionIdParam }>('/sections/:id/things', {
 		schema: {
 			description: 'List things in a section.',


### PR DESCRIPTION
## Summary
- New `GET /cms/things` endpoint returning all things (id, title, firstLines) ordered newest first
- For the CMS thing picker modal (replacing per-section browsing)
- Guarded by editor role (inherited from cms plugin hooks)

## Test plan
- [x] 87 tests pass
- [x] Build and lint clean