### PR TITLE
Skip check-paths on workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
         run: npm test
 
   check-paths:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       deployable: ${{ steps.filter.outputs.deployable }}


### PR DESCRIPTION
Prevents git error 128 from dorny/paths-filter on manual deploys.