### PR TITLE
Add admin user management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Fastify app using a plugin-based structure under `src/plugins/`:
   - `sectionThingRoutes.ts` — `GET /things` lists all things for the picker + things within sections CRUD + reorder
   - `thingRoutes.ts` — thing CRUD: GET/POST/PUT/DELETE `/cms/things/:thingId` with notes, SEO, info sync + thing statuses/categories reference data. Create/update/delete fire-and-forget sync to Meilisearch
   - `searchCmsRoutes.ts` — `POST /cms/search/reindex` for full reindex of all things
+  - `userRoutes.ts` — admin user management. Requires `isAdmin` + `canEditUsers` (bit 14) via `requireAdmin` + `requireCanEditUsers` hooks. Endpoints: `GET /cms/groups`, `GET/POST /cms/users`, `GET/PUT/DELETE /cms/users/:userId`, `POST /cms/users/:userId/resend-activation`, `POST /cms/users/:userId/reset-password`. Self-protection: cannot delete self, change own group, ban self, or remove own `canEditUsers`. On update: bumps `token_version` + deletes refresh tokens. Create sends admin-specific activation email
   - Sections: `statusId` (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn); public API filters `WHERE section_status_id IN (2, 3)`
   - Reorder endpoints accept plain array body `[id1, id2, ...]`
   - Section settings: API `{ showAll, reverseOrder }` ↔ DB `{ show_all, things_order }`; stored as `NULL` when all defaults
@@ -95,7 +96,19 @@ Shared utilities in `src/lib/`:
 - `mappers.ts` — row mappers (`mapThingBaseRow`, `splitLines`, `parseJSON`, `thingDisplayTitle`)
 - `databaseHelpers.ts` — `withConnection` (pool acquire/release)
 - `email.ts` — SMTP transport via nodemailer
-- `emailTemplates.ts` — email templates (auth + admin notifications: `thingVotedEmail`, `accountRegisteredEmail`, `accountDeletedEmail`)
+- `emailTemplates.ts` — email templates:
+
+  | Template | Recipient | Trigger |
+  |----------|-----------|---------|
+  | `activationEmail` | user | self-registration |
+  | `resetPasswordEmail` | user | self-requested password reset |
+  | `passwordChangedEmail` | user | password changed |
+  | `adminActivationEmail` | user | admin created account |
+  | `adminPasswordResetEmail` | user | admin triggered password reset |
+  | `adminResendActivationEmail` | user | admin resent activation |
+  | `thingVotedEmail` | `ADMIN_NOTIFY_EMAIL` | vote cast/removed |
+  | `accountRegisteredEmail` | `ADMIN_NOTIFY_EMAIL` | new user registered |
+  | `accountDeletedEmail` | `ADMIN_NOTIFY_EMAIL` | user deleted account |
 - `maskEmail.ts` — masks emails for logging
 - `authNotifier/` — `AuthNotifier` interface, `EmailAuthNotifier` (production), `ConsoleAuthNotifier` (dev)
 

--- a/api.http
+++ b/api.http
@@ -291,6 +291,54 @@ Authorization: Bearer {{login.response.body.accessToken}}
 DELETE {{host}}/cms/things/1
 Authorization: Bearer {{login.response.body.accessToken}}
 
+### ---- CMS: User Management ----
+
+### List auth groups (requires admin + canEditUsers)
+GET {{host}}/cms/groups
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### List all users (requires admin + canEditUsers)
+GET {{host}}/cms/users
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Get a user (requires admin + canEditUsers)
+GET {{host}}/cms/users/1
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Create a user (requires admin + canEditUsers, sends activation email)
+POST {{host}}/cms/users
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "login": "newuser",
+  "email": "new@example.com",
+  "password": "password123",
+  "groupId": 3
+}
+
+### Update a user (requires admin + canEditUsers)
+PUT {{host}}/cms/users/5
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "groupId": 2,
+  "rights": 24
+}
+
+### Delete a user (requires admin + canEditUsers, cannot delete self)
+DELETE {{host}}/cms/users/5
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Resend activation email (requires admin + canEditUsers)
+POST {{host}}/cms/users/5/resend-activation
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Trigger password reset (requires admin + canEditUsers)
+POST {{host}}/cms/users/5/reset-password
+Authorization: Bearer {{login.response.body.accessToken}}
+
 ### ---- Search ----
 
 ### Search things (public)

