### PR TITLE
Add Meilisearch full-text search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ SMTP_FROM_ADDRESS=notifier@mellonis.ru
 ALLOWED_ORIGINS=
 WEBAUTHN_RP_ID=localhost
 ADMIN_NOTIFY_EMAIL=
+MEILI_URL=http://poetry-meilisearch:7700
+MEILI_MASTER_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,11 @@ SMTP_FROM_ADDRESS=notifier@mellonis.ru   # required, email address for From head
 ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://poetry-old2.mellonis.ru  # required, comma-separated whitelist of client origins (CORS + email links)
 WEBAUTHN_RP_ID=mellonis.ru       # optional, WebAuthn Relying Party ID (default: mellonis.ru, use "localhost" for local dev)
 ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions
+MEILI_URL=http://poetry-meilisearch:7700  # optional, Meilisearch host (default: http://poetry-meilisearch:7700)
+MEILI_MASTER_KEY=<key>               # optional (required for search to work), shared with Meilisearch container
 ```
 
-See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead.
+See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead. If `MEILI_MASTER_KEY` is not set, search is disabled (sync calls become no-ops, `GET /search` returns 503).
 
 ## Architecture
 
@@ -71,11 +73,13 @@ Fastify app using a plugin-based structure under `src/plugins/`:
   - Returns updated `{ plus, minus }` counts
   - Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
 - **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields. Sourced from `news` table (id=1). No auth required
+- **`search/`** — Meilisearch integration. `search.ts` is a `fastify-plugin` that decorates `fastify.meiliClient` (nullable — `null` when `MEILI_MASTER_KEY` is not set). `searchRoutes.ts` provides public `GET /search?q=&limit=&offset=` (always filters `statusId=2`). `searchSync.ts` has `syncThingToSearch` / `deleteThingFromSearch` / `reindexAll`. `textStripping.ts` strips BBCode tags and `{note}` markers for indexing. CMS thing mutations fire-and-forget sync to Meilisearch after DB write.
 - **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations require `canEditContent` right (bit 12). Shared hook in `hooks.ts`. Sub-plugins:
   - `authorRoutes.ts` — GET + PUT `/cms/author` for about page editing
   - `sectionRoutes.ts` — section types, section statuses, sections CRUD + reorder
   - `sectionThingRoutes.ts` — `GET /things` lists all things for the picker + things within sections CRUD + reorder
-  - `thingRoutes.ts` — thing CRUD: GET/POST/PUT/DELETE `/cms/things/:thingId` with notes, SEO, info sync + thing statuses/categories reference data
+  - `thingRoutes.ts` — thing CRUD: GET/POST/PUT/DELETE `/cms/things/:thingId` with notes, SEO, info sync + thing statuses/categories reference data. Create/update/delete fire-and-forget sync to Meilisearch
+  - `searchCmsRoutes.ts` — `POST /cms/search/reindex` for full reindex of all things
   - Sections: `statusId` (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn); public API filters `WHERE section_status_id IN (2, 3)`
   - Reorder endpoints accept plain array body `[id1, id2, ...]`
   - Section settings: API `{ showAll, reverseOrder }` ↔ DB `{ show_all, things_order }`; stored as `NULL` when all defaults

--- a/api.http
+++ b/api.http
@@ -291,6 +291,17 @@ Authorization: Bearer {{login.response.body.accessToken}}
 DELETE {{host}}/cms/things/1
 Authorization: Bearer {{login.response.body.accessToken}}
 
+### ---- Search ----
+
+### Search things (public)
+GET {{host}}/search?q=ночь&limit=10
+
+### ---- CMS: Search Reindex ----
+
+### Reindex all things (requires editor + canEditContent)
+POST {{host}}/cms/search/reindex
+Authorization: Bearer {{login.response.body.accessToken}}
+
 ### ---- Votes ----
 
 ### Cast or update a vote (requires auth + canVote)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"fastify-plugin": "^5.1.0",
 				"fastify-type-provider-zod": "^6.1.0",
 				"jose": "^6.2.2",
+				"meilisearch": "^0.57.0",
 				"nodemailer": "^8.0.5",
 				"pino-pretty": "^13.1.3",
 				"zod": "^4.3.6"
@@ -3360,6 +3361,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/meilisearch": {
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.57.0.tgz",
+			"integrity": "sha512-J3ZdX6MjguEIG9Yo+duRZeVsbMdRuwM2OFvJUs8wZSeBADYZ2qc1eajlClKLRqS/mAhGh2bLiU5SbmhKXKuWSw==",
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"fastify-plugin": "^5.1.0",
 		"fastify-type-provider-zod": "^6.1.0",
 		"jose": "^6.2.2",
+		"meilisearch": "^0.57.0",
 		"nodemailer": "^8.0.5",
 		"pino-pretty": "^13.1.3",
 		"zod": "^4.3.6"

--- a/smoke-test-v1.sh
+++ b/smoke-test-v1.sh
@@ -126,7 +126,12 @@ bold "2. Things of the Day"
 check_json_array "GET /things-of-the-day" "/things-of-the-day"
 
 bold ""
-bold "3. Swagger docs"
+bold "3. Search"
+
+check "GET /search?q=test (no Meilisearch)" GET "/search?q=test" 503
+
+bold ""
+bold "4. Swagger docs"
 
 check "GET /docs" GET "/docs" 200
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { votesPlugin } from './plugins/votes/votes.js';
 import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
 import { authorPlugin } from './plugins/author/author.js';
 import { cmsPlugin } from './plugins/cms/cms.js';
+import searchPlugin from './plugins/search/search.js';
+import { searchRoutes } from './plugins/search/searchRoutes.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -40,6 +42,7 @@ fastify.register(cors, {
 	credentials: true,
 });
 fastify.register(databasePlugin);
+fastify.register(searchPlugin);
 fastify.register(authPlugin);
 fastify.register(authNotifierPlugin);
 fastify.register(swaggerPlugin);
@@ -52,6 +55,7 @@ fastify.register(votesPlugin, { prefix: '/things' });
 fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
 fastify.register(authorPlugin, { prefix: '/author' });
 fastify.register(cmsPlugin, { prefix: '/cms' });
+fastify.register(searchRoutes, { prefix: '/search' });
 
 async function main() {
 	await fastify.listen({

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -3,6 +3,7 @@ import { authorRoutes } from './authorRoutes.js';
 import { sectionRoutes } from './sectionRoutes.js';
 import { sectionThingRoutes } from './sectionThingRoutes.js';
 import { thingRoutes } from './thingRoutes.js';
+import { searchCmsRoutes } from './searchCmsRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -20,6 +21,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(sectionRoutes);
 	fastify.register(sectionThingRoutes);
 	fastify.register(thingRoutes);
+	fastify.register(searchCmsRoutes);
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/searchCmsRoutes.ts
+++ b/src/plugins/cms/searchCmsRoutes.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import { requireCanEditContent } from './hooks.js';
+import { reindexAll } from '../search/searchSync.js';
+
+export async function searchCmsRoutes(fastify: FastifyInstance) {
+	fastify.post('/search/reindex', {
+		onRequest: requireCanEditContent,
+		schema: {
+			description: 'Reindex all things in Meilisearch.',
+			tags: ['CMS'],
+			response: {
+				200: z.object({ indexed: z.number().int() }),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				503: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			if (!fastify.meiliClient) {
+				return reply.code(503).send({ error: 'Search is not available' });
+			}
+
+			try {
+				const count = await reindexAll(fastify.meiliClient, fastify.mysql, request.log);
+				request.log.info({ count }, 'Full reindex complete');
+				return { indexed: count };
+			} catch (error) {
+				request.log.error(error, 'Reindex failed');
+				return reply.code(500).send({ error: 'Reindex failed' });
+			}
+		},
+	});
+}

--- a/src/plugins/cms/thingRoutes.ts
+++ b/src/plugins/cms/thingRoutes.ts
@@ -22,6 +22,7 @@ import {
 	type UpdateThingRequest,
 } from './schemas.js';
 import { requireCanEditContent } from './hooks.js';
+import { syncThingToSearch, deleteThingFromSearch } from '../search/searchSync.js';
 
 export async function thingRoutes(fastify: FastifyInstance) {
 	fastify.get('/thing-statuses', {
@@ -114,6 +115,10 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				const thing = await getCmsThing(fastify.mysql, id);
 
 				request.log.info({ thingId: id }, 'Thing created');
+				if (fastify.meiliClient) {
+					syncThingToSearch(fastify.meiliClient, fastify.mysql, id, request.log)
+						.catch((err) => request.log.error(err, 'Meilisearch sync failed'));
+				}
 				return reply.code(201).send(thing);
 			} catch (error) {
 				request.log.error(error);
@@ -149,6 +154,10 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				const updated = await getCmsThing(fastify.mysql, request.params.thingId);
 
 				request.log.info({ thingId: request.params.thingId }, 'Thing updated');
+				if (fastify.meiliClient) {
+					syncThingToSearch(fastify.meiliClient, fastify.mysql, request.params.thingId, request.log)
+						.catch((err) => request.log.error(err, 'Meilisearch sync failed'));
+				}
 				return updated;
 			} catch (error) {
 				request.log.error(error);
@@ -188,6 +197,10 @@ export async function thingRoutes(fastify: FastifyInstance) {
 
 				await deleteThing(fastify.mysql, request.params.thingId);
 				request.log.info({ thingId: request.params.thingId }, 'Thing deleted');
+				if (fastify.meiliClient) {
+					deleteThingFromSearch(fastify.meiliClient, request.params.thingId, request.log)
+						.catch((err) => request.log.error(err, 'Meilisearch delete failed'));
+				}
 				return reply.code(204).send();
 			} catch (error) {
 				request.log.error(error);

--- a/src/plugins/search/schemas.ts
+++ b/src/plugins/search/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const searchQuery = z.object({
+	q: z.string().min(1).max(200),
+	limit: z.coerce.number().int().min(1).max(50).default(20),
+	offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type SearchQuery = z.infer<typeof searchQuery>;
+
+export const searchHit = z.object({
+	id: z.number().int(),
+	title: z.string(),
+	firstLine: z.string(),
+	text: z.string(),
+	notes: z.string(),
+	audioTitles: z.string(),
+	categoryId: z.number().int(),
+});
+
+export const searchResponse = z.object({
+	hits: z.array(searchHit),
+	totalHits: z.number().int(),
+	query: z.string(),
+});

--- a/src/plugins/search/search.ts
+++ b/src/plugins/search/search.ts
@@ -1,6 +1,7 @@
 import fp from 'fastify-plugin';
 import type { FastifyInstance } from 'fastify';
 import { Meilisearch } from 'meilisearch';
+import { reindexAll } from './searchSync.js';
 
 declare module 'fastify' {
 	interface FastifyInstance {
@@ -34,4 +35,13 @@ export default fp(async (fastify: FastifyInstance) => {
 
 	fastify.decorate('meiliClient', client);
 	fastify.log.info({ url }, 'Meilisearch connected');
+
+	const { numberOfDocuments } = await index.getStats();
+
+	if (numberOfDocuments === 0) {
+		fastify.log.info('Search index is empty — reindexing all things');
+		reindexAll(client, fastify.mysql, fastify.log)
+			.then((count) => fastify.log.info({ count }, 'Initial reindex complete'))
+			.catch((err) => fastify.log.error(err, 'Initial reindex failed'));
+	}
 }, { name: 'search' });

--- a/src/plugins/search/search.ts
+++ b/src/plugins/search/search.ts
@@ -1,0 +1,37 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance } from 'fastify';
+import { Meilisearch } from 'meilisearch';
+
+declare module 'fastify' {
+	interface FastifyInstance {
+		meiliClient: Meilisearch | null;
+	}
+}
+
+const INDEX_NAME = 'things';
+
+export { INDEX_NAME as SEARCH_INDEX_NAME };
+
+export default fp(async (fastify: FastifyInstance) => {
+	const masterKey = process.env.MEILI_MASTER_KEY;
+
+	if (!masterKey) {
+		fastify.log.warn('MEILI_MASTER_KEY not set — search is disabled');
+		fastify.decorate('meiliClient', null);
+		return;
+	}
+
+	const url = process.env.MEILI_URL ?? 'http://poetry-meilisearch:7700';
+	const client = new Meilisearch({ host: url, apiKey: masterKey });
+
+	await client.createIndex(INDEX_NAME, { primaryKey: 'id' }).catch(() => {});
+
+	const index = client.index(INDEX_NAME);
+	await index.updateSettings({
+		searchableAttributes: ['title', 'text', 'notes', 'audioTitles'],
+		filterableAttributes: ['categoryId', 'statusId'],
+	});
+
+	fastify.decorate('meiliClient', client);
+	fastify.log.info({ url }, 'Meilisearch connected');
+}, { name: 'search' });

--- a/src/plugins/search/searchRoutes.ts
+++ b/src/plugins/search/searchRoutes.ts
@@ -1,0 +1,55 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { searchQuery, searchResponse, type SearchQuery } from './schemas.js';
+import { errorResponse } from '../../lib/schemas.js';
+import { SEARCH_INDEX_NAME } from './search.js';
+
+export async function searchRoutes(fastify: FastifyInstance) {
+	fastify.get<{ Querystring: SearchQuery }>('/', {
+		schema: {
+			description: 'Full-text search across published things.',
+			tags: ['Search'],
+			querystring: searchQuery,
+			response: {
+				200: searchResponse,
+				503: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Querystring: SearchQuery }>, reply) => {
+			if (!fastify.meiliClient) {
+				return reply.code(503).send({ error: 'Search is not available' });
+			}
+
+			try {
+				const { q, limit, offset } = request.query;
+
+				const result = await fastify.meiliClient.index(SEARCH_INDEX_NAME).search(q, {
+					filter: 'statusId = 2',
+					limit,
+					offset,
+					attributesToHighlight: ['title', 'text', 'notes', 'audioTitles'],
+					highlightPreTag: '<mark>',
+					highlightPostTag: '</mark>',
+					attributesToCrop: ['text', 'notes'],
+					cropLength: 60,
+				});
+
+				return {
+					hits: result.hits.map((hit: Record<string, unknown> & { _formatted?: Record<string, unknown> }) => ({
+						id: hit.id as number,
+						title: (hit._formatted?.title ?? hit.title) as string,
+						firstLine: hit.firstLine as string,
+						text: (hit._formatted?.text ?? hit.text) as string,
+						notes: (hit._formatted?.notes ?? hit.notes) as string,
+						audioTitles: (hit._formatted?.audioTitles ?? hit.audioTitles) as string,
+						categoryId: hit.categoryId as number,
+					})),
+					totalHits: result.estimatedTotalHits ?? 0,
+					query: q,
+				};
+			} catch (error) {
+				request.log.error(error, 'Search failed');
+				return reply.code(500).send({ error: 'Search failed' });
+			}
+		},
+	});
+}

--- a/src/plugins/search/searchSync.ts
+++ b/src/plugins/search/searchSync.ts
@@ -1,0 +1,122 @@
+import type { Meilisearch } from 'meilisearch';
+import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
+import type { FastifyBaseLogger } from 'fastify';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { prepareText, prepareNotes, extractAudioTitles } from './textStripping.js';
+import { SEARCH_INDEX_NAME } from './search.js';
+
+interface ThingSearchDocument {
+	id: number;
+	title: string;
+	firstLine: string;
+	text: string;
+	notes: string;
+	audioTitles: string;
+	categoryId: number;
+	statusId: number;
+}
+
+const thingForSearchQuery = `
+	SELECT
+		t.id,
+		t.title,
+		t.first_lines AS firstLines,
+		t.text,
+		t.r_thing_category_id AS categoryId,
+		t.r_thing_status_id   AS statusId,
+		ti.text                AS info
+	FROM thing t
+	LEFT JOIN thing_info ti ON ti.r_thing_id = t.id
+	WHERE t.id = ?;
+`;
+
+const thingNotesForSearchQuery = `
+	SELECT text FROM thing_note WHERE r_thing_id = ? ORDER BY \`order\`, id;
+`;
+
+const allThingIdsQuery = `
+	SELECT id FROM thing ORDER BY id;
+`;
+
+const buildDocument = (
+	row: MySQLRowDataPacket,
+	noteRows: MySQLRowDataPacket[],
+): ThingSearchDocument => ({
+	id: row.id as number,
+	title: prepareText((row.title as string) ?? ''),
+	firstLine: (row.firstLines as string)?.split('\n')[0] ?? '',
+	text: prepareText(row.text as string),
+	notes: prepareNotes(noteRows.map((n) => ({ text: n.text as string }))),
+	audioTitles: extractAudioTitles((row.info as string) ?? null).join('\n'),
+	categoryId: row.categoryId as number,
+	statusId: row.statusId as number,
+});
+
+export const syncThingToSearch = async (
+	client: Meilisearch,
+	mysql: MySQLPromisePool,
+	thingId: number,
+	log: FastifyBaseLogger,
+): Promise<void> => {
+	const document = await withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingForSearchQuery, [thingId]);
+
+		if (rows.length === 0) return null;
+
+		const [noteRows] = await connection.query<MySQLRowDataPacket[]>(thingNotesForSearchQuery, [thingId]);
+		return buildDocument(rows[0], noteRows);
+	});
+
+	if (!document) return;
+
+	await client.index(SEARCH_INDEX_NAME).addDocuments([document]);
+	log.info({ thingId }, 'Search index updated');
+};
+
+export const deleteThingFromSearch = async (
+	client: Meilisearch,
+	thingId: number,
+	log: FastifyBaseLogger,
+): Promise<void> => {
+	await client.index(SEARCH_INDEX_NAME).deleteDocument(thingId);
+	log.info({ thingId }, 'Search index entry deleted');
+};
+
+const BATCH_SIZE = 50;
+
+export const reindexAll = async (
+	client: Meilisearch,
+	mysql: MySQLPromisePool,
+	log: FastifyBaseLogger,
+): Promise<number> => {
+	const ids = await withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(allThingIdsQuery);
+		return rows.map((r) => r.id as number);
+	});
+
+	for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+		const batch = ids.slice(i, i + BATCH_SIZE);
+
+		const documents = await withConnection(mysql, async (connection) => {
+			const results: ThingSearchDocument[] = [];
+
+			for (const id of batch) {
+				const [rows] = await connection.query<MySQLRowDataPacket[]>(thingForSearchQuery, [id]);
+				if (rows.length === 0) continue;
+
+				const [noteRows] = await connection.query<MySQLRowDataPacket[]>(thingNotesForSearchQuery, [id]);
+				results.push(buildDocument(rows[0], noteRows));
+			}
+
+			return results;
+		});
+
+		if (documents.length > 0) {
+			await client.index(SEARCH_INDEX_NAME).addDocuments(documents);
+		}
+
+		log.info({ batch: `${i + 1}-${Math.min(i + BATCH_SIZE, ids.length)}`, total: ids.length }, 'Reindex batch complete');
+	}
+
+	return ids.length;
+};

