### PR TITLE
Add thing CRUD endpoints and admin notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,19 +55,47 @@ See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port ov
 Fastify app using a plugin-based structure under `src/plugins/`:
 
 - **`database/`** — registers the MySQL connection pool on the Fastify instance via `@fastify/mysql`
-- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `requireRight`) visible to all plugins; `authRoutes.ts` provides routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Sends `ADMIN_NOTIFY_EMAIL` on new registration. Also contains pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`. Sub-directory `passkey/` provides WebAuthn passkey routes (`/auth/passkey/*` for registration/login, `/auth/passkeys` for listing/deleting). RP ID is configurable via `WEBAUTHN_RP_ID` env var
-- **`authNotifier/`** — `fastify-plugin` that decorates `fastify.authNotifier` with an `AuthNotifier` implementation. In production (`NODE_ENV=production`): `EmailAuthNotifier` sends via SMTP. Otherwise: `ConsoleAuthNotifier` logs keys to pino (for local dev/testing without SMTP).
+- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `requireRight`) visible to all plugins
+  - `authRoutes.ts` — routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Sends `ADMIN_NOTIFY_EMAIL` on new registration
+  - Pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`
+  - `passkey/` — WebAuthn passkey routes (`/auth/passkey/*` for registration/login, `/auth/passkeys` for listing/deleting). RP ID configurable via `WEBAUTHN_RP_ID` env var
+- **`authNotifier/`** — `fastify-plugin` that decorates `fastify.authNotifier` with an `AuthNotifier` implementation
+  - Production (`NODE_ENV=production`): `EmailAuthNotifier` sends via SMTP
+  - Dev: `ConsoleAuthNotifier` logs keys to pino
 - **`swagger/`** — mounts OpenAPI docs at `/docs` via `@fastify/swagger` + `@fastify/swagger-ui`
 - **`sections/`** — routes prefixed `/sections`
 - **`thingsOfTheDay/`** — routes prefixed `/things-of-the-day`
 - **`users/`** — routes prefixed `/users` (change password, delete account). Sends `ADMIN_NOTIFY_EMAIL` on account deletion
-- **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`). Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote. All mutations return updated `{ plus, minus }` counts. Sends email notification to `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
-- **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields (`seoDescription`, `seoKeywords`) sourced from `news` table (id=1). No auth required
-- **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations additionally require `canEditContent` right (bit 12). Split into sub-plugins: `authorRoutes.ts` (GET + PUT `/cms/author` for about page editing), `sectionRoutes.ts` (section types, section statuses, sections CRUD + reorder), `sectionThingRoutes.ts` (`GET /things` lists all things for the picker + things within sections CRUD + reorder). Sections have `statusId` (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn); public API filters `WHERE section_status_id IN (2, 3)`. Reorder endpoints accept plain array body `[id1, id2, ...]`. Shared hook in `hooks.ts`. Section settings map between API format (`{ showAll, reverseOrder }`) and DB format (`{ show_all, things_order }`); stored as `NULL` when all defaults. Reordering things uses two-phase UPDATE with high offset to avoid unique constraint conflicts on `thing_position_in_section`. DELETE section cascades thing_identifiers but refuses if external redirects (`r_redirect_thing_identifier_id`) point into the section
+- **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`)
+  - Requires auth + `canVote` right. `PUT` with `vote: 0` removes the vote
+  - Returns updated `{ plus, minus }` counts
+  - Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
+- **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields. Sourced from `news` table (id=1). No auth required
+- **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations require `canEditContent` right (bit 12). Shared hook in `hooks.ts`. Sub-plugins:
+  - `authorRoutes.ts` — GET + PUT `/cms/author` for about page editing
+  - `sectionRoutes.ts` — section types, section statuses, sections CRUD + reorder
+  - `sectionThingRoutes.ts` — `GET /things` lists all things for the picker + things within sections CRUD + reorder
+  - `thingRoutes.ts` — thing CRUD: GET/POST/PUT/DELETE `/cms/things/:thingId` with notes, SEO, info sync + thing statuses/categories reference data
+  - Sections: `statusId` (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn); public API filters `WHERE section_status_id IN (2, 3)`
+  - Reorder endpoints accept plain array body `[id1, id2, ...]`
+  - Section settings: API `{ showAll, reverseOrder }` ↔ DB `{ show_all, things_order }`; stored as `NULL` when all defaults
+  - Reordering things: two-phase UPDATE with high offset to avoid unique constraint conflicts
+  - DELETE section: cascades thing_identifiers, refuses if external redirects point in
+  - DELETE thing: refuses if thing is in any section
 
 Each route plugin is split into: `*.ts` (handler), `schemas.ts`, `queries.ts`, `databaseHelpers.ts`.
 
-Shared utilities live in `src/lib/`: `schemas.ts` (Zod schemas), `queries.ts` (SQL fragments), `mappers.ts` (row mappers), `databaseHelpers.ts` (`withConnection`), `email.ts` (SMTP transport), `emailTemplates.ts` (HTML renderers), `maskEmail.ts` (masks emails for logging). Domain-specific notifier implementations live in their own subdirectory — e.g., `lib/authNotifier/` contains `AuthNotifier.ts` (interface), `EmailAuthNotifier.ts`, `ConsoleAuthNotifier.ts`. Plugin schemas extend or re-export from `src/lib/schemas.ts`. Route handlers use `fastify.authNotifier` for auth-related notifications — never call `sendEmail` directly.
+Shared utilities in `src/lib/`:
+- `schemas.ts` — Zod schemas (shared `thingSchema`, `errorResponse`)
+- `queries.ts` — SQL fragments (thing fields, user vote field)
+- `mappers.ts` — row mappers (`mapThingBaseRow`, `splitLines`, `parseJSON`, `thingDisplayTitle`)
+- `databaseHelpers.ts` — `withConnection` (pool acquire/release)
+- `email.ts` — SMTP transport via nodemailer
+- `emailTemplates.ts` — email templates (auth + admin notifications: `thingVotedEmail`, `accountRegisteredEmail`, `accountDeletedEmail`)
+- `maskEmail.ts` — masks emails for logging
+- `authNotifier/` — `AuthNotifier` interface, `EmailAuthNotifier` (production), `ConsoleAuthNotifier` (dev)
+
+Plugin schemas extend or re-export from `src/lib/schemas.ts`. Auth notifications use `fastify.authNotifier`; admin notifications use `sendEmail` directly (fire-and-forget).
 
 Validation and serialization use `fastify-type-provider-zod`. All Fastify route schemas reference Zod objects.
 

--- a/api.http
+++ b/api.http
@@ -228,6 +228,69 @@ Authorization: Bearer {{login.response.body.accessToken}}
 
 [3, 1, 2]
 
+### ---- CMS: Author ----
+
+### Get author page content (requires editor role)
+GET {{host}}/cms/author
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Update author page content (requires editor + canEditContent)
+PUT {{host}}/cms/author
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "text": "Author bio text",
+  "date": "2026-04-25",
+  "seoDescription": null,
+  "seoKeywords": null
+}
+
+### ---- CMS: Thing CRUD ----
+
+### List thing statuses (requires editor role)
+GET {{host}}/cms/thing-statuses
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### List thing categories (requires editor role)
+GET {{host}}/cms/thing-categories
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### List all things (requires editor role)
+GET {{host}}/cms/things
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Get a thing for editing (requires editor role)
+GET {{host}}/cms/things/1
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Create a thing (requires editor + canEditContent)
+POST {{host}}/cms/things
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "text": "New poem text",
+  "categoryId": 1,
+  "finishDate": "2026-04-25"
+}
+
+### Update a thing (requires editor + canEditContent)
+PUT {{host}}/cms/things/1
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "title": "Updated Title",
+  "notes": [{"text": "A note"}],
+  "seoDescription": "Description",
+  "seoKeywords": "keywords"
+}
+
+### Delete a thing (requires editor + canEditContent, must not be in any section)
+DELETE {{host}}/cms/things/1
+Authorization: Bearer {{login.response.body.accessToken}}
+
 ### ---- Votes ----
 
 ### Cast or update a vote (requires auth + canVote)

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -10,7 +10,7 @@ export const thingFields = `
 	thing_seo_description           AS seoDescription,
 	thing_seo_keywords              AS seoKeywords,
 	thing_info                      AS info,
-	(SELECT CONCAT('[', GROUP_CONCAT(JSON_QUOTE(text) ORDER BY id SEPARATOR ','), ']')
+	(SELECT CONCAT('[', GROUP_CONCAT(JSON_QUOTE(text) ORDER BY \`order\`, id SEPARATOR ','), ']')
 	 FROM thing_note
 	 WHERE r_thing_id = thing_id)   AS notes,
 	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote > 0) AS votesPlus,

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { authorRoutes } from './authorRoutes.js';
 import { sectionRoutes } from './sectionRoutes.js';
 import { sectionThingRoutes } from './sectionThingRoutes.js';
+import { thingRoutes } from './thingRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -18,6 +19,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(authorRoutes);
 	fastify.register(sectionRoutes);
 	fastify.register(sectionThingRoutes);
+	fastify.register(thingRoutes);
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -26,6 +26,22 @@ import {
 	allThingsQuery,
 	cmsAuthorQuery,
 	updateAuthorQuery,
+	thingStatusesQuery,
+	thingCategoriesQuery,
+	cmsThingByIdQuery,
+	thingNotesQuery,
+	createThingQuery,
+	updateThingQuery,
+	deleteThingQuery,
+	thingInSectionsCountQuery,
+	upsertThingSeoQuery,
+	deleteThingSeoQuery,
+	upsertThingInfoQuery,
+	deleteThingInfoQuery,
+	insertThingNoteQuery,
+	updateThingNoteQuery,
+	deleteThingNotesExceptQuery,
+	deleteAllThingNotesQuery,
 } from './queries.js';
 
 // --- Settings mapping ---
@@ -389,3 +405,208 @@ export const updateAuthor = async (
 		await connection.query(updateAuthorQuery, [data.text, data.date, data.seoDescription, data.seoKeywords]);
 	});
 };
+
+// --- Thing CRUD ---
+
+export interface CmsThingNote {
+	id: number;
+	text: string;
+}
+
+export interface CmsThing {
+	id: number;
+	title: string;
+	text: string;
+	categoryId: number;
+	statusId: number;
+	startDate: string | null;
+	finishDate: string;
+	firstLines: string | null;
+	firstLinesAutoGenerating: boolean;
+	excludeFromDaily: boolean;
+	notes: CmsThingNote[];
+	seoDescription: string | null;
+	seoKeywords: string | null;
+	info: string | null;
+}
+
+export const getThingStatuses = async (mysql: MySQLPromisePool): Promise<SectionType[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingStatusesQuery);
+		return rows.map((row) => ({ id: row.id as number, title: row.title as string }));
+	});
+
+export const getThingCategories = async (mysql: MySQLPromisePool): Promise<SectionType[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingCategoriesQuery);
+		return rows.map((row) => ({ id: row.id as number, title: row.title as string }));
+	});
+
+export const getCmsThing = async (mysql: MySQLPromisePool, thingId: number): Promise<CmsThing | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(cmsThingByIdQuery, [thingId]);
+
+		if (rows.length === 0) {
+			return null;
+		}
+
+		const row = rows[0];
+		const [noteRows] = await connection.query<MySQLRowDataPacket[]>(thingNotesQuery, [thingId]);
+
+		return {
+			id: row.id as number,
+			title: row.title as string,
+			text: row.text as string,
+			categoryId: row.categoryId as number,
+			statusId: row.statusId as number,
+			startDate: (row.startDate as string) ?? null,
+			finishDate: row.finishDate as string,
+			firstLines: (row.firstLines as string) ?? null,
+			firstLinesAutoGenerating: Boolean(row.firstLinesAutoGenerating),
+			excludeFromDaily: Boolean(row.excludeFromDaily),
+			notes: noteRows.map((n) => ({ id: n.id as number, text: n.text as string })),
+			seoDescription: (row.seoDescription as string) ?? null,
+			seoKeywords: (row.seoKeywords as string) ?? null,
+			info: (row.info as string) ?? null,
+		};
+	});
+
+export const createThing = async (
+	mysql: MySQLPromisePool,
+	data: {
+		title: string; text: string; categoryId: number; statusId: number;
+		startDate: string | null; finishDate: string;
+		firstLines: string | null; firstLinesAutoGenerating: boolean; excludeFromDaily: boolean;
+		notes: { text: string }[];
+		seoDescription: string | null; seoKeywords: string | null; info: string | null;
+	},
+): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			const [result] = await connection.query<MySQLResultSetHeader>(createThingQuery, [
+				data.title, data.text, data.categoryId, data.statusId,
+				data.startDate, data.finishDate,
+				data.firstLines, data.firstLinesAutoGenerating ? 1 : 0, data.excludeFromDaily ? 1 : 0,
+			]);
+			const thingId = result.insertId;
+
+			if (data.seoDescription || data.seoKeywords) {
+				await connection.query(upsertThingSeoQuery, [thingId, data.seoDescription, data.seoKeywords]);
+			}
+
+			if (data.info) {
+				await connection.query(upsertThingInfoQuery, [thingId, data.info]);
+			}
+
+			for (let i = 0; i < data.notes.length; i++) {
+				await connection.query(insertThingNoteQuery, [thingId, data.notes[i].text, i + 1]);
+			}
+
+			await connection.commit();
+			return thingId;
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+
+export const updateThing = async (
+	mysql: MySQLPromisePool,
+	thingId: number,
+	data: {
+		title?: string; text?: string; categoryId?: number; statusId?: number;
+		startDate?: string | null; finishDate?: string;
+		firstLines?: string | null; firstLinesAutoGenerating?: boolean; excludeFromDaily?: boolean;
+		notes?: { id?: number; text: string }[];
+		seoDescription?: string | null; seoKeywords?: string | null; info?: string | null;
+	},
+	current: CmsThing,
+): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			await connection.query(updateThingQuery, [
+				data.title ?? current.title,
+				data.text ?? current.text,
+				data.categoryId ?? current.categoryId,
+				data.statusId ?? current.statusId,
+				data.startDate !== undefined ? data.startDate : current.startDate,
+				data.finishDate ?? current.finishDate,
+				data.firstLines !== undefined ? data.firstLines : current.firstLines,
+				(data.firstLinesAutoGenerating ?? current.firstLinesAutoGenerating) ? 1 : 0,
+				(data.excludeFromDaily ?? current.excludeFromDaily) ? 1 : 0,
+				thingId,
+			]);
+
+			// SEO upsert/delete
+			if (data.seoDescription !== undefined || data.seoKeywords !== undefined) {
+				const desc = data.seoDescription !== undefined ? data.seoDescription : current.seoDescription;
+				const kw = data.seoKeywords !== undefined ? data.seoKeywords : current.seoKeywords;
+
+				if (desc || kw) {
+					await connection.query(upsertThingSeoQuery, [thingId, desc, kw]);
+				} else {
+					await connection.query(deleteThingSeoQuery, [thingId]);
+				}
+			}
+
+			// Info upsert/delete
+			if (data.info !== undefined) {
+				if (data.info) {
+					await connection.query(upsertThingInfoQuery, [thingId, data.info]);
+				} else {
+					await connection.query(deleteThingInfoQuery, [thingId]);
+				}
+			}
+
+			// Notes sync (array position = order)
+			if (data.notes !== undefined) {
+				const keepIds: number[] = [];
+
+				for (let i = 0; i < data.notes.length; i++) {
+					const note = data.notes[i];
+
+					if (note.id) {
+						await connection.query(updateThingNoteQuery, [note.text, i + 1, note.id, thingId]);
+						keepIds.push(note.id);
+					} else {
+						await connection.query(insertThingNoteQuery, [thingId, note.text, i + 1]);
+					}
+				}
+
+				if (keepIds.length > 0) {
+					await connection.query(deleteThingNotesExceptQuery, [thingId, keepIds]);
+				} else {
+					await connection.query(deleteAllThingNotesQuery, [thingId]);
+				}
+			}
+
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+
+export const deleteThing = async (mysql: MySQLPromisePool, thingId: number): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			await connection.query(deleteAllThingNotesQuery, [thingId]);
+			await connection.query(deleteThingSeoQuery, [thingId]);
+			await connection.query(deleteThingInfoQuery, [thingId]);
+			await connection.query(deleteThingQuery, [thingId]);
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});
+};
+
+export const getThingInSectionsCount = async (mysql: MySQLPromisePool, thingId: number): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingInSectionsCountQuery, [thingId]);
+		return rows[0].cnt as number;
+	});

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -172,3 +172,97 @@ export const updateAuthorQuery = `
 	SET text = ?, date = ?, seo_description = ?, seo_keywords = ?
 	WHERE id = 1;
 `;
+
+// --- Thing CRUD ---
+
+export const thingStatusesQuery = `
+	SELECT id, title FROM thing_status ORDER BY id;
+`;
+
+export const thingCategoriesQuery = `
+	SELECT id, title FROM thing_category ORDER BY id;
+`;
+
+export const cmsThingByIdQuery = `
+	SELECT
+		t.id,
+		t.title,
+		t.text,
+		t.r_thing_category_id          AS categoryId,
+		t.r_thing_status_id            AS statusId,
+		CAST(t.start_date AS CHAR)     AS startDate,
+		CAST(t.finish_date AS CHAR)    AS finishDate,
+		t.first_lines                  AS firstLines,
+		t.first_lines_auto_generating  AS firstLinesAutoGenerating,
+		t.exclude_from_daily           AS excludeFromDaily,
+		ts.description                 AS seoDescription,
+		ts.keywords                    AS seoKeywords,
+		ti.text                        AS info
+	FROM thing t
+	LEFT JOIN thing_seo ts ON ts.r_thing_id = t.id
+	LEFT JOIN thing_info ti ON ti.r_thing_id = t.id
+	WHERE t.id = ?;
+`;
+
+export const thingNotesQuery = `
+	SELECT id, text FROM thing_note WHERE r_thing_id = ? ORDER BY \`order\`, id;
+`;
+
+export const createThingQuery = `
+	INSERT INTO thing (title, text, r_thing_category_id, r_thing_status_id, start_date, finish_date,
+		first_lines, first_lines_auto_generating, exclude_from_daily, last_modified)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
+`;
+
+export const updateThingQuery = `
+	UPDATE thing SET
+		title = ?, text = ?, r_thing_category_id = ?, r_thing_status_id = ?,
+		start_date = ?, finish_date = ?,
+		first_lines = ?, first_lines_auto_generating = ?, exclude_from_daily = ?,
+		last_modified = NOW()
+	WHERE id = ?;
+`;
+
+export const deleteThingQuery = `
+	DELETE FROM thing WHERE id = ?;
+`;
+
+export const thingInSectionsCountQuery = `
+	SELECT COUNT(*) AS cnt FROM thing_identifier WHERE r_thing_id = ?;
+`;
+
+export const upsertThingSeoQuery = `
+	INSERT INTO thing_seo (r_thing_id, description, keywords)
+	VALUES (?, ?, ?)
+	ON DUPLICATE KEY UPDATE description = VALUES(description), keywords = VALUES(keywords);
+`;
+
+export const deleteThingSeoQuery = `
+	DELETE FROM thing_seo WHERE r_thing_id = ?;
+`;
+
+export const upsertThingInfoQuery = `
+	INSERT INTO thing_info (r_thing_id, text)
+	VALUES (?, ?)
+	ON DUPLICATE KEY UPDATE text = VALUES(text);
+`;
+
+export const deleteThingInfoQuery = `
+	DELETE FROM thing_info WHERE r_thing_id = ?;
+`;
+
+export const insertThingNoteQuery = `
+	INSERT INTO thing_note (r_thing_id, text, \`order\`) VALUES (?, ?, ?);
+`;
+
+export const updateThingNoteQuery = `
+	UPDATE thing_note SET text = ?, \`order\` = ? WHERE id = ? AND r_thing_id = ?;
+`;
+
+export const deleteThingNotesExceptQuery = `
+	DELETE FROM thing_note WHERE r_thing_id = ? AND id NOT IN (?);
+`;
+
+export const deleteAllThingNotesQuery = `
+	DELETE FROM thing_note WHERE r_thing_id = ?;
+`;

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -121,6 +121,89 @@ export const updateAuthorRequest = z.object({
 	seoKeywords: z.string().nullable().default(null),
 });
 
+// --- Thing CRUD ---
+
+const thingNoteItem = z.object({
+	id: z.number().int().optional(),
+	text: z.string().min(1),
+});
+
+// Partial date: YYYY-00-00 (year), YYYY-MM-00 (year-month), YYYY-MM-DD (full)
+// YYYY-00-DD is invalid (month=0 with day≠0)
+const partialDateRegex = /^\d{4}-(00-00|(0[1-9]|1[0-2])-(00|0[1-9]|[12]\d|3[01]))$/;
+
+const isValidPartialDate = (value: string): boolean => {
+	if (!partialDateRegex.test(value)) {
+		return false;
+	}
+
+	const [, mm, dd] = value.split('-');
+
+	// Partial dates (with 00) are valid by format alone
+	if (mm === '00' || dd === '00') {
+		return true;
+	}
+
+	// Full dates: verify the day is valid for the month
+	const date = new Date(value);
+	return date.getMonth() + 1 === Number(mm) && date.getDate() === Number(dd);
+};
+
+const partialDate = z.string().refine(isValidPartialDate, { message: 'Invalid date' });
+
+export const cmsThingResponse = z.object({
+	id: z.number().int(),
+	title: z.string(),
+	text: z.string(),
+	categoryId: z.number().int(),
+	statusId: z.number().int(),
+	startDate: z.string().nullable(),
+	finishDate: z.string(),
+	firstLines: z.string().nullable(),
+	firstLinesAutoGenerating: z.boolean(),
+	excludeFromDaily: z.boolean(),
+	notes: z.array(z.object({ id: z.number().int(), text: z.string() })),
+	seoDescription: z.string().nullable(),
+	seoKeywords: z.string().nullable(),
+	info: z.string().nullable(),
+});
+
+export const thingIdParam = z.object({
+	thingId: z.coerce.number().int().positive(),
+});
+
+export const createThingRequest = z.object({
+	title: z.string().default('.'),
+	text: z.string().min(1),
+	categoryId: z.number().int().min(1).max(4),
+	statusId: z.number().int().min(1).max(4).default(1),
+	startDate: partialDate.nullable().default(null),
+	finishDate: partialDate,
+	firstLines: z.string().nullable().default(null),
+	firstLinesAutoGenerating: z.boolean().default(true),
+	excludeFromDaily: z.boolean().default(false),
+	notes: z.array(thingNoteItem).default([]),
+	seoDescription: z.string().nullable().default(null),
+	seoKeywords: z.string().nullable().default(null),
+	info: z.string().nullable().default(null),
+});
+
+export const updateThingRequest = z.object({
+	title: z.string().optional(),
+	text: z.string().min(1).optional(),
+	categoryId: z.number().int().min(1).max(4).optional(),
+	statusId: z.number().int().min(1).max(4).optional(),
+	startDate: partialDate.nullable().optional(),
+	finishDate: partialDate.optional(),
+	firstLines: z.string().nullable().optional(),
+	firstLinesAutoGenerating: z.boolean().optional(),
+	excludeFromDaily: z.boolean().optional(),
+	notes: z.array(thingNoteItem).optional(),
+	seoDescription: z.string().nullable().optional(),
+	seoKeywords: z.string().nullable().optional(),
+	info: z.string().nullable().optional(),
+});
+
 // --- Inferred types ---
 
 export type SectionIdParam = z.infer<typeof sectionIdParam>;
@@ -131,3 +214,6 @@ export type ThingInSectionParams = z.infer<typeof thingInSectionParams>;
 export type AddThingRequest = z.infer<typeof addThingRequest>;
 export type ReorderThingsRequest = z.infer<typeof reorderThingsRequest>;
 export type UpdateAuthorRequest = z.infer<typeof updateAuthorRequest>;
+export type ThingIdParam = z.infer<typeof thingIdParam>;
+export type CreateThingRequest = z.infer<typeof createThingRequest>;
+export type UpdateThingRequest = z.infer<typeof updateThingRequest>;

--- a/src/plugins/cms/thingRoutes.ts
+++ b/src/plugins/cms/thingRoutes.ts
@@ -1,0 +1,198 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import {
+	getThingStatuses,
+	getThingCategories,
+	getCmsThing,
+	createThing,
+	updateThing,
+	deleteThing,
+	getThingInSectionsCount,
+} from './databaseHelpers.js';
+import {
+	sectionTypesResponse,
+	cmsThingResponse,
+	thingIdParam,
+	createThingRequest,
+	updateThingRequest,
+	type ThingIdParam,
+	type CreateThingRequest,
+	type UpdateThingRequest,
+} from './schemas.js';
+import { requireCanEditContent } from './hooks.js';
+
+export async function thingRoutes(fastify: FastifyInstance) {
+	fastify.get('/thing-statuses', {
+		schema: {
+			description: 'List thing statuses.',
+			tags: ['CMS'],
+			response: {
+				200: sectionTypesResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getThingStatuses(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.get('/thing-categories', {
+		schema: {
+			description: 'List thing categories.',
+			tags: ['CMS'],
+			response: {
+				200: sectionTypesResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getThingCategories(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.get<{ Params: ThingIdParam }>('/things/:thingId', {
+		schema: {
+			description: 'Get a thing for editing.',
+			tags: ['CMS'],
+			params: thingIdParam,
+			response: {
+				200: cmsThingResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const thing = await getCmsThing(fastify.mysql, request.params.thingId);
+
+				if (!thing) {
+					return reply.code(404).send({ error: 'Thing not found' });
+				}
+
+				return thing;
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.post('/things', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Create a new thing.',
+			tags: ['CMS'],
+			body: createThingRequest,
+			response: {
+				201: cmsThingResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: CreateThingRequest }>, reply) => {
+			try {
+				const id = await createThing(fastify.mysql, request.body);
+				const thing = await getCmsThing(fastify.mysql, id);
+
+				request.log.info({ thingId: id }, 'Thing created');
+				return reply.code(201).send(thing);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put<{ Params: ThingIdParam; Body: UpdateThingRequest }>('/things/:thingId', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Update a thing.',
+			tags: ['CMS'],
+			params: thingIdParam,
+			body: updateThingRequest,
+			response: {
+				200: cmsThingResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const current = await getCmsThing(fastify.mysql, request.params.thingId);
+
+				if (!current) {
+					return reply.code(404).send({ error: 'Thing not found' });
+				}
+
+				await updateThing(fastify.mysql, request.params.thingId, request.body, current);
+				const updated = await getCmsThing(fastify.mysql, request.params.thingId);
+
+				request.log.info({ thingId: request.params.thingId }, 'Thing updated');
+				return updated;
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.delete<{ Params: ThingIdParam }>('/things/:thingId', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Delete a thing. Refuses if thing is in any section.',
+			tags: ['CMS'],
+			params: thingIdParam,
+			response: {
+				204: z.void(),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				const current = await getCmsThing(fastify.mysql, request.params.thingId);
+
+				if (!current) {
+					return reply.code(404).send({ error: 'Thing not found' });
+				}
+
+				const sectionCount = await getThingInSectionsCount(fastify.mysql, request.params.thingId);
+
+				if (sectionCount > 0) {
+					return reply.code(409).send({ error: 'Thing is in sections — remove it from all sections first' });
+				}
+
+				await deleteThing(fastify.mysql, request.params.thingId);
+				request.log.info({ thingId: request.params.thingId }, 'Thing deleted');
+				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}


### PR DESCRIPTION
## Summary
- Thing CRUD: GET/POST/PUT/DELETE `/cms/things/:thingId` with notes (ordered), SEO, info sync
- Reference data: `GET /cms/thing-statuses`, `GET /cms/thing-categories`
- Partial date validation: `YYYY-00-00` (year), `YYYY-MM-00` (year-month), full dates validated
- Admin notifications: votes (with thing title), registrations, account deletions via `ADMIN_NOTIFY_EMAIL`
- Extract `thingDisplayTitle()` to shared mappers
- Notes ordered by `order` column (array position from CMS)
- CLAUDE.md restructured with nested lists
- api.http updated with all CMS endpoints

## Test plan
- [x] 87 tests pass
- [x] Build and lint clean
- [ ] Deploy after DB migration on VPS