### PR TITLE
Refactor smoke tests, fix SEO validation and notes sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ node build/index.js
 
 # Smoke tests (require running server + DB)
 ./smoke-test-v1.sh [base_url]   # public endpoints only
-./smoke-test.sh [base_url]      # full auth flow (creates/deletes a test user)
+./smoke-test.sh [base_url]      # full auth flow (test cases in smoke-tests/*.sh)
 ```
 
 ## Environment

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -2,6 +2,7 @@
 #
 # Smoke test for api.mellonis.ru
 # Starts a managed server instance, captures logs to extract activation/reset keys.
+# Test cases are sourced from smoke-tests/*.sh
 # Usage: ./smoke-test.sh
 #
 
@@ -18,6 +19,7 @@ SMOKE_PORT=3033
 BASE_URL="http://localhost:${SMOKE_PORT}"
 LOG_FILE=$(mktemp)
 SERVER_PID=""
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # ---- Helpers ----
 
@@ -51,7 +53,7 @@ json_field() {
 
 request() {
     local method="$1" path="$2" body="${3:-}" token="${4:-}"
-    local headers=(-H "Content-Type: application/json" -H "Accept: application/json")
+    local headers=(-H "Accept: application/json")
     local curl_opts=(-s -w "\n%{http_code}" -X "$method")
 
     if [ -n "$token" ]; then
@@ -59,6 +61,7 @@ request() {
     fi
 
     if [ -n "$body" ]; then
+        headers+=(-H "Content-Type: application/json")
         curl_opts+=(-d "$body")
     fi
 
@@ -71,12 +74,8 @@ parse_response() {
     RESPONSE_STATUS=$(echo "$response" | tail -1)
 }
 
-# Extract a key logged by ConsoleAuthNotifier from the server log.
-# Usage: extract_key_from_log "login_value"
-# The log format is:  key: "hexstring"  (on its own line, after a line matching the login)
 extract_key_from_log() {
     local login="$1"
-    # Find the last log block mentioning this login, then extract the key
     grep -A3 "login.*\"${login}\"" "$LOG_FILE" | grep -o 'key: "[^"]*"' | tail -1 | sed 's/key: "//;s/"//'
 }
 
@@ -88,7 +87,6 @@ bold "Starting managed server on port ${SMOKE_PORT}..."
 PORT=$SMOKE_PORT node --env-file=.env build/index.js > "$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 
-# Wait for server to be ready (up to 10 seconds)
 for i in $(seq 1 20); do
     if curl -s -o /dev/null "http://localhost:${SMOKE_PORT}/sections" 2>/dev/null; then
         break
@@ -116,257 +114,9 @@ bold "Smoke testing ${BASE_URL}"
 bold "Test user: ${TEST_LOGIN} / ${TEST_EMAIL}"
 bold "============================================"
 
-# 1. Public endpoints
-bold ""
-bold "1. Public endpoints"
-
-parse_response "$(request GET /sections)"
-assert_status "GET /sections" 200 "$RESPONSE_STATUS"
-
-parse_response "$(request GET /things-of-the-day)"
-assert_status "GET /things-of-the-day" 200 "$RESPONSE_STATUS"
-
-# 2. Register
-bold ""
-bold "2. Registration"
-
-parse_response "$(request POST /auth/register "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\",\"email\":\"${TEST_EMAIL}\"}")"
-assert_status "POST /auth/register (new user)" 201 "$RESPONSE_STATUS"
-
-parse_response "$(request POST /auth/register "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\",\"email\":\"${TEST_EMAIL}\"}")"
-assert_status "POST /auth/register (duplicate login)" 409 "$RESPONSE_STATUS"
-
-# 3. Login before activation
-bold ""
-bold "3. Login before activation"
-
-parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-assert_status "POST /auth/login (not activated)" 403 "$RESPONSE_STATUS"
-
-# 4. Resend activation
-bold ""
-bold "4. Resend activation"
-
-parse_response "$(request POST /auth/resend-activation "{\"login\":\"${TEST_LOGIN}\"}")"
-assert_status "POST /auth/resend-activation (unactivated user)" 200 "$RESPONSE_STATUS"
-
-parse_response "$(request POST /auth/resend-activation "{\"login\":\"nonexistent_user\"}")"
-assert_status "POST /auth/resend-activation (unknown user)" 200 "$RESPONSE_STATUS"
-
-# 5. Activate (extract key from server log)
-bold ""
-bold "5. Activation"
-
-# Give the log a moment to flush
-sleep 0.2
-ACTIVATION_KEY=$(extract_key_from_log "$TEST_LOGIN")
-
-if [ -n "$ACTIVATION_KEY" ]; then
-    parse_response "$(request POST /auth/activate "{\"key\":\"${ACTIVATION_KEY}\"}")"
-    assert_status "POST /auth/activate" 200 "$RESPONSE_STATUS"
-else
-    red "  FAIL  Could not extract activation key from server log"
-    FAIL=$((FAIL + 1))
-fi
-
-# 6. Login
-bold ""
-bold "6. Login"
-
-parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-assert_status "POST /auth/login (valid credentials)" 200 "$RESPONSE_STATUS"
-
-ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
-USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
-
-if [ -z "$ACCESS_TOKEN" ] || [ -z "$REFRESH_TOKEN" ]; then
-    red "  FAIL  Could not extract tokens from login response"
-    FAIL=$((FAIL + 1))
-fi
-
-parse_response "$(request POST /auth/login "{\"login\":\"nobody\",\"password\":\"wrong\"}")"
-assert_status "POST /auth/login (invalid credentials)" 401 "$RESPONSE_STATUS"
-
-# 7. Refresh
-bold ""
-bold "7. Token refresh"
-
-if [ -n "$REFRESH_TOKEN" ]; then
-    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
-    assert_status "POST /auth/refresh (valid token)" 200 "$RESPONSE_STATUS"
-
-    # Update tokens from refresh response
-    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-    REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
-
-    FAKE_TOKEN="0000000000000000000000000000000000000000000000000000000000000000"
-    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${FAKE_TOKEN}\"}")"
-    assert_status "POST /auth/refresh (invalid token)" 401 "$RESPONSE_STATUS"
-else
-    red "  SKIP  Token refresh (no refresh token)"
-    FAIL=$((FAIL + 2))
-fi
-
-# 8. Protected endpoint without auth
-bold ""
-bold "8. Auth enforcement"
-
-parse_response "$(request PATCH "/users/${USER_ID}/password" "{\"currentPassword\":\"x\",\"newPassword\":\"newpass123\"}")"
-assert_status "PATCH /users/:id/password (no auth)" 401 "$RESPONSE_STATUS"
-
-# 9. Password reset flow
-bold ""
-bold "9. Password reset"
-
-parse_response "$(request POST /auth/request-password-reset "{\"email\":\"${TEST_EMAIL}\"}")"
-assert_status "POST /auth/request-password-reset" 200 "$RESPONSE_STATUS"
-
-sleep 0.2
-RESET_KEY=$(extract_key_from_log "$TEST_LOGIN")
-
-if [ -n "$RESET_KEY" ]; then
-    parse_response "$(request POST /auth/reset-password "{\"key\":\"${RESET_KEY}\",\"newPassword\":\"${TEST_PASSWORD}\"}")"
-    assert_status "POST /auth/reset-password" 200 "$RESPONSE_STATUS"
-
-    # Verify login with same password (reset set it back)
-    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-    assert_status "POST /auth/login (after reset)" 200 "$RESPONSE_STATUS"
-
-    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-    REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
-    USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
-else
-    red "  FAIL  Could not extract reset key from server log"
-    FAIL=$((FAIL + 2))
-fi
-
-# 10. CMS (requires editor role + canEditContent right)
-bold ""
-bold "10. CMS"
-
-# Promote test user to editor group (r_group_id=2) via direct DB query
-# Parse CONNECTION_STRING from .env: mysql://user:password@host:port/schema
-DB_CONN=$(grep '^CONNECTION_STRING=' .env | sed 's/^CONNECTION_STRING=//')
-DB_USER=$(echo "$DB_CONN" | sed 's|mysql://||;s|:.*||')
-DB_PASS=$(echo "$DB_CONN" | sed 's|mysql://[^:]*:||;s|@.*||')
-DB_HOST=$(echo "$DB_CONN" | sed 's|.*@||;s|:.*||')
-DB_PORT=$(echo "$DB_CONN" | sed 's|.*:||;s|/.*||')
-DB_NAME=$(echo "$DB_CONN" | sed 's|.*/||')
-
-mysql -u "$DB_USER" -p"$DB_PASS" -h "$DB_HOST" -P "$DB_PORT" "$DB_NAME" -e \
-    "UPDATE auth_user SET r_group_id = 2 WHERE login = '${TEST_LOGIN}'" 2>/dev/null
-
-# Re-login to get updated JWT with editor role
-parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-assert_status "POST /auth/login (as editor)" 200 "$RESPONSE_STATUS"
-
-ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
-
-if [ -n "$ACCESS_TOKEN" ]; then
-    # Read-only CMS endpoints (editor role sufficient)
-    parse_response "$(request GET /cms/section-types "" "$ACCESS_TOKEN")"
-    assert_status "GET /cms/section-types" 200 "$RESPONSE_STATUS"
-
-    parse_response "$(request GET /cms/sections "" "$ACCESS_TOKEN")"
-    assert_status "GET /cms/sections" 200 "$RESPONSE_STATUS"
-
-    # Mutation without canEditContent right — should be 403
-    parse_response "$(request POST /cms/sections "{\"identifier\":\"smtest\",\"title\":\"Smoke\",\"typeId\":1}" "$ACCESS_TOKEN")"
-    assert_status "POST /cms/sections (no canEditContent)" 403 "$RESPONSE_STATUS"
-
-    # Grant canEditContent (bit 12) to the test user
-    mysql -u "$DB_USER" -p"$DB_PASS" -h "$DB_HOST" -P "$DB_PORT" "$DB_NAME" -e \
-        "UPDATE auth_user SET rights = rights | (1 << 12) WHERE login = '${TEST_LOGIN}'" 2>/dev/null
-
-    # Re-login to get updated JWT with canEditContent
-    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-
-    # Create section
-    parse_response "$(request POST /cms/sections "{\"identifier\":\"smtest\",\"title\":\"Smoke Test\",\"typeId\":1}" "$ACCESS_TOKEN")"
-    assert_status "POST /cms/sections (create)" 201 "$RESPONSE_STATUS"
-    SECTION_DB_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
-
-    if [ -n "$SECTION_DB_ID" ]; then
-        # Update section
-        parse_response "$(request PUT "/cms/sections/${SECTION_DB_ID}" "{\"title\":\"Smoke Updated\",\"settings\":{\"showAll\":true,\"reverseOrder\":false}}" "$ACCESS_TOKEN")"
-        assert_status "PUT /cms/sections/:id (update)" 200 "$RESPONSE_STATUS"
-
-        # List things (empty)
-        parse_response "$(request GET "/cms/sections/${SECTION_DB_ID}/things" "" "$ACCESS_TOKEN")"
-        assert_status "GET /cms/sections/:id/things" 200 "$RESPONSE_STATUS"
-
-        # Delete section (empty, should succeed)
-        parse_response "$(request DELETE "/cms/sections/${SECTION_DB_ID}" "" "$ACCESS_TOKEN")"
-        assert_status "DELETE /cms/sections/:id" 204 "$RESPONSE_STATUS"
-    else
-        red "  SKIP  CMS section CRUD (could not extract section ID)"
-        FAIL=$((FAIL + 3))
-    fi
-else
-    red "  SKIP  CMS (no access token after editor promotion)"
-    FAIL=$((FAIL + 7))
-fi
-
-# 11. Voting
-bold ""
-bold "11. Voting"
-
-if [ -n "$ACCESS_TOKEN" ]; then
-    # Cast a vote
-    parse_response "$(request PUT /things/1/vote "{\"vote\":1}" "$ACCESS_TOKEN")"
-    assert_status "PUT /things/1/vote (upvote)" 200 "$RESPONSE_STATUS"
-
-    # Change vote
-    parse_response "$(request PUT /things/1/vote "{\"vote\":-1}" "$ACCESS_TOKEN")"
-    assert_status "PUT /things/1/vote (downvote)" 200 "$RESPONSE_STATUS"
-
-    # Remove vote
-    parse_response "$(request PUT /things/1/vote "{\"vote\":0}" "$ACCESS_TOKEN")"
-    assert_status "PUT /things/1/vote (remove)" 200 "$RESPONSE_STATUS"
-else
-    red "  SKIP  Voting (no access token)"
-    FAIL=$((FAIL + 3))
-fi
-
-# 12. Logout
-bold ""
-bold "12. Logout"
-
-if [ -n "$REFRESH_TOKEN" ]; then
-    parse_response "$(request POST /auth/logout "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
-    assert_status "POST /auth/logout" 204 "$RESPONSE_STATUS"
-
-    # Refresh with revoked token should fail
-    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
-    assert_status "POST /auth/refresh (after logout)" 401 "$RESPONSE_STATUS"
-else
-    red "  SKIP  Logout (no refresh token)"
-    FAIL=$((FAIL + 2))
-fi
-
-# 13. Cleanup — delete the test user
-bold ""
-bold "13. Cleanup"
-
-# Login fresh for deletion
-parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-if [ "$RESPONSE_STATUS" -eq 200 ]; then
-    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
-    USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
-
-    parse_response "$(request DELETE "/users/${USER_ID}" "{\"password\":\"${TEST_PASSWORD}\"}" "$ACCESS_TOKEN")"
-    assert_status "DELETE /users/:id (self-delete)" 204 "$RESPONSE_STATUS"
-
-    # Verify user is gone
-    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
-    assert_status "POST /auth/login (after delete)" 401 "$RESPONSE_STATUS"
-else
-    red "  SKIP  Cleanup (could not login)"
-    FAIL=$((FAIL + 2))
-fi
+for test_file in "$SCRIPT_DIR"/smoke-tests/*.sh; do
+    source "$test_file"
+done
 
 # ---- Summary ----
 

--- a/smoke-tests/01-public.sh
+++ b/smoke-tests/01-public.sh
@@ -1,0 +1,9 @@
+# 1. Public endpoints
+bold ""
+bold "1. Public endpoints"
+
+parse_response "$(request GET /sections)"
+assert_status "GET /sections" 200 "$RESPONSE_STATUS"
+
+parse_response "$(request GET /things-of-the-day)"
+assert_status "GET /things-of-the-day" 200 "$RESPONSE_STATUS"

--- a/smoke-tests/02-registration.sh
+++ b/smoke-tests/02-registration.sh
@@ -1,0 +1,9 @@
+# 2. Registration
+bold ""
+bold "2. Registration"
+
+parse_response "$(request POST /auth/register "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\",\"email\":\"${TEST_EMAIL}\"}")"
+assert_status "POST /auth/register (new user)" 201 "$RESPONSE_STATUS"
+
+parse_response "$(request POST /auth/register "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\",\"email\":\"${TEST_EMAIL}\"}")"
+assert_status "POST /auth/register (duplicate login)" 409 "$RESPONSE_STATUS"

--- a/smoke-tests/03-login-before-activation.sh
+++ b/smoke-tests/03-login-before-activation.sh
@@ -1,0 +1,6 @@
+# 3. Login before activation
+bold ""
+bold "3. Login before activation"
+
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+assert_status "POST /auth/login (not activated)" 403 "$RESPONSE_STATUS"

--- a/smoke-tests/04-resend-activation.sh
+++ b/smoke-tests/04-resend-activation.sh
@@ -1,0 +1,9 @@
+# 4. Resend activation
+bold ""
+bold "4. Resend activation"
+
+parse_response "$(request POST /auth/resend-activation "{\"login\":\"${TEST_LOGIN}\"}")"
+assert_status "POST /auth/resend-activation (unactivated user)" 200 "$RESPONSE_STATUS"
+
+parse_response "$(request POST /auth/resend-activation "{\"login\":\"nonexistent_user\"}")"
+assert_status "POST /auth/resend-activation (unknown user)" 200 "$RESPONSE_STATUS"

--- a/smoke-tests/05-activation.sh
+++ b/smoke-tests/05-activation.sh
@@ -1,0 +1,14 @@
+# 5. Activation
+bold ""
+bold "5. Activation"
+
+sleep 0.2
+ACTIVATION_KEY=$(extract_key_from_log "$TEST_LOGIN")
+
+if [ -n "$ACTIVATION_KEY" ]; then
+    parse_response "$(request POST /auth/activate "{\"key\":\"${ACTIVATION_KEY}\"}")"
+    assert_status "POST /auth/activate" 200 "$RESPONSE_STATUS"
+else
+    red "  FAIL  Could not extract activation key from server log"
+    FAIL=$((FAIL + 1))
+fi

--- a/smoke-tests/06-login.sh
+++ b/smoke-tests/06-login.sh
@@ -1,0 +1,18 @@
+# 6. Login
+bold ""
+bold "6. Login"
+
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+assert_status "POST /auth/login (valid credentials)" 200 "$RESPONSE_STATUS"
+
+ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
+USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+if [ -z "$ACCESS_TOKEN" ] || [ -z "$REFRESH_TOKEN" ]; then
+    red "  FAIL  Could not extract tokens from login response"
+    FAIL=$((FAIL + 1))
+fi
+
+parse_response "$(request POST /auth/login "{\"login\":\"nobody\",\"password\":\"wrong\"}")"
+assert_status "POST /auth/login (invalid credentials)" 401 "$RESPONSE_STATUS"

--- a/smoke-tests/07-token-refresh.sh
+++ b/smoke-tests/07-token-refresh.sh
@@ -1,0 +1,18 @@
+# 7. Token refresh
+bold ""
+bold "7. Token refresh"
+
+if [ -n "$REFRESH_TOKEN" ]; then
+    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
+    assert_status "POST /auth/refresh (valid token)" 200 "$RESPONSE_STATUS"
+
+    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+    REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
+
+    FAKE_TOKEN="0000000000000000000000000000000000000000000000000000000000000000"
+    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${FAKE_TOKEN}\"}")"
+    assert_status "POST /auth/refresh (invalid token)" 401 "$RESPONSE_STATUS"
+else
+    red "  SKIP  Token refresh (no refresh token)"
+    FAIL=$((FAIL + 2))
+fi

--- a/smoke-tests/08-auth-enforcement.sh
+++ b/smoke-tests/08-auth-enforcement.sh
@@ -1,0 +1,6 @@
+# 8. Auth enforcement
+bold ""
+bold "8. Auth enforcement"
+
+parse_response "$(request PATCH "/users/${USER_ID}/password" "{\"currentPassword\":\"x\",\"newPassword\":\"newpass123\"}")"
+assert_status "PATCH /users/:id/password (no auth)" 401 "$RESPONSE_STATUS"

--- a/smoke-tests/09-password-reset.sh
+++ b/smoke-tests/09-password-reset.sh
@@ -1,0 +1,24 @@
+# 9. Password reset
+bold ""
+bold "9. Password reset"
+
+parse_response "$(request POST /auth/request-password-reset "{\"email\":\"${TEST_EMAIL}\"}")"
+assert_status "POST /auth/request-password-reset" 200 "$RESPONSE_STATUS"
+
+sleep 0.2
+RESET_KEY=$(extract_key_from_log "$TEST_LOGIN")
+
+if [ -n "$RESET_KEY" ]; then
+    parse_response "$(request POST /auth/reset-password "{\"key\":\"${RESET_KEY}\",\"newPassword\":\"${TEST_PASSWORD}\"}")"
+    assert_status "POST /auth/reset-password" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+    assert_status "POST /auth/login (after reset)" 200 "$RESPONSE_STATUS"
+
+    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+    REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
+    USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+else
+    red "  FAIL  Could not extract reset key from server log"
+    FAIL=$((FAIL + 2))
+fi

--- a/smoke-tests/10-cms.sh
+++ b/smoke-tests/10-cms.sh
@@ -1,0 +1,67 @@
+# 10. CMS (requires editor role + canEditContent right)
+bold ""
+bold "10. CMS"
+
+CMS_READY=false
+
+# Parse DB connection from .env
+DB_CONN=$(grep '^CONNECTION_STRING=' .env | sed 's/^CONNECTION_STRING=//')
+DB_USER=$(echo "$DB_CONN" | sed 's|mysql://||;s|:.*||')
+DB_PASS=$(echo "$DB_CONN" | sed 's|mysql://[^:]*:||;s|@.*||')
+DB_HOST=$(echo "$DB_CONN" | sed 's|.*@||;s|:.*||')
+DB_PORT=$(echo "$DB_CONN" | sed 's|.*:||;s|/.*||')
+DB_NAME=$(echo "$DB_CONN" | sed 's|.*/||')
+
+run_sql() {
+    docker exec poetry-db mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" -e "$1" 2>/dev/null \
+        || mysql -u "$DB_USER" -p"$DB_PASS" -h "$DB_HOST" -P "$DB_PORT" "$DB_NAME" -e "$1" 2>/dev/null
+}
+
+# Promote test user to editor group
+if ! run_sql "UPDATE auth_user SET r_group_id = 2 WHERE login = '${TEST_LOGIN}'"; then
+    red "  SKIP  CMS (mysql client not available or DB connection failed)"
+    return 0 2>/dev/null || true
+fi
+
+# Re-login to get updated JWT with editor role
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+assert_status "POST /auth/login (as editor)" 200 "$RESPONSE_STATUS"
+
+ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")
+
+if [ -n "$ACCESS_TOKEN" ]; then
+    # Read-only CMS endpoints (editor role sufficient)
+    parse_response "$(request GET /cms/section-types "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/section-types" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request GET /cms/sections "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/sections" 200 "$RESPONSE_STATUS"
+
+    CMS_READY=true
+
+    # Create section
+    parse_response "$(request POST /cms/sections "{\"identifier\":\"smtst\",\"title\":\"Smoke Test\",\"typeId\":1}" "$ACCESS_TOKEN")"
+    assert_status "POST /cms/sections (create)" 201 "$RESPONSE_STATUS"
+    SECTION_DB_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "$SECTION_DB_ID" ]; then
+        # Update section
+        parse_response "$(request PUT "/cms/sections/${SECTION_DB_ID}" "{\"title\":\"Smoke Updated\",\"settings\":{\"showAll\":true,\"reverseOrder\":false}}" "$ACCESS_TOKEN")"
+        assert_status "PUT /cms/sections/:id (update)" 200 "$RESPONSE_STATUS"
+
+        # List things (empty)
+        parse_response "$(request GET "/cms/sections/${SECTION_DB_ID}/things" "" "$ACCESS_TOKEN")"
+        assert_status "GET /cms/sections/:id/things" 200 "$RESPONSE_STATUS"
+
+        # Delete section (empty, should succeed)
+        parse_response "$(request DELETE "/cms/sections/${SECTION_DB_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/sections/:id" 204 "$RESPONSE_STATUS"
+    else
+        red "  SKIP  CMS section CRUD (could not extract section ID)"
+        FAIL=$((FAIL + 3))
+    fi
+else
+    red "  SKIP  CMS (no access token after editor promotion)"
+    FAIL=$((FAIL + 7))
+fi

--- a/smoke-tests/10b-cms-things.sh
+++ b/smoke-tests/10b-cms-things.sh
@@ -1,0 +1,39 @@
+# 10b. CMS thing CRUD
+bold ""
+bold "10b. CMS thing CRUD"
+
+if [ "$CMS_READY" != "true" ]; then
+    red "  SKIP  CMS thing CRUD (CMS setup failed)"
+elif [ -n "$ACCESS_TOKEN" ]; then
+    # Create thing
+    parse_response "$(request POST /cms/things "{\"text\":\"Smoke test poem\\nSecond line\",\"categoryId\":1,\"finishDate\":\"2026-01-01\"}" "$ACCESS_TOKEN")"
+    assert_status "POST /cms/things (create)" 201 "$RESPONSE_STATUS"
+    THING_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "$THING_ID" ]; then
+        # Get thing
+        parse_response "$(request GET "/cms/things/${THING_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "GET /cms/things/:id" 200 "$RESPONSE_STATUS"
+
+        # Update thing
+        parse_response "$(request PUT "/cms/things/${THING_ID}" "{\"title\":\"Smoke Title\",\"statusId\":2,\"notes\":[{\"text\":\"Note 1\"},{\"text\":\"Note 2\"}],\"seoDescription\":\"Test desc\",\"seoKeywords\":\"test,smoke\"}" "$ACCESS_TOKEN")"
+        assert_status "PUT /cms/things/:id (update)" 200 "$RESPONSE_STATUS"
+
+        # Update notes (reorder + add)
+        NOTE_1_ID=$(echo "$RESPONSE_BODY" | grep -o '"notes":\[{"id":[0-9]*' | grep -o '[0-9]*$')
+        if [ -n "$NOTE_1_ID" ]; then
+            parse_response "$(request PUT "/cms/things/${THING_ID}" "{\"notes\":[{\"text\":\"New note\"},{\"id\":${NOTE_1_ID},\"text\":\"Note 1 updated\"}]}" "$ACCESS_TOKEN")"
+            assert_status "PUT /cms/things/:id (reorder notes)" 200 "$RESPONSE_STATUS"
+        fi
+
+        # Delete thing
+        parse_response "$(request DELETE "/cms/things/${THING_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/things/:id" 204 "$RESPONSE_STATUS"
+    else
+        red "  SKIP  CMS thing CRUD (could not extract thing ID)"
+        FAIL=$((FAIL + 4))
+    fi
+else
+    red "  SKIP  CMS thing CRUD (no access token)"
+    FAIL=$((FAIL + 5))
+fi

--- a/smoke-tests/10c-cms-section-things.sh
+++ b/smoke-tests/10c-cms-section-things.sh
@@ -1,0 +1,59 @@
+# 10c. CMS section-thing interactions
+bold ""
+bold "10c. CMS section-thing interactions"
+
+if [ "$CMS_READY" != "true" ]; then
+    red "  SKIP  CMS section-thing interactions (CMS setup failed)"
+elif [ -n "$ACCESS_TOKEN" ]; then
+    # Create a section and two things for testing
+    parse_response "$(request POST /cms/sections "{\"identifier\":\"smint\",\"title\":\"Smoke Interaction\",\"typeId\":1}" "$ACCESS_TOKEN")"
+    assert_status "POST /cms/sections (for interaction test)" 201 "$RESPONSE_STATUS"
+    INT_SECTION_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    parse_response "$(request POST /cms/things "{\"text\":\"Thing A\",\"categoryId\":1,\"finishDate\":\"2026-01-01\"}" "$ACCESS_TOKEN")"
+    THING_A_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    parse_response "$(request POST /cms/things "{\"text\":\"Thing B\",\"categoryId\":1,\"finishDate\":\"2026-01-02\"}" "$ACCESS_TOKEN")"
+    THING_B_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "$INT_SECTION_ID" ] && [ -n "$THING_A_ID" ] && [ -n "$THING_B_ID" ]; then
+        # Add things to section
+        parse_response "$(request POST "/cms/sections/${INT_SECTION_ID}/things" "{\"thingId\":${THING_A_ID}}" "$ACCESS_TOKEN")"
+        assert_status "POST /cms/sections/:id/things (add A)" 201 "$RESPONSE_STATUS"
+
+        parse_response "$(request POST "/cms/sections/${INT_SECTION_ID}/things" "{\"thingId\":${THING_B_ID}}" "$ACCESS_TOKEN")"
+        assert_status "POST /cms/sections/:id/things (add B)" 201 "$RESPONSE_STATUS"
+
+        # Reorder things in section
+        parse_response "$(request PUT "/cms/sections/${INT_SECTION_ID}/things/reorder" "[${THING_B_ID},${THING_A_ID}]" "$ACCESS_TOKEN")"
+        assert_status "PUT /cms/sections/:id/things/reorder" 200 "$RESPONSE_STATUS"
+
+        # Delete thing that is in section — should fail
+        parse_response "$(request DELETE "/cms/things/${THING_A_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/things/:id (in section, expect 409)" 409 "$RESPONSE_STATUS"
+
+        # Remove things from section
+        parse_response "$(request DELETE "/cms/sections/${INT_SECTION_ID}/things/${THING_A_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/sections/:id/things/:thingId (remove A)" 204 "$RESPONSE_STATUS"
+
+        parse_response "$(request DELETE "/cms/sections/${INT_SECTION_ID}/things/${THING_B_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/sections/:id/things/:thingId (remove B)" 204 "$RESPONSE_STATUS"
+
+        # Now delete things (should succeed)
+        parse_response "$(request DELETE "/cms/things/${THING_A_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/things/:id (A, after removal)" 204 "$RESPONSE_STATUS"
+
+        parse_response "$(request DELETE "/cms/things/${THING_B_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/things/:id (B, after removal)" 204 "$RESPONSE_STATUS"
+
+        # Delete section
+        parse_response "$(request DELETE "/cms/sections/${INT_SECTION_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /cms/sections/:id (interaction cleanup)" 204 "$RESPONSE_STATUS"
+    else
+        red "  SKIP  CMS section-thing interactions (could not create test data)"
+        FAIL=$((FAIL + 8))
+    fi
+else
+    red "  SKIP  CMS section-thing interactions (no access token)"
+    FAIL=$((FAIL + 9))
+fi

--- a/smoke-tests/11-voting.sh
+++ b/smoke-tests/11-voting.sh
@@ -1,0 +1,17 @@
+# 11. Voting
+bold ""
+bold "11. Voting"
+
+if [ -n "$ACCESS_TOKEN" ]; then
+    parse_response "$(request PUT /things/1/vote "{\"vote\":1}" "$ACCESS_TOKEN")"
+    assert_status "PUT /things/1/vote (upvote)" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request PUT /things/1/vote "{\"vote\":-1}" "$ACCESS_TOKEN")"
+    assert_status "PUT /things/1/vote (downvote)" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request PUT /things/1/vote "{\"vote\":0}" "$ACCESS_TOKEN")"
+    assert_status "PUT /things/1/vote (remove)" 200 "$RESPONSE_STATUS"
+else
+    red "  SKIP  Voting (no access token)"
+    FAIL=$((FAIL + 3))
+fi

--- a/smoke-tests/12-logout.sh
+++ b/smoke-tests/12-logout.sh
@@ -1,0 +1,14 @@
+# 12. Logout
+bold ""
+bold "12. Logout"
+
+if [ -n "$REFRESH_TOKEN" ]; then
+    parse_response "$(request POST /auth/logout "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
+    assert_status "POST /auth/logout" 204 "$RESPONSE_STATUS"
+
+    parse_response "$(request POST /auth/refresh "{\"refreshToken\":\"${REFRESH_TOKEN}\"}")"
+    assert_status "POST /auth/refresh (after logout)" 401 "$RESPONSE_STATUS"
+else
+    red "  SKIP  Logout (no refresh token)"
+    FAIL=$((FAIL + 2))
+fi

--- a/smoke-tests/13-cleanup.sh
+++ b/smoke-tests/13-cleanup.sh
@@ -1,0 +1,18 @@
+# 13. Cleanup — delete the test user
+bold ""
+bold "13. Cleanup"
+
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+if [ "$RESPONSE_STATUS" -eq 200 ]; then
+    ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+    USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    parse_response "$(request DELETE "/users/${USER_ID}" "{\"password\":\"${TEST_PASSWORD}\"}" "$ACCESS_TOKEN")"
+    assert_status "DELETE /users/:id (self-delete)" 204 "$RESPONSE_STATUS"
+
+    parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+    assert_status "POST /auth/login (after delete)" 401 "$RESPONSE_STATUS"
+else
+    red "  SKIP  Cleanup (could not login)"
+    FAIL=$((FAIL + 2))
+fi

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -491,7 +491,7 @@ export const createThing = async (
 			]);
 			const thingId = result.insertId;
 
-			if (data.seoDescription || data.seoKeywords) {
+			if (data.seoDescription && data.seoKeywords) {
 				await connection.query(upsertThingSeoQuery, [thingId, data.seoDescription, data.seoKeywords]);
 			}
 
@@ -539,12 +539,12 @@ export const updateThing = async (
 				thingId,
 			]);
 
-			// SEO upsert/delete
+			// SEO upsert/delete (schema validates both fields are provided together)
 			if (data.seoDescription !== undefined || data.seoKeywords !== undefined) {
 				const desc = data.seoDescription !== undefined ? data.seoDescription : current.seoDescription;
 				const kw = data.seoKeywords !== undefined ? data.seoKeywords : current.seoKeywords;
 
-				if (desc || kw) {
+				if (desc && kw) {
 					await connection.query(upsertThingSeoQuery, [thingId, desc, kw]);
 				} else {
 					await connection.query(deleteThingSeoQuery, [thingId]);
@@ -562,23 +562,24 @@ export const updateThing = async (
 
 			// Notes sync (array position = order)
 			if (data.notes !== undefined) {
-				const keepIds: number[] = [];
+				const keepIds = data.notes.filter((n) => n.id).map((n) => n.id as number);
 
+				// Delete removed notes first
+				if (keepIds.length > 0) {
+					await connection.query(deleteThingNotesExceptQuery, [thingId, keepIds]);
+				} else {
+					await connection.query(deleteAllThingNotesQuery, [thingId]);
+				}
+
+				// Then update existing and insert new
 				for (let i = 0; i < data.notes.length; i++) {
 					const note = data.notes[i];
 
 					if (note.id) {
 						await connection.query(updateThingNoteQuery, [note.text, i + 1, note.id, thingId]);
-						keepIds.push(note.id);
 					} else {
 						await connection.query(insertThingNoteQuery, [thingId, note.text, i + 1]);
 					}
-				}
-
-				if (keepIds.length > 0) {
-					await connection.query(deleteThingNotesExceptQuery, [thingId, keepIds]);
-				} else {
-					await connection.query(deleteAllThingNotesQuery, [thingId]);
 				}
 			}
 

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -128,6 +128,16 @@ const thingNoteItem = z.object({
 	text: z.string().min(1),
 });
 
+// SEO fields must be provided together or both be null/undefined
+const seoFieldsTogether = (d: { seoDescription?: string | null; seoKeywords?: string | null }) => {
+	if (d.seoDescription === undefined && d.seoKeywords === undefined) {
+		return true;
+	}
+
+	return (d.seoDescription == null) === (d.seoKeywords == null);
+};
+const seoFieldsTogetherMessage = { message: 'seoDescription and seoKeywords must be provided together or both be null' };
+
 // Partial date: YYYY-00-00 (year), YYYY-MM-00 (year-month), YYYY-MM-DD (full)
 // YYYY-00-DD is invalid (month=0 with day≠0)
 const partialDateRegex = /^\d{4}-(00-00|(0[1-9]|1[0-2])-(00|0[1-9]|[12]\d|3[01]))$/;
@@ -186,7 +196,7 @@ export const createThingRequest = z.object({
 	seoDescription: z.string().nullable().default(null),
 	seoKeywords: z.string().nullable().default(null),
 	info: z.string().nullable().default(null),
-});
+}).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 export const updateThingRequest = z.object({
 	title: z.string().nullable().optional(),
@@ -202,7 +212,7 @@ export const updateThingRequest = z.object({
 	seoDescription: z.string().nullable().optional(),
 	seoKeywords: z.string().nullable().optional(),
 	info: z.string().nullable().optional(),
-});
+}).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 // --- Inferred types ---
 


### PR DESCRIPTION
## Summary
- Split `smoke-test.sh` into 13 sourced files in `smoke-tests/`
- Add thing CRUD tests (10b) and section-thing interaction tests (10c)
- Fix Content-Type header only sent when body exists (fixes DELETE 400)
- Fix notes sync: delete before insert (fixes empty notes after update)
- SEO fields validated together at schema level (`seoFieldsTogether` refine)
- `run_sql` uses docker exec with mysql client fallback

## Test plan
- [x] 87 unit tests pass
- [x] Build and lint clean
- [x] 45 smoke tests pass locally