--- a/smoke-tests/10d-cms-users.sh
+++ b/smoke-tests/10d-cms-users.sh
@@ -1,0 +1,64 @@
+# 10d. CMS User Management (requires admin + canEditUsers)
+bold ""
+bold "10d. CMS User Management"
+
+if [ "$CMS_READY" != "true" ]; then
+    red "  SKIP  CMS users (CMS not ready)"
+    return 0 2>/dev/null || true
+fi
+
+# Promote test user to admin group
+if ! run_sql "UPDATE auth_user SET r_group_id = 1 WHERE login = '${TEST_LOGIN}'"; then
+    red "  SKIP  CMS users (mysql client not available)"
+    return 0 2>/dev/null || true
+fi
+
+# Re-login as admin
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+assert_status "POST /auth/login (as admin)" 200 "$RESPONSE_STATUS"
+
+ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+
+if [ -z "$ACCESS_TOKEN" ]; then
+    red "  SKIP  CMS users (no access token after admin promotion)"
+    FAIL=$((FAIL + 6))
+    return 0 2>/dev/null || true
+fi
+
+# List groups
+parse_response "$(request GET /cms/groups "" "$ACCESS_TOKEN")"
+assert_status "GET /cms/groups" 200 "$RESPONSE_STATUS"
+
+# List users
+parse_response "$(request GET /cms/users "" "$ACCESS_TOKEN")"
+assert_status "GET /cms/users" 200 "$RESPONSE_STATUS"
+
+# Create user
+parse_response "$(request POST /cms/users "{\"login\":\"smkusr\",\"email\":\"smoke@test.test\",\"password\":\"pass123\",\"groupId\":3}" "$ACCESS_TOKEN")"
+assert_status "POST /cms/users (create)" 201 "$RESPONSE_STATUS"
+NEW_USER_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+if [ -n "$NEW_USER_ID" ]; then
+    # Get user
+    parse_response "$(request GET "/cms/users/${NEW_USER_ID}" "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/users/:id" 200 "$RESPONSE_STATUS"
+
+    # Update user
+    parse_response "$(request PUT "/cms/users/${NEW_USER_ID}" "{\"groupId\":2}" "$ACCESS_TOKEN")"
+    assert_status "PUT /cms/users/:id (update)" 200 "$RESPONSE_STATUS"
+
+    # Delete user
+    parse_response "$(request DELETE "/cms/users/${NEW_USER_ID}" "" "$ACCESS_TOKEN")"
+    assert_status "DELETE /cms/users/:id" 204 "$RESPONSE_STATUS"
+else
+    red "  SKIP  CMS user CRUD (could not extract user ID)"
+    FAIL=$((FAIL + 3))
+fi
+
+# Restore test user to editor group
+run_sql "UPDATE auth_user SET r_group_id = 2 WHERE login = '${TEST_LOGIN}'" > /dev/null 2>&1
+
+# Re-login as editor for subsequent tests
+parse_response "$(request POST /auth/login "{\"login\":\"${TEST_LOGIN}\",\"password\":\"${TEST_PASSWORD}\"}")"
+ACCESS_TOKEN=$(json_field "accessToken" "$RESPONSE_BODY")
+REFRESH_TOKEN=$(json_field "refreshToken" "$RESPONSE_BODY")

--- a/src/lib/authNotifier/AuthNotifier.ts
+++ b/src/lib/authNotifier/AuthNotifier.ts
@@ -2,4 +2,7 @@ export interface AuthNotifier {
 	sendActivation(email: string, login: string, key: string, origin: string): Promise<void>;
 	sendPasswordReset(email: string, login: string, key: string, origin: string): Promise<void>;
 	sendPasswordChanged(email: string, login: string, origin: string): Promise<void>;
+	sendAdminActivation(email: string, login: string, key: string, origin: string): Promise<void>;
+	sendAdminPasswordReset(email: string, login: string, key: string, origin: string): Promise<void>;
+	sendAdminResendActivation(email: string, login: string, key: string, origin: string): Promise<void>;
 }

--- a/src/lib/authNotifier/ConsoleAuthNotifier.ts
+++ b/src/lib/authNotifier/ConsoleAuthNotifier.ts
@@ -20,4 +20,16 @@ export class ConsoleAuthNotifier implements AuthNotifier {
 	async sendPasswordChanged(email: string, login: string, origin: string): Promise<void> {
 		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending password changed email');
 	}
+
+	async sendAdminActivation(email: string, login: string, key: string, origin: string): Promise<void> {
+		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin-created activation email');
+	}
+
+	async sendAdminPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
+		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin password reset email');
+	}
+
+	async sendAdminResendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
+		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin resend activation email');
+	}
 }

--- a/src/lib/authNotifier/EmailAuthNotifier.ts
+++ b/src/lib/authNotifier/EmailAuthNotifier.ts
@@ -1,7 +1,14 @@
 import type { FastifyBaseLogger } from 'fastify';
 import type { AuthNotifier } from './AuthNotifier.js';
 import { sendEmail } from '../email.js';
-import { activationEmail, passwordChangedEmail, resetPasswordEmail } from '../emailTemplates.js';
+import {
+	activationEmail,
+	adminActivationEmail,
+	adminPasswordResetEmail,
+	adminResendActivationEmail,
+	passwordChangedEmail,
+	resetPasswordEmail,
+} from '../emailTemplates.js';
 import { maskEmail } from '../maskEmail.js';
 
 export class EmailAuthNotifier implements AuthNotifier {
@@ -27,5 +34,23 @@ export class EmailAuthNotifier implements AuthNotifier {
 		const resetHref = `${origin}/reset-password/`;
 		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending password changed email');
 		await sendEmail(email, passwordChangedEmail(origin, login, resetHref));
+	}
+
+	async sendAdminActivation(email: string, login: string, key: string, origin: string): Promise<void> {
+		const href = `${origin}/activate/?key=${key}`;
+		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin-created activation email');
+		await sendEmail(email, adminActivationEmail(origin, login, href));
+	}
+
+	async sendAdminPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
+		const href = `${origin}/reset-password/?key=${key}`;
+		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin password reset email');
+		await sendEmail(email, adminPasswordResetEmail(origin, login, href));
+	}
+
+	async sendAdminResendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
+		const href = `${origin}/activate/?key=${key}`;
+		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin resend activation email');
+		await sendEmail(email, adminResendActivationEmail(origin, login, href));
 	}
 }

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -65,6 +65,44 @@ export const accountRegisteredEmail = (login: string): EmailMessage => ({
 	html: `<p>Новый пользователь: <strong>${login}</strong></p>`,
 });
 
