### PR TITLE
Add admin email notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ SMTP_FROM_NAME="Система оповещений "
 SMTP_FROM_ADDRESS=notifier@mellonis.ru
 ALLOWED_ORIGINS=
 WEBAUTHN_RP_ID=localhost
+ADMIN_NOTIFY_EMAIL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ SMTP_FROM_NAME=Система оповещений        # required, display na
 SMTP_FROM_ADDRESS=notifier@mellonis.ru   # required, email address for From header (no fallback to SMTP_LOGIN — would leak credentials)
 ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://poetry-old2.mellonis.ru  # required, comma-separated whitelist of client origins (CORS + email links)
 WEBAUTHN_RP_ID=mellonis.ru       # optional, WebAuthn Relying Party ID (default: mellonis.ru, use "localhost" for local dev)
+ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions
 ```
 
 See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead.
@@ -54,13 +55,13 @@ See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port ov
 Fastify app using a plugin-based structure under `src/plugins/`:
 
 - **`database/`** — registers the MySQL connection pool on the Fastify instance via `@fastify/mysql`
-- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `requireRight`) visible to all plugins; `authRoutes.ts` provides routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Also contains pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`. Sub-directory `passkey/` provides WebAuthn passkey routes (`/auth/passkey/*` for registration/login, `/auth/passkeys` for listing/deleting). RP ID is configurable via `WEBAUTHN_RP_ID` env var
+- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `requireRight`) visible to all plugins; `authRoutes.ts` provides routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Sends `ADMIN_NOTIFY_EMAIL` on new registration. Also contains pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`. Sub-directory `passkey/` provides WebAuthn passkey routes (`/auth/passkey/*` for registration/login, `/auth/passkeys` for listing/deleting). RP ID is configurable via `WEBAUTHN_RP_ID` env var
 - **`authNotifier/`** — `fastify-plugin` that decorates `fastify.authNotifier` with an `AuthNotifier` implementation. In production (`NODE_ENV=production`): `EmailAuthNotifier` sends via SMTP. Otherwise: `ConsoleAuthNotifier` logs keys to pino (for local dev/testing without SMTP).
 - **`swagger/`** — mounts OpenAPI docs at `/docs` via `@fastify/swagger` + `@fastify/swagger-ui`
 - **`sections/`** — routes prefixed `/sections`
 - **`thingsOfTheDay/`** — routes prefixed `/things-of-the-day`
-- **`users/`** — routes prefixed `/users` (change password, delete account)
-- **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`). Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote. All mutations return updated `{ plus, minus }` counts
+- **`users/`** — routes prefixed `/users` (change password, delete account). Sends `ADMIN_NOTIFY_EMAIL` on account deletion
+- **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`). Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote. All mutations return updated `{ plus, minus }` counts. Sends email notification to `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
 - **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields (`seoDescription`, `seoKeywords`) sourced from `news` table (id=1). No auth required
 - **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations additionally require `canEditContent` right (bit 12). Split into sub-plugins: `authorRoutes.ts` (GET + PUT `/cms/author` for about page editing), `sectionRoutes.ts` (section types, section statuses, sections CRUD + reorder), `sectionThingRoutes.ts` (`GET /things` lists all things for the picker + things within sections CRUD + reorder). Sections have `statusId` (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn); public API filters `WHERE section_status_id IN (2, 3)`. Reorder endpoints accept plain array body `[id1, id2, ...]`. Shared hook in `hooks.ts`. Section settings map between API format (`{ showAll, reverseOrder }`) and DB format (`{ show_all, things_order }`); stored as `NULL` when all defaults. Reordering things uses two-phase UPDATE with high offset to avoid unique constraint conflicts on `thing_position_in_section`. DELETE section cascades thing_identifiers but refuses if external redirects (`r_redirect_thing_identifier_id`) point into the section
 

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -51,6 +51,25 @@ padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
  просто проигнорируйте это письмо.</p>`),
 });
 
+export const thingVotedEmail = (voterLogin: string, thingTitle: string, vote: number): EmailMessage => ({
+	subject: vote === 0
+		? `Голос снят: ${voterLogin}`
+		: `Голос ${vote > 0 ? '↑' : '↓'} от ${voterLogin}`,
+	html: vote === 0
+		? `<p><strong>${voterLogin}</strong> снял(а) голос: ${thingTitle}</p>`
+		: `<p><strong>${voterLogin}</strong> проголосовал(а) ${vote > 0 ? 'за' : 'против'}: ${thingTitle}</p>`,
+});
+
+export const accountRegisteredEmail = (login: string): EmailMessage => ({
+	subject: `Регистрация: ${login}`,
+	html: `<p>Новый пользователь: <strong>${login}</strong></p>`,
+});
+
+export const accountDeletedEmail = (login: string): EmailMessage => ({
+	subject: `Удаление аккаунта: ${login}`,
+	html: `<p>Пользователь <strong>${login}</strong> удалил аккаунт.</p>`,
+});
+
 export const passwordChangedEmail = (siteOrigin: string, login: string, resetHref: string): EmailMessage => ({
 	subject: 'Пароль изменён',
 	html: layout(siteOrigin, login, `<p style="color:#333;font-size:14px;">Пароль для вашего

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -19,6 +19,18 @@ export const parseJSON = (value: string | null): unknown => {
 	}
 };
 
+export const thingDisplayTitle = (title: string | null, firstLines: string | null, id: number): string => {
+	if (title) {
+		return title;
+	}
+
+	if (firstLines) {
+		return `«${firstLines.split('\n')[0]}…»`;
+	}
+
+	return `#${id}`;
+};
+
 export const mapThingBaseRow = (row: MySQLRowDataPacket) => ({
 	id: row.id as number,
 	categoryId: row.categoryId,

--- a/src/plugins/auth/authRoutes.ts
+++ b/src/plugins/auth/authRoutes.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { errorResponse } from '../../lib/schemas.js';
 import { maskEmail } from '../../lib/maskEmail.js';
+import { sendEmail } from '../../lib/email.js';
+import { accountRegisteredEmail } from '../../lib/emailTemplates.js';
 import { checkPassword, hashPassword, needsRehash } from './password.js';
 import { hashRefreshToken } from './jwt.js';
 import {
@@ -203,7 +205,15 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 					fastify.log.error({ login, email: maskEmail(email), err: notifierError }, 'Failed to send activation email');
 				}
 
-				return reply.code(201).send({ message: 'Registration successful. Check your email to activate your account.' });
+				const adminEmail = process.env.ADMIN_NOTIFY_EMAIL;
+
+					if (adminEmail) {
+						sendEmail(adminEmail, accountRegisteredEmail(login)).catch((err) => {
+							request.log.warn(err, 'Admin registration notification failed');
+						});
+					}
+
+					return reply.code(201).send({ message: 'Registration successful. Check your email to activate your account.' });
 			} catch (error) {
 				request.log.error(error);
 				return reply.code(500).send({ error: 'Internal server error' });

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { errorResponse } from '../../lib/schemas.js';
+import { sendEmail } from '../../lib/email.js';
+import { accountDeletedEmail } from '../../lib/emailTemplates.js';
 import { checkPassword, hashPassword } from '../auth/password.js';
 import { deleteAllUserRefreshTokens } from '../auth/databaseHelpers.js';
 import { getUserCredentials, updatePassword, deleteUser } from './databaseHelpers.js';
@@ -115,6 +117,15 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				await deleteUser(fastify.mysql, id);
 
 				request.log.info({ login: user.login, userId: id }, 'Account deleted');
+
+				const adminEmail = process.env.ADMIN_NOTIFY_EMAIL;
+
+				if (adminEmail) {
+					sendEmail(adminEmail, accountDeletedEmail(user.login)).catch((err) => {
+						request.log.warn(err, 'Admin account deletion notification failed');
+					});
+				}
+
 				return reply.code(204).send();
 			} catch (error) {
 				request.log.error(error);

--- a/src/plugins/votes/databaseHelpers.ts
+++ b/src/plugins/votes/databaseHelpers.ts
@@ -1,6 +1,7 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
 import { withConnection } from '../../lib/databaseHelpers.js';
-import { upsertVoteQuery, deleteVoteQuery, voteCountsQuery } from './queries.js';
+import { thingDisplayTitle } from '../../lib/mappers.js';
+import { upsertVoteQuery, deleteVoteQuery, voteCountsQuery, thingTitleQuery } from './queries.js';
 
 export const upsertVote = async (mysql: MySQLPromisePool, thingId: number, userId: number, vote: number): Promise<void> => {
 	await withConnection(mysql, async (connection) => {
@@ -23,4 +24,11 @@ export const getVoteCounts = async (mysql: MySQLPromisePool, thingId: number): P
 	withConnection(mysql, async (connection) => {
 		const [rows] = await connection.query<MySQLRowDataPacket[]>(voteCountsQuery, [thingId]);
 		return { plus: rows[0].plus as number, minus: rows[0].minus as number };
+	});
+
+export const getThingTitle = async (mysql: MySQLPromisePool, thingId: number): Promise<string> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingTitleQuery, [thingId]);
+		const row = rows[0];
+		return thingDisplayTitle(row?.title as string | null ?? null, row?.firstLines as string | null ?? null, thingId);
 	});

--- a/src/plugins/votes/queries.ts
+++ b/src/plugins/votes/queries.ts
@@ -9,6 +9,10 @@ export const deleteVoteQuery = `
 	WHERE r_thing_id = ? AND r_user_id = ?
 `;
 
+export const thingTitleQuery = `
+	SELECT title, first_lines AS firstLines FROM thing WHERE id = ?
+`;
+
 export const voteCountsQuery = `
 	SELECT
 		COUNT(CASE WHEN vote > 0 THEN 1 END) AS plus,

--- a/src/plugins/votes/votes.ts
+++ b/src/plugins/votes/votes.ts
@@ -1,7 +1,9 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { errorResponse } from '../../lib/schemas.js';
 import { authErrorResponse } from '../auth/schemas.js';
-import { upsertVote, deleteVote, getVoteCounts } from './databaseHelpers.js';
+import { sendEmail } from '../../lib/email.js';
+import { thingVotedEmail } from '../../lib/emailTemplates.js';
+import { upsertVote, deleteVote, getVoteCounts, getThingTitle } from './databaseHelpers.js';
 import {
 	voteParams,
 	voteRequest,
@@ -9,6 +11,8 @@ import {
 	type VoteParams,
 	type VoteRequest,
 } from './schemas.js';
+
+const ADMIN_NOTIFY_EMAIL = process.env.ADMIN_NOTIFY_EMAIL;
 
 export async function votesPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: votes...');
@@ -34,6 +38,7 @@ export async function votesPlugin(fastify: FastifyInstance) {
 				const { thingId } = request.params;
 				const { vote } = request.body;
 				const userId = request.user!.sub;
+				const login = request.user!.login;
 
 				if (vote === 0) {
 					await deleteVote(fastify.mysql, thingId, userId);
@@ -41,6 +46,14 @@ export async function votesPlugin(fastify: FastifyInstance) {
 				} else {
 					await upsertVote(fastify.mysql, thingId, userId, vote);
 					request.log.info({ thingId, userId, vote }, 'Vote recorded');
+				}
+
+				if (ADMIN_NOTIFY_EMAIL) {
+					getThingTitle(fastify.mysql, thingId).then((title) => {
+						sendEmail(ADMIN_NOTIFY_EMAIL, thingVotedEmail(login, title, vote));
+					}).catch((err) => {
+						request.log.warn(err, 'Vote notification email failed');
+					});
 				}
 
 				return await getVoteCounts(fastify.mysql, thingId);


### PR DESCRIPTION
## Summary
- `ADMIN_NOTIFY_EMAIL` env var — receives notifications on:
  - Vote cast/removal (includes thing title with fallback)
  - New user registration
  - Account deletion
- All fire-and-forget (don't block the response)
- Extract `thingDisplayTitle()` to shared `lib/mappers.ts`
- Email templates: `thingVotedEmail`, `accountRegisteredEmail`, `accountDeletedEmail`

## Test plan
- [x] 87 tests pass
- [x] Build and lint clean