--- a/src/plugins/search/textStripping.test.ts
+++ b/src/plugins/search/textStripping.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest';
+import { stripBBCode, stripNoteMarkers, prepareText, prepareNotes, extractAudioTitles } from './textStripping.js';
+
+describe('stripBBCode', () => {
+	test('strips bold and italic tags', () => {
+		expect(stripBBCode('[b]bold[/b] and [i]italic[/i]')).toBe('bold and italic');
+	});
+
+	test('strips quote tags to guillemets', () => {
+		expect(stripBBCode('[q]quote[/q]')).toBe('\u00ABquote\u00BB');
+	});
+
+	test('strips nested tags', () => {
+		expect(stripBBCode('[b][i]text[/i][/b]')).toBe('text');
+	});
+
+	test('strips center, right, part tags', () => {
+		expect(stripBBCode('[c]center[/c] [r]right[/r] [part]part[/part]')).toBe('center right part');
+	});
+
+	test('replaces [nbsp] with space', () => {
+		expect(stripBBCode('word[nbsp]word')).toBe('word word');
+	});
+
+	test('converts em-dashes', () => {
+		expect(stripBBCode('word --- word')).toBe('word \u2014 word');
+		expect(stripBBCode('word--word')).toBe('word\u2013word');
+	});
+
+	test('converts backticks to combining acute accent', () => {
+		expect(stripBBCode('o`')).toBe('o\u0301');
+	});
+
+	test('strips image tags', () => {
+		expect(stripBBCode('[img alt]/path/to/img[/img]')).toBe('');
+	});
+
+	test('strips br tags', () => {
+		expect(stripBBCode('line[br]line[br/]end')).toBe('linelineend');
+	});
+
+	test('returns empty string for empty input', () => {
+		expect(stripBBCode('')).toBe('');
+	});
+
+	test('returns plain text unchanged', () => {
+		expect(stripBBCode('plain text')).toBe('plain text');
+	});
+});
+
+describe('stripNoteMarkers', () => {
+	test('strips inline note markers', () => {
+		expect(stripNoteMarkers('text{note}rest')).toBe('textnoterest');
+	});
+
+	test('strips out-of-text note markers', () => {
+		expect(stripNoteMarkers('text{!note}rest')).toBe('textnoterest');
+	});
+
+	test('strips multiple markers', () => {
+		expect(stripNoteMarkers('{first} text{!second}')).toBe('first textsecond');
+	});
+
+	test('leaves text without markers unchanged', () => {
+		expect(stripNoteMarkers('plain text')).toBe('plain text');
+	});
+});
+
+describe('prepareText', () => {
+	test('strips both BBCode and note markers', () => {
+		expect(prepareText('[b]bold[/b]{!note}')).toBe('boldnote');
+	});
+});
+
+describe('prepareNotes', () => {
+	test('strips BBCode from notes and joins with newline', () => {
+		const notes = [
+			{ text: '[i]italic[/i] note' },
+			{ text: 'plain note' },
+		];
+		expect(prepareNotes(notes)).toBe('italic note\nplain note');
+	});
+
+	test('returns empty string for empty array', () => {
+		expect(prepareNotes([])).toBe('');
+	});
+});
+
+describe('extractAudioTitles', () => {
+	test('extracts audio titles from valid JSON', () => {
+		const info = JSON.stringify({
+			attachments: {
+				audio: [
+					{ title: 'Track 1', sources: [{ src: '/a.mp3', type: 'audio/mpeg' }] },
+					{ title: 'Track 2', sources: [{ src: '/b.mp3', type: 'audio/mpeg' }] },
+				],
+			},
+		});
+		expect(extractAudioTitles(info)).toEqual(['Track 1', 'Track 2']);
+	});
+
+	test('skips audio items without title', () => {
+		const info = JSON.stringify({
+			attachments: {
+				audio: [
+					{ sources: [{ src: '/a.mp3', type: 'audio/mpeg' }] },
+					{ title: 'With title', sources: [{ src: '/b.mp3', type: 'audio/mpeg' }] },
+				],
+			},
+		});
+		expect(extractAudioTitles(info)).toEqual(['With title']);
+	});
+
+	test('returns empty array for null', () => {
+		expect(extractAudioTitles(null)).toEqual([]);
+	});
+
+	test('returns empty array for invalid JSON', () => {
+		expect(extractAudioTitles('not json')).toEqual([]);
+	});
+
+	test('returns empty array for JSON without audio', () => {
+		expect(extractAudioTitles('{}')).toEqual([]);
+	});
+});