+export const adminActivationEmail = (siteOrigin: string, login: string, href: string): EmailMessage => ({
+	subject: 'Для вас создан аккаунт',
+	html: layout(siteOrigin, login, `<p style="color:#333;font-size:14px;">Для вас создан аккаунт
+ на сайте. Для активации подтвердите ваш email.</p>
+<p style="text-align:center;margin:25px 0;">
+<a href="${href}" style="display:inline-block;background:#333;color:#fff;
+padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
+Подтвердить email</a></p>
+<p style="color:#999;font-size:12px;">Или скопируйте ссылку:
+<a href="${href}" style="color:#666;">${href}</a></p>`),
+});
+
+export const adminPasswordResetEmail = (siteOrigin: string, login: string, href: string): EmailMessage => ({
+	subject: 'Сброс пароля',
+	html: layout(siteOrigin, login, `<p style="color:#333;font-size:14px;">Администратор запросил
+ сброс пароля для вашего аккаунта.</p>
+<p style="text-align:center;margin:25px 0;">
+<a href="${href}" style="display:inline-block;background:#333;color:#fff;
+padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
+Сбросить пароль</a></p>
+<p style="color:#999;font-size:12px;">Или скопируйте ссылку:
+<a href="${href}" style="color:#666;">${href}</a></p>
+<p style="color:#999;font-size:12px;">Если вы не ожидали этого письма,
+ обратитесь к администратору.</p>`),
+});
+
+export const adminResendActivationEmail = (siteOrigin: string, login: string, href: string): EmailMessage => ({
+	subject: 'Подтверждение email',
+	html: layout(siteOrigin, login, `<p style="color:#333;font-size:14px;">Администратор повторно
+ отправил ссылку для активации вашего аккаунта.</p>
+<p style="text-align:center;margin:25px 0;">
+<a href="${href}" style="display:inline-block;background:#333;color:#fff;
+padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
+Подтвердить email</a></p>
+<p style="color:#999;font-size:12px;">Или скопируйте ссылку:
+<a href="${href}" style="color:#666;">${href}</a></p>`),
+});
+
 export const accountDeletedEmail = (login: string): EmailMessage => ({
 	subject: `Удаление аккаунта: ${login}`,
 	html: `<p>Пользователь <strong>${login}</strong> удалил аккаунт.</p>`,

--- a/src/plugins/auth/auth.test.ts
+++ b/src/plugins/auth/auth.test.ts
@@ -80,7 +80,7 @@ describe('POST /auth/login', () => {
 		expect(body.refreshToken).toBeDefined();
 		expect(body.user.id).toBe(1);
 		expect(body.user.login).toBe('testuser');
-		expect(body.user.rights).toEqual({ canVote: true, canEditContent: false });
+		expect(body.user.rights).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
 	});
 
 	it('returns 401 for wrong password', async () => {

--- a/src/plugins/auth/databaseHelpers.ts
+++ b/src/plugins/auth/databaseHelpers.ts
@@ -129,17 +129,22 @@ const isKeyOlderThan = (key: string, ttlInSeconds: number): boolean => {
 const hashKey = (key: string): string =>
 	createHash('sha256').update(key).digest('hex');
 
+const DEFAULT_GROUP_ID = 3;
+const DEFAULT_USER_RIGHTS = 24; // canVote (bit 3) + canComment (bit 4)
+
 export const createUser = async (
 	mysql: MySQLPromisePool,
 	login: string,
 	passwordHash: string,
 	email: string,
 	key: string,
+	groupId: number = DEFAULT_GROUP_ID,
+	rights: number = DEFAULT_USER_RIGHTS,
 ): Promise<number> =>
 	withConnection(mysql, async (connection) => {
 		const [result] = await connection.query<MySQLResultSetHeader>(
 			insertUserQuery,
-			[login, passwordHash, email, hashKey(key)],
+			[groupId, rights, login, passwordHash, email, hashKey(key)],
 		);
 		return result.insertId;
 	});

--- a/src/plugins/auth/jwt.test.ts
+++ b/src/plugins/auth/jwt.test.ts
@@ -15,7 +15,7 @@ describe('JWT access tokens', () => {
 			isAdmin: false,
 			isEditor: true,
 			tokenVersion: 1,
-			rights: { canVote: true, canEditContent: false },
+			rights: { canVote: true, canEditContent: false, canEditUsers: false },
 		};
 
 		const token = await signAccessToken(payload, secret);
@@ -26,11 +26,11 @@ describe('JWT access tokens', () => {
 		expect(decoded.isAdmin).toBe(false);
 		expect(decoded.isEditor).toBe(true);
 		expect(decoded.tokenVersion).toBe(1);
-		expect(decoded.rights).toEqual({ canVote: true, canEditContent: false });
+		expect(decoded.rights).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
 	});
 
 	it('rejects a token with wrong secret', async () => {
-		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false, canEditContent: false } };
+		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false, canEditContent: false, canEditUsers: false } };
 		const token = await signAccessToken(payload, secret);
 		const wrongSecret = new TextEncoder().encode('wrong-secret-that-is-at-least-32-chars-long');
 

--- a/src/plugins/auth/queries.ts
+++ b/src/plugins/auth/queries.ts
@@ -37,7 +37,7 @@ export const updateLastLoginQuery = `
 
 export const insertUserQuery = `
 	INSERT INTO auth_user (r_group_id, rights, login, password_hash, email, \`key\`, key_created_at)
-	VALUES (3, 24, ?, ?, ?, ?, NOW())
+	VALUES (?, ?, ?, ?, ?, ?, NOW())
 `;
 
 export const updateUserRightsAndKeyQuery = `

--- a/src/plugins/auth/rights.test.ts
+++ b/src/plugins/auth/rights.test.ts
@@ -12,33 +12,33 @@ import {
 describe('resolveRights', () => {
 	// Bits 3..10 rule: (!group) && user
 	it('canVote: false when neither side has bit 3', () => {
-		expect(resolveRights(0, 0)).toEqual({ canVote: false, canEditContent: false });
+		expect(resolveRights(0, 0)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: true when user opts in (group has no bit 3)', () => {
-		expect(resolveRights(8, 0)).toEqual({ canVote: true, canEditContent: false });
+		expect(resolveRights(8, 0)).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: false when group blocks (group has bit 3, user does not)', () => {
-		expect(resolveRights(0, 8)).toEqual({ canVote: false, canEditContent: false });
+		expect(resolveRights(0, 8)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: false when group blocks (both sides have bit 3)', () => {
-		expect(resolveRights(8, 8)).toEqual({ canVote: false, canEditContent: false });
+		expect(resolveRights(8, 8)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('resolves default new user rights (24 = can_vote + can_comment)', () => {
-		expect(resolveRights(24, 0)).toEqual({ canVote: true, canEditContent: false });
+		expect(resolveRights(24, 0)).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
 	});
 
 	// Bits 11..15 rule: XOR (group default, user override)
-	it('canEditContent: true when group has bit 12 (editors group = 30720)', () => {
-		expect(resolveRights(24, 30720).canEditContent).toBe(true);
+	it('canEditContent: true when group has bit 12 (editors group = 14336)', () => {
+		expect(resolveRights(24, 14336).canEditContent).toBe(true);
 	});
 
 	it('canEditContent: false when user overrides group bit 12 off', () => {
 		// XOR: both have bit 12 → false
-		expect(resolveRights(24 | 4096, 30720).canEditContent).toBe(false);
+		expect(resolveRights(24 | 4096, 14336).canEditContent).toBe(false);
 	});
 
 	it('canEditContent: true when user overrides with bit 12 (group has no bit 12)', () => {
@@ -49,17 +49,31 @@ describe('resolveRights', () => {
 		expect(resolveRights(0, 0).canEditContent).toBe(false);
 	});
 
+	// canEditUsers (bit 14, XOR rule)
+	it('canEditUsers: true when group has bit 14 (admins group = 63488)', () => {
+		expect(resolveRights(24, 63488).canEditUsers).toBe(true);
+	});
+
+	it('canEditUsers: false for editors group (14336, no bit 14)', () => {
+		expect(resolveRights(24, 14336).canEditUsers).toBe(false);
+	});
+
+	it('canEditUsers: false when user overrides group bit 14 off', () => {
+		// XOR: both have bit 14 → false
+		expect(resolveRights(24 | 16384, 63488).canEditUsers).toBe(false);
+	});
+
 	// Banned override
 	it('zeros all rights when user is banned (bit 2)', () => {
-		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false, canEditContent: false });
+		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('zeros all rights when group is banned (bit 2)', () => {
-		expect(resolveRights(8, 4)).toEqual({ canVote: false, canEditContent: false });
+		expect(resolveRights(8, 4)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('zeros canEditContent when banned even if group has bit 12', () => {
-		expect(resolveRights(4, 30720).canEditContent).toBe(false);
+		expect(resolveRights(4, 14336).canEditContent).toBe(false);
 	});
 });
 

--- a/src/plugins/auth/rights.ts
+++ b/src/plugins/auth/rights.ts
@@ -4,11 +4,13 @@ const RIGHT_BITS = {
 	banned: 2,
 	canVote: 3,
 	canEditContent: 12,
+	canEditUsers: 14,
 } as const;
 
 export interface ResolvedRights {
 	canVote: boolean;
 	canEditContent: boolean;
+	canEditUsers: boolean;
 }
 
 const hasBit = (value: number, bit: number): boolean => (value & (1 << bit)) !== 0;
@@ -39,6 +41,7 @@ export const resolveRights = (userRights: number, groupRights: number): Resolved
 	return {
 		canVote: resolveBit(g, u, RIGHT_BITS.canVote),
 		canEditContent: resolveBit(g, u, RIGHT_BITS.canEditContent),
+		canEditUsers: resolveBit(g, u, RIGHT_BITS.canEditUsers),
 	};
 };
 

--- a/src/plugins/auth/schemas.ts
+++ b/src/plugins/auth/schemas.ts
@@ -8,6 +8,7 @@ const loginSchema = z.string()
 export const resolvedRightsSchema = z.object({
 	canVote: z.boolean(),
 	canEditContent: z.boolean(),
+	canEditUsers: z.boolean(),
 });
 
 export const userInfoSchema = z.object({

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -33,12 +33,23 @@ function createMockMysql(...responses: Record<string, unknown>[][]): MySQLPromis
 	} as unknown as MySQLPromisePool;
 }
 
+const mockNotifier = {
+	sendActivation: vi.fn().mockResolvedValue(undefined),
+	sendPasswordReset: vi.fn().mockResolvedValue(undefined),
+	sendPasswordChanged: vi.fn().mockResolvedValue(undefined),
+	sendAdminActivation: vi.fn().mockResolvedValue(undefined),
+	sendAdminPasswordReset: vi.fn().mockResolvedValue(undefined),
+	sendAdminResendActivation: vi.fn().mockResolvedValue(undefined),
+};
+
 async function buildApp(mysql: MySQLPromisePool) {
 	const app = Fastify({ logger: false });
 
 	app.setValidatorCompiler(validatorCompiler);
 	app.setSerializerCompiler(serializerCompiler);
 	app.decorate('mysql', mysql);
+	app.decorate('authNotifier', mockNotifier);
+	app.decorate('resolveOrigin', () => 'https://test.example.com');
 	app.register(authPlugin);
 	app.register(cmsPlugin, { prefix: '/cms' });
 
@@ -52,7 +63,7 @@ const getEditorToken = async (canEditContent = true) =>
 		isAdmin: false,
 		isEditor: true,
 		tokenVersion: 0,
-		rights: { canVote: true, canEditContent },
+		rights: { canVote: true, canEditContent, canEditUsers: false },
 	}, secret);
 
 const getNonEditorToken = async () =>
@@ -62,7 +73,17 @@ const getNonEditorToken = async () =>
 		isAdmin: false,
 		isEditor: false,
 		tokenVersion: 0,
-		rights: { canVote: true, canEditContent: false },
+		rights: { canVote: true, canEditContent: false, canEditUsers: false },
+	}, secret);
+
+const getAdminToken = async (canEditUsers = true) =>
+	signAccessToken({
+		sub: 100,
+		login: 'admin',
+		isAdmin: true,
+		isEditor: true,
+		tokenVersion: 0,
+		rights: { canVote: true, canEditContent: true, canEditUsers },
 	}, secret);
 
 const sectionRow = {
@@ -329,5 +350,305 @@ describe('PUT /cms/sections/:id/things/reorder', () => {
 
 		expect(response.statusCode).toBe(400);
 		expect(response.json().error).toContain('must match');
+	});
+});
+
+// --- User management ---
+
+const userRow = {
+	id: 5,
+	login: 'testuser',
+	email: 'test@example.com',
+	groupId: 3,
+	groupTitle: 'users',
+	rights: 24,
+	lastLogin: null,
+};
+
+const groupRows = [
+	{ id: 0, title: 'guests', rights: 0 },
+	{ id: 1, title: 'admins', rights: 63488 },
+	{ id: 2, title: 'editors', rights: 14336 },
+	{ id: 3, title: 'users', rights: 0 },
+];
+
+describe('CMS user management auth', () => {
+	it('returns 403 for editor (not admin) on /cms/users', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().message).toBe('Admin access required');
+	});
+
+	it('returns 403 for admin without canEditUsers on /cms/users', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getAdminToken(false);
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().message).toBe('Missing required right: canEditUsers');
+	});
+
+	it('allows admin with canEditUsers to list users', async () => {
+		const app = await buildApp(createMockMysql([userRow]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toHaveLength(1);
+		expect(response.json()[0].login).toBe('testuser');
+	});
+});
+
+describe('GET /cms/users/:userId', () => {
+	it('returns 404 for non-existent user', async () => {
+		const app = await buildApp(createMockMysql([]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/users/999',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('returns user by id', async () => {
+		const app = await buildApp(createMockMysql([userRow]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/users/5',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(5);
+		expect(response.json().isBanned).toBe(false);
+		expect(response.json().isEmailActivated).toBe(false);
+	});
+});
+
+describe('POST /cms/users', () => {
+	it('returns 409 for duplicate login or email', async () => {
+		// Responses: loginOrEmailExists returns a row
+		const app = await buildApp(createMockMysql([{ '1': 1 }]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { login: 'testuser', email: 'test@example.com', password: 'pass123', groupId: 3 },
+		});
+
+		expect(response.statusCode).toBe(409);
+	});
+
+	it('creates a user', async () => {
+		// Responses: loginOrEmailExists (empty), insertCmsUser, getUserById
+		const app = await buildApp(createMockMysql(
+			[],
+			[{ insertId: 50 }],
+			[{ ...userRow, id: 50 }],
+		));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { login: 'newuser', email: 'new@example.com', password: 'pass123', groupId: 3 },
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().id).toBe(50);
+		expect(mockNotifier.sendAdminActivation).toHaveBeenCalled();
+	});
+
+	it('rejects invalid login format', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { login: 'INVALID!', email: 'test@example.com', password: 'pass123', groupId: 3 },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+});
+
+describe('PUT /cms/users/:userId', () => {
+	it('prevents self group change', async () => {
+		// Admin token has sub=100. Editing user 100.
+		// Responses: getUserById
+		const selfRow = { ...userRow, id: 100, login: 'admin', groupId: 1, groupTitle: 'admins' };
+		const app = await buildApp(createMockMysql([selfRow]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/users/100',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { groupId: 3 },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().error).toBe('Cannot change own group');
+	});
+
+	it('prevents self ban', async () => {
+		const selfRow = { ...userRow, id: 100, login: 'admin', groupId: 1, groupTitle: 'admins' };
+		// Responses: getUserById, getGroups (for canEditUsers resolution)
+		const app = await buildApp(createMockMysql([selfRow], groupRows));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/users/100',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { rights: 24 | 4 }, // add banned bit
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().error).toBe('Cannot ban self');
+	});
+
+	it('updates another user', async () => {
+		// Responses: getUserById, getGroups, updateCmsUser, bumpTokenVersion, deleteRefreshTokens, getUserById (refetch)
+		const updatedRow = { ...userRow, groupId: 2, groupTitle: 'editors' };
+		const app = await buildApp(createMockMysql(
+			[userRow],
+			groupRows,
+			[], // update
+			[], // bump token
+			[], // delete tokens
+			[updatedRow],
+		));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/users/5',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { groupId: 2 },
+		});
+
+		expect(response.statusCode).toBe(200);
+	});
+});
+
+describe('DELETE /cms/users/:userId', () => {
+	it('prevents self deletion', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/users/100',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().message).toBe('Cannot delete self');
+	});
+
+	it('returns 404 for non-existent user', async () => {
+		const app = await buildApp(createMockMysql([]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/users/999',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('deletes a user', async () => {
+		// Responses: getUserById, deleteCmsUser
+		const app = await buildApp(createMockMysql([userRow], []));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/users/5',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(204);
+	});
+});
+
+describe('POST /cms/users/:userId/resend-activation', () => {
+	it('rejects for already activated user', async () => {
+		const activatedRow = { ...userRow, rights: 25 }; // bit 0 set = activated
+		const app = await buildApp(createMockMysql([activatedRow]));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users/5/resend-activation',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().error).toBe('User is already activated');
+	});
+
+	it('resends activation email', async () => {
+		// Responses: getUserById, updateUserRightsAndKey
+		const app = await buildApp(createMockMysql([userRow], []));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users/5/resend-activation',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(mockNotifier.sendAdminResendActivation).toHaveBeenCalled();
+	});
+});
+
+describe('POST /cms/users/:userId/reset-password', () => {
+	it('triggers password reset', async () => {
+		// Responses: getUserById, updateUserRightsAndKey
+		const app = await buildApp(createMockMysql([userRow], []));
+		const token = await getAdminToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/users/5/reset-password',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().message).toBe('Password reset email sent');
+		expect(mockNotifier.sendAdminPasswordReset).toHaveBeenCalled();
 	});
 });

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -4,6 +4,7 @@ import { sectionRoutes } from './sectionRoutes.js';
 import { sectionThingRoutes } from './sectionThingRoutes.js';
 import { thingRoutes } from './thingRoutes.js';
 import { searchCmsRoutes } from './searchCmsRoutes.js';
+import { userRoutes } from './userRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -22,6 +23,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(sectionThingRoutes);
 	fastify.register(thingRoutes);
 	fastify.register(searchCmsRoutes);
+	fastify.register(userRoutes);
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/hooks.ts
+++ b/src/plugins/cms/hooks.ts
@@ -5,3 +5,15 @@ export const requireCanEditContent = async (request: FastifyRequest, reply: Fast
 		return reply.code(403).send({ error: 'forbidden', message: 'Missing required right: canEditContent' });
 	}
 };
+
+export const requireAdmin = async (request: FastifyRequest, reply: FastifyReply) => {
+	if (!request.user?.isAdmin) {
+		return reply.code(403).send({ error: 'forbidden', message: 'Admin access required' });
+	}
+};
+
+export const requireCanEditUsers = async (request: FastifyRequest, reply: FastifyReply) => {
+	if (!request.user?.rights.canEditUsers) {
+		return reply.code(403).send({ error: 'forbidden', message: 'Missing required right: canEditUsers' });
+	}
+};

--- a/src/plugins/cms/userDatabaseHelpers.ts
+++ b/src/plugins/cms/userDatabaseHelpers.ts
@@ -1,0 +1,106 @@
+import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { isBanned, isEmailActivated, isPasswordResetRequested } from '../auth/rights.js';
+import {
+	listGroupsQuery,
+	listUsersQuery,
+	getUserByIdQuery,
+	updateCmsUserQuery,
+	deleteCmsUserQuery,
+	bumpTokenVersionQuery,
+} from './userQueries.js';
+import { deleteAllUserRefreshTokensQuery } from '../auth/queries.js';
+
+// --- Types ---
+
+export interface CmsGroup {
+	id: number;
+	title: string;
+	rights: number;
+}
+
+export interface CmsUser {
+	id: number;
+	login: string | null;
+	email: string | null;
+	groupId: number;
+	groupTitle: string;
+	rights: number;
+	lastLogin: string | null;
+	isBanned: boolean;
+	isEmailActivated: boolean;
+	isPasswordResetRequested: boolean;
+}
+
+// --- Mappers ---
+
+const mapUserRow = (row: MySQLRowDataPacket): CmsUser => {
+	const rights = row.rights as number;
+
+	return {
+		id: row.id as number,
+		login: (row.login as string) ?? null,
+		email: (row.email as string) ?? null,
+		groupId: row.groupId as number,
+		groupTitle: row.groupTitle as string,
+		rights,
+		lastLogin: (row.lastLogin as string) ?? null,
+		isBanned: isBanned(rights),
+		isEmailActivated: isEmailActivated(rights),
+		isPasswordResetRequested: isPasswordResetRequested(rights),
+	};
+};
+
+// --- Groups ---
+
+export const getGroups = async (mysql: MySQLPromisePool): Promise<CmsGroup[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(listGroupsQuery);
+		return rows.map((row) => ({
+			id: row.id as number,
+			title: row.title as string,
+			rights: row.rights as number,
+		}));
+	});
+
+// --- Users CRUD ---
+
+export const getUsers = async (mysql: MySQLPromisePool): Promise<CmsUser[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(listUsersQuery);
+		return rows.map(mapUserRow);
+	});
+
+export const getUserById = async (mysql: MySQLPromisePool, userId: number): Promise<CmsUser | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(getUserByIdQuery, [userId]);
+		return rows.length > 0 ? mapUserRow(rows[0]) : null;
+	});
+
+export const updateCmsUser = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+	groupId: number,
+	rights: number,
+): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.query(updateCmsUserQuery, [groupId, rights, userId]);
+	});
+
+export const deleteCmsUser = async (mysql: MySQLPromisePool, userId: number): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.query(deleteCmsUserQuery, [userId]);
+	});
+
+export const invalidateUserSessions = async (mysql: MySQLPromisePool, userId: number): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.beginTransaction();
+		try {
+			await connection.query(bumpTokenVersionQuery, [userId]);
+			await connection.query(deleteAllUserRefreshTokensQuery, [userId]);
+			await connection.commit();
+		} catch (error) {
+			await connection.rollback();
+			throw error;
+		}
+	});

--- a/src/plugins/cms/userQueries.ts
+++ b/src/plugins/cms/userQueries.ts
@@ -1,0 +1,47 @@
+// --- Groups ---
+
+export const listGroupsQuery = `
+	SELECT id, title, rights FROM auth_group ORDER BY id;
+`;
+
+// --- Users ---
+
+export const listUsersQuery = `
+	SELECT
+		u.id,
+		u.login,
+		u.email,
+		u.r_group_id       AS groupId,
+		g.title             AS groupTitle,
+		u.rights,
+		CAST(u.last_login AS CHAR) AS lastLogin
+	FROM auth_user u
+	JOIN auth_group g ON u.r_group_id = g.id
+	ORDER BY u.id;
+`;
+
+export const getUserByIdQuery = `
+	SELECT
+		u.id,
+		u.login,
+		u.email,
+		u.r_group_id       AS groupId,
+		g.title             AS groupTitle,
+		u.rights,
+		CAST(u.last_login AS CHAR) AS lastLogin
+	FROM auth_user u
+	JOIN auth_group g ON u.r_group_id = g.id
+	WHERE u.id = ?;
+`;
+
+export const updateCmsUserQuery = `
+	UPDATE auth_user SET r_group_id = ?, rights = ? WHERE id = ?;
+`;
+
+export const deleteCmsUserQuery = `
+	DELETE FROM auth_user WHERE id = ?;
+`;
+
+export const bumpTokenVersionQuery = `
+	UPDATE auth_user SET token_version = token_version + 1 WHERE id = ?;
+`;

--- a/src/plugins/cms/userRoutes.ts
+++ b/src/plugins/cms/userRoutes.ts
@@ -1,0 +1,352 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import { requireAdmin, requireCanEditUsers } from './hooks.js';
+import {
+	cmsGroupsResponse,
+	cmsUserResponse,
+	cmsUsersResponse,
+	userIdParam,
+	createUserRequest,
+	updateUserRequest,
+	type UserIdParam,
+	type CreateUserRequest,
+	type UpdateUserRequest,
+} from './userSchemas.js';
+import {
+	getGroups,
+	getUsers,
+	getUserById,
+	updateCmsUser,
+	deleteCmsUser,
+	invalidateUserSessions,
+} from './userDatabaseHelpers.js';
+import { createUser, loginOrEmailExists, generateVerificationKey, updateUserRightsAndKey } from '../auth/databaseHelpers.js';
+import { hashPassword } from '../auth/password.js';
+import { setPasswordResetRequested } from '../auth/rights.js';
+import { maskEmail } from '../../lib/maskEmail.js';
+
+const adminHooks = [requireAdmin, requireCanEditUsers];
+
+export async function userRoutes(fastify: FastifyInstance) {
+	// --- Groups reference ---
+
+	fastify.get('/groups', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'List all auth groups.',
+			tags: ['CMS'],
+			response: {
+				200: cmsGroupsResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (_request, reply) => {
+			try {
+				return await getGroups(fastify.mysql);
+			} catch (error) {
+				_request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- List users ---
+
+	fastify.get('/users', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'List all users.',
+			tags: ['CMS'],
+			response: {
+				200: cmsUsersResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getUsers(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Get user ---
+
+	fastify.get('/users/:userId', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Get a single user by ID.',
+			tags: ['CMS'],
+			params: userIdParam,
+			response: {
+				200: cmsUserResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const user = await getUserById(fastify.mysql, request.params.userId);
+
+				if (!user) {
+					return reply.code(404).send({ error: 'User not found' });
+				}
+
+				return user;
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Create user ---
+
+	fastify.post('/users', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Create a new user. Sends activation email.',
+			tags: ['CMS'],
+			body: createUserRequest,
+			response: {
+				201: cmsUserResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Body: CreateUserRequest }>, reply) => {
+			try {
+				const { login, email, password, groupId } = request.body;
+
+				if (await loginOrEmailExists(fastify.mysql, login, email)) {
+					return reply.code(409).send({ error: 'Login or email already exists' });
+				}
+
+				const passwordHash = await hashPassword(password);
+				const key = generateVerificationKey();
+
+				const userId = await createUser(fastify.mysql, login, passwordHash, email, key, groupId);
+
+				request.log.info({ userId, login, email: maskEmail(email), createdBy: request.user!.sub }, 'Admin created user');
+
+				await fastify.authNotifier.sendAdminActivation(email, login, key, fastify.resolveOrigin(request));
+
+				const user = await getUserById(fastify.mysql, userId);
+				return reply.code(201).send(user);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Update user ---
+
+	fastify.put('/users/:userId', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Update user group and/or rights.',
+			tags: ['CMS'],
+			params: userIdParam,
+			body: updateUserRequest,
+			response: {
+				200: cmsUserResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam; Body: UpdateUserRequest }>, reply) => {
+			try {
+				const { userId } = request.params;
+				const currentUser = await getUserById(fastify.mysql, userId);
+
+				if (!currentUser) {
+					return reply.code(404).send({ error: 'User not found' });
+				}
+
+				const isSelf = userId === request.user!.sub;
+				const newGroupId = request.body.groupId ?? currentUser.groupId;
+				const newRights = request.body.rights ?? currentUser.rights;
+
+				// Self-protection: cannot change own group
+				if (isSelf && request.body.groupId !== undefined && request.body.groupId !== currentUser.groupId) {
+					return reply.code(409).send({ error: 'Cannot change own group' });
+				}
+
+				// Self-protection: cannot ban self (bit 2)
+				if (isSelf && (newRights & (1 << 2)) !== 0 && !currentUser.isBanned) {
+					return reply.code(409).send({ error: 'Cannot ban self' });
+				}
+
+				// Self-protection: cannot remove own canEditUsers (bit 14)
+				// Check via XOR resolution: group XOR user for bit 14
+				const groupRights = (await getGroups(fastify.mysql)).find((g) => g.id === newGroupId)?.rights ?? 0;
+				const resolvedCanEditUsers = ((groupRights >> 14) & 1) !== ((newRights >> 14) & 1);
+
+				if (isSelf && !resolvedCanEditUsers) {
+					return reply.code(409).send({ error: 'Cannot remove own canEditUsers right' });
+				}
+
+				await updateCmsUser(fastify.mysql, userId, newGroupId, newRights);
+				await invalidateUserSessions(fastify.mysql, userId);
+
+				request.log.info({ userId, login: currentUser.login, updatedBy: request.user!.sub }, 'Admin updated user');
+
+				return await getUserById(fastify.mysql, userId);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Delete user ---
+
+	fastify.delete('/users/:userId', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Delete a user account.',
+			tags: ['CMS'],
+			params: userIdParam,
+			response: {
+				204: z.void(),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const { userId } = request.params;
+
+				if (userId === request.user!.sub) {
+					return reply.code(403).send({ error: 'forbidden', message: 'Cannot delete self' });
+				}
+
+				const user = await getUserById(fastify.mysql, userId);
+
+				if (!user) {
+					return reply.code(404).send({ error: 'User not found' });
+				}
+
+				await deleteCmsUser(fastify.mysql, userId);
+
+				request.log.info({ userId, login: user.login, deletedBy: request.user!.sub }, 'Admin deleted user');
+
+				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Resend activation ---
+
+	fastify.post('/users/:userId/resend-activation', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Resend activation email for a user.',
+			tags: ['CMS'],
+			params: userIdParam,
+			response: {
+				200: z.object({ message: z.string() }),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const user = await getUserById(fastify.mysql, request.params.userId);
+
+				if (!user) {
+					return reply.code(404).send({ error: 'User not found' });
+				}
+
+				if (user.isEmailActivated) {
+					return reply.code(409).send({ error: 'User is already activated' });
+				}
+
+				if (!user.email) {
+					return reply.code(409).send({ error: 'User has no email' });
+				}
+
+				const key = generateVerificationKey();
+				await updateUserRightsAndKey(fastify.mysql, user.id, user.rights, key);
+
+				request.log.info({ userId: user.id, login: user.login, triggeredBy: request.user!.sub }, 'Admin resent activation');
+
+				await fastify.authNotifier.sendAdminResendActivation(user.email, user.login, key, fastify.resolveOrigin(request));
+
+				return { message: 'Activation email sent' };
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	// --- Reset password ---
+
+	fastify.post('/users/:userId/reset-password', {
+		onRequest: adminHooks,
+		schema: {
+			description: 'Trigger password reset for a user.',
+			tags: ['CMS'],
+			params: userIdParam,
+			response: {
+				200: z.object({ message: z.string() }),
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const user = await getUserById(fastify.mysql, request.params.userId);
+
+				if (!user) {
+					return reply.code(404).send({ error: 'User not found' });
+				}
+
+				if (!user.email) {
+					return reply.code(409).send({ error: 'User has no email' });
+				}
+
+				const key = generateVerificationKey();
+				const newRights = setPasswordResetRequested(user.rights);
+				await updateUserRightsAndKey(fastify.mysql, user.id, newRights, key);
+
+				request.log.info({ userId: user.id, login: user.login, triggeredBy: request.user!.sub }, 'Admin triggered password reset');
+
+				await fastify.authNotifier.sendAdminPasswordReset(user.email, user.login, key, fastify.resolveOrigin(request));
+
+				return { message: 'Password reset email sent' };
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}

--- a/src/plugins/cms/userSchemas.ts
+++ b/src/plugins/cms/userSchemas.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+// --- Groups reference ---
+
+export const cmsGroupItem = z.object({
+	id: z.number().int(),
+	title: z.string(),
+	rights: z.number().int(),
+});
+
+export const cmsGroupsResponse = z.array(cmsGroupItem);
+
+// --- User item ---
+
+export const cmsUserItem = z.object({
+	id: z.number().int(),
+	login: z.string().nullable(),
+	email: z.string().nullable(),
+	groupId: z.number().int(),
+	groupTitle: z.string(),
+	rights: z.number().int(),
+	lastLogin: z.string().nullable(),
+	isBanned: z.boolean(),
+	isEmailActivated: z.boolean(),
+	isPasswordResetRequested: z.boolean(),
+});
+
+export const cmsUserResponse = cmsUserItem;
+export const cmsUsersResponse = z.array(cmsUserItem);
+
+// --- Params ---
+
+export const userIdParam = z.object({
+	userId: z.coerce.number().int().positive(),
+});
+
+// --- Create user ---
+
+export const createUserRequest = z.object({
+	login: z.string().regex(/^[a-z][a-z0-9_]{1,15}$/),
+	email: z.string().email().max(50),
+	password: z.string().min(6),
+	groupId: z.number().int().min(0).max(3),
+});
+
+// --- Update user ---
+
+export const updateUserRequest = z.object({
+	groupId: z.number().int().min(0).max(3).optional(),
+	rights: z.number().int().min(0).optional(),
+});
+
+// --- Inferred types ---
+
+export type UserIdParam = z.infer<typeof userIdParam>;
+export type CreateUserRequest = z.infer<typeof createUserRequest>;
+export type UpdateUserRequest = z.infer<typeof updateUserRequest>;

--- a/src/plugins/users/users.test.ts
+++ b/src/plugins/users/users.test.ts
@@ -51,7 +51,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async () =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true, canEditContent: false } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true, canEditContent: false, canEditUsers: false } }, secret);
 
 describe('PATCH /users/:id/password', () => {
 	it('returns 401 without auth token', async () => {

--- a/src/plugins/votes/votes.test.ts
+++ b/src/plugins/votes/votes.test.ts
@@ -43,7 +43,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async (canVote = true) =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote, canEditContent: false } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote, canEditContent: false, canEditUsers: false } }, secret);
 
 describe('PUT /things/:thingId/vote', () => {
 	it('returns 401 without auth token', async () => {


### PR DESCRIPTION
## Summary
- New `canEditUsers` right (bit 14) with admin-only access via `requireAdmin` + `requireCanEditUsers` hooks
- User CRUD: list, create, get, update, delete with self-protection rules
- Admin email actions: resend activation, trigger password reset
- 3 admin-specific email templates
- Shared `createUser` function (auth + CMS)
- 17 new tests, smoke test `10d-cms-users.sh`

## Test plan
- [x] 131 tests pass
- [x] Lint clean
- [ ] Smoke test with running DB