### PR TITLE
Fix search: strip inline notes, index them separately

### DIFF
--- a/src/plugins/search/searchSync.ts
+++ b/src/plugins/search/searchSync.ts
@@ -2,7 +2,7 @@ import type { Meilisearch } from 'meilisearch';
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
 import type { FastifyBaseLogger } from 'fastify';
 import { withConnection } from '../../lib/databaseHelpers.js';
-import { prepareText, prepareNotes, extractAudioTitles } from './textStripping.js';
+import { prepareText, prepareNotes, extractAudioTitles, extractInlineNotes, stripBBCode } from './textStripping.js';
 import { SEARCH_INDEX_NAME } from './search.js';
 
 interface ThingSearchDocument {
@@ -41,16 +41,23 @@ const allThingIdsQuery = `
 const buildDocument = (
 	row: MySQLRowDataPacket,
 	noteRows: MySQLRowDataPacket[],
-): ThingSearchDocument => ({
-	id: row.id as number,
-	title: prepareText((row.title as string) ?? ''),
-	firstLine: (row.firstLines as string)?.split('\n')[0] ?? '',
-	text: prepareText(row.text as string),
-	notes: prepareNotes(noteRows.map((n) => ({ text: n.text as string }))),
-	audioTitles: extractAudioTitles((row.info as string) ?? null).join('\n'),
-	categoryId: row.categoryId as number,
-	statusId: row.statusId as number,
-});
+): ThingSearchDocument => {
+	const rawText = row.text as string;
+	const inlineNotes = extractInlineNotes(rawText).map(stripBBCode);
+	const dbNotes = prepareNotes(noteRows.map((n) => ({ text: n.text as string })));
+	const allNotes = [dbNotes, ...inlineNotes].filter(Boolean).join('\n');
+
+	return {
+		id: row.id as number,
+		title: prepareText((row.title as string) ?? ''),
+		firstLine: (row.firstLines as string)?.split('\n')[0] ?? '',
+		text: prepareText(rawText),
+		notes: allNotes,
+		audioTitles: extractAudioTitles((row.info as string) ?? null).join('\n'),
+		categoryId: row.categoryId as number,
+		statusId: row.statusId as number,
+	};
+};
 
 export const syncThingToSearch = async (
 	client: Meilisearch,

--- a/src/plugins/search/textStripping.test.ts
+++ b/src/plugins/search/textStripping.test.ts
@@ -49,16 +49,16 @@ describe('stripBBCode', () => {
 });
 
 describe('stripNoteMarkers', () => {
-	test('strips inline note markers', () => {
-		expect(stripNoteMarkers('text{note}rest')).toBe('textnoterest');
+	test('replaces inline note markers with space', () => {
+		expect(stripNoteMarkers('text{note}rest')).toBe('text rest');
 	});
 
-	test('strips out-of-text note markers', () => {
-		expect(stripNoteMarkers('text{!note}rest')).toBe('textnoterest');
+	test('replaces out-of-text note markers with space', () => {
+		expect(stripNoteMarkers('text{!note}rest')).toBe('text rest');
 	});
 
-	test('strips multiple markers', () => {
-		expect(stripNoteMarkers('{first} text{!second}')).toBe('first textsecond');
+	test('replaces multiple markers with spaces', () => {
+		expect(stripNoteMarkers('{first} text{!second}')).toBe('  text ');
 	});
 
 	test('leaves text without markers unchanged', () => {
@@ -68,7 +68,7 @@ describe('stripNoteMarkers', () => {
 
 describe('prepareText', () => {
 	test('strips both BBCode and note markers', () => {
-		expect(prepareText('[b]bold[/b]{!note}')).toBe('boldnote');
+		expect(prepareText('[b]bold[/b]{!note}')).toBe('bold ');
 	});
 });
 

--- a/src/plugins/search/textStripping.ts
+++ b/src/plugins/search/textStripping.ts
@@ -21,7 +21,16 @@ export const stripBBCode = (text: string): string =>
 	);
 
 export const stripNoteMarkers = (text: string): string =>
-	text.replace(/\{!?(.*?)}/g, '$1');
+	text.replace(/\{!?.*?}/g, ' ');
+
+export const extractInlineNotes = (text: string): string[] => {
+	const notes: string[] = [];
+	text.replace(/\{!?(.*?)}/g, (_, content: string) => {
+		if (content) notes.push(content);
+		return '';
+	});
+	return notes;
+};
 
 export const prepareText = (text: string): string =>
 	stripBBCode(stripNoteMarkers(text));


### PR DESCRIPTION
## Summary
- Strip `{note}` markers from text by replacing with space (fixes concatenated words like "ТотороТоторо")
- Extract inline notes and append to the `notes` search field so they remain searchable
- Needs reindex after deploy

## Test plan
- [ ] Search for a word that only exists in inline notes — should find it
- [ ] Search no longer matches concatenated text around note markers