--- a/src/plugins/search/textStripping.ts
+++ b/src/plugins/search/textStripping.ts
@@ -1,0 +1,43 @@
+const plainTextRules: [RegExp, string][] = [
+	[/<<([^>]*?)>>/g, '$1'],
+	[/^---\s/mg, '— '],
+	[/]---\s/g, ']— '],
+	[/([\\(:])(\s)?\s*---\s/g, '$1$2— '],
+	[/\s---/g, ' —'],
+	[/--/g, '–'],
+	[/`/g, '\u0301'],
+	[/\[nbsp]/g, ' '],
+	[/\[q]/g, '«'],
+	[/\[\/q]/g, '»'],
+	[/\[img[^\]]*].*?\[\/img]?/igs, ''],
+	[/\[[^[]*]/g, ''],
+	[/\[\/[^[]*]/g, ''],
+];
+
+export const stripBBCode = (text: string): string =>
+	plainTextRules.reduce(
+		(result, [pattern, replacement]) => result.replace(pattern, replacement),
+		text,
+	);
+
+export const stripNoteMarkers = (text: string): string =>
+	text.replace(/\{!?(.*?)}/g, '$1');
+
+export const prepareText = (text: string): string =>
+	stripBBCode(stripNoteMarkers(text));
+
+export const prepareNotes = (notes: { text: string }[]): string =>
+	notes.map((n) => stripBBCode(n.text)).join('\n');
+
+export const extractAudioTitles = (infoJson: string | null): string[] => {
+	if (!infoJson) return [];
+
+	try {
+		const info = JSON.parse(infoJson) as { attachments?: { audio?: { title?: string }[] } };
+		return (info.attachments?.audio ?? [])
+			.map((a) => a.title)
+			.filter((t): t is string => t != null);
+	} catch {
+		return [];
+	}
+};


### PR DESCRIPTION
## Summary
- Add search plugin with Meilisearch integration (text stripping, sync, public search endpoint)
- Fire-and-forget sync on CMS thing create/update/delete
- `POST /cms/search/reindex` for bulk indexing
- Searchable fields: title, text, notes, audio titles
- Gracefully disabled when `MEILI_MASTER_KEY` is not set (returns 503)

## Test plan
- [ ] Deploy, call `POST /cms/search/reindex` to populate index
- [ ] Test `GET /search?q=ночь` returns highlighted results
- [ ] Create/edit/delete a thing in CMS, verify search updates
- [ ] Verify smoke tests pass (`./smoke-test-v1.sh`)