### PR TITLE
Add comments plugin (guestbook + per-thing) with moderation, votes, reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ SMTP_FROM_NAME=Система оповещений        # required, display na
 SMTP_FROM_ADDRESS=notifier@mellonis.ru   # required, email address for From header (no fallback to SMTP_LOGIN — would leak credentials)
 ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://old2.poetry.mellonis.ru  # required, comma-separated whitelist of client origins (CORS + email links)
 WEBAUTHN_RP_ID=poetry.mellonis.ru       # optional, WebAuthn Relying Party ID (default: poetry.mellonis.ru, use "localhost" for local dev)
-ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions
+ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions, comment reports
 MEILI_URL=http://poetry-meilisearch:7700  # optional, Meilisearch host (default: http://poetry-meilisearch:7700)
 MEILI_MASTER_KEY=<key>               # optional (required for search to work), shared with Meilisearch container
 ```
@@ -73,6 +73,14 @@ Fastify app using a plugin-based structure under `src/plugins/`:
   - Returns updated `{ plus, minus }` counts
   - Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
 - **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields. Sourced from `news` table (id=1). No auth required
+- **`comments/`** — routes prefixed `/comments`. Unified site-wide guestbook + per-thing comments in one table; `r_thing_id IS NULL` rows are guestbook entries. One-level threading (a reply's parent must itself be top-level). Post-moderation: new comments default to `Visible` (status 1). Status set: 1=Visible, 2=Hidden (mod-removed), 3=Deleted (self- or admin-removed)
+  - Public: `GET /` (paginated by top-level + replies inline; `optionalVerifyJwt` enriches rows with `userVote`), `GET /:commentId` (top-level rows return `replies: []` bundled in for single-thread view; reply rows are returned bare since one-level threading bounds depth), `POST /` (auth + `canComment` bit 4 + rate-limit 1/30s; reply path also fires `commentReplyEmail` to the parent author when the parent is a different, non-banned user), `PUT /:commentId` (own + 15-min edit window), `DELETE /:commentId` (own → status=Deleted), `PUT /:commentId/vote` (auth + `canVote` + rate-limit 5/min, mirrors `vote` table semantics with -1/0/+1; self-vote allowed), `POST /:commentId/report` (auth + rate-limit 1/5min, sends `ADMIN_NOTIFY_EMAIL`)
+  - Pagination: top-level only, replies always bundled with their parent — keeps trees coherent under append-style "Show more"
+  - Tombstones: removed comments are returned only when they have at least one direct visible child (one-level threading bounds the check); text/author/votes are masked client-side via `text=null`, `authorLogin=null`. Replies in non-Visible state are omitted entirely
+  - Sanitization: `sanitizeCommentText.ts` (NFC normalize → CRLF→LF → strip control chars → collapse blank-line runs → trim → length 2–4000 → flood reject). Plain-text only; renderers must escape on output
+  - Reply notification: deep-link URL points to the parent (top-level), since pagination is on top-level. Shape: `<origin>/sections/<sectionIdentifier>/<positionInSection>?thread=<parentId>` for thing comments, `<origin>/guestbook?thread=<parentId>` for guestbook (no trailing slash before `?` — nextjs convention). Single-thread mode is drift-proof — the link still works regardless of how many comments accumulate later. Frontend reads `?thread=…` and renders only that top-level + its replies via `GET /comments/:id`
+  - Moderation routes live in `cms/commentsCmsRoutes.ts` (registered by `cmsPlugin`, gated by editor + `canEditContent`): `GET /cms/comments`, `POST /cms/comments/:id/{hide,delete,restore}`, `DELETE /cms/comments/:id` (hard delete). Hide/delete on a comment auto-resolves any open `comment_report` rows for it
+- **`@fastify/rate-limit`** — registered globally with `global: false`; routes opt in via `config: { rateLimit: { max, timeWindow } }`. In-memory store (no Redis), keyed by IP (the rate-limit hook runs before `verifyJwt`)
 - **`search/`** — Meilisearch integration. `search.ts` is a `fastify-plugin` that decorates `fastify.meiliClient` (nullable — `null` when `MEILI_MASTER_KEY` is not set). `searchRoutes.ts` provides public `GET /search?q=&limit=&offset=` (always filters `statusId=2`). `searchSync.ts` has `syncThingToSearch` / `deleteThingFromSearch` / `reindexAll`. `textStripping.ts` strips BBCode tags and `{note}` markers for indexing. CMS thing mutations fire-and-forget sync to Meilisearch after DB write. **Index versioning:** `INDEX_VERSION` constant in `search.ts` tracks the indexing schema version. On startup, the plugin compares it against the version stored in a `_meta` Meilisearch index. If they differ, a full reindex runs automatically. Bump `INDEX_VERSION` when changing stripping logic, indexed fields, or document shape.
 - **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations require `canEditContent` right (bit 12). Shared hook in `hooks.ts`. Sub-plugins:
   - `authorRoutes.ts` — GET + PUT `/cms/author` for about page editing
@@ -109,6 +117,8 @@ Shared utilities in `src/lib/`:
   | `thingVotedEmail` | `ADMIN_NOTIFY_EMAIL` | vote cast/removed |
   | `accountRegisteredEmail` | `ADMIN_NOTIFY_EMAIL` | new user registered |
   | `accountDeletedEmail` | `ADMIN_NOTIFY_EMAIL` | user deleted account |
+  | `commentReportedEmail` | `ADMIN_NOTIFY_EMAIL` | user reported a comment |
+  | `commentReplyEmail` | parent comment author | someone replied to their comment (skipped on self-reply, deleted author, banned) |
 - `maskEmail.ts` — masks emails for logging
 - `authNotifier/` — `AuthNotifier` interface, `EmailAuthNotifier` (production), `ConsoleAuthNotifier` (dev)
 

--- a/api.http
+++ b/api.http
@@ -369,3 +369,110 @@ Authorization: Bearer {{login.response.body.accessToken}}
 {
   "vote": 0
 }
+
+### ---- Comments ----
+
+### List comments for a thing (public; auth optional for userVote)
+GET {{host}}/comments?thingId=1&limit=20
+
+### List guestbook (site-wide) comments
+GET {{host}}/comments?scope=site&limit=20
+
+### Get a single comment
+GET {{host}}/comments/1
+
+### Post a comment on a thing (requires auth + canComment)
+# @name newComment
+POST {{host}}/comments
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "thingId": 1,
+  "text": "Nice poem!"
+}
+
+### Post a guestbook entry
+POST {{host}}/comments
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "text": "Hello, this is a guestbook entry."
+}
+
+### Reply to a comment (parentId; thingId is inherited from parent)
+POST {{host}}/comments
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "parentId": {{newComment.response.body.id}},
+  "text": "Replying to the parent."
+}
+
+### Edit own comment (within 15 min of creation)
+PUT {{host}}/comments/{{newComment.response.body.id}}
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "text": "Edited comment text."
+}
+
+### Like a comment (+1)
+PUT {{host}}/comments/{{newComment.response.body.id}}/vote
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "vote": 1
+}
+
+### Dislike (-1) / remove vote (0)
+PUT {{host}}/comments/{{newComment.response.body.id}}/vote
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "vote": 0
+}
+
+### Report a comment
+POST {{host}}/comments/{{newComment.response.body.id}}/report
+Content-Type: application/json
+Authorization: Bearer {{login.response.body.accessToken}}
+
+{
+  "reason": "Off-topic"
+}
+
+### Delete own comment (status -> Deleted)
+DELETE {{host}}/comments/{{newComment.response.body.id}}
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### ---- CMS: Comment Moderation ----
+
+### Moderation feed (requires editor + canEditContent)
+GET {{host}}/cms/comments?status=visible&limit=20
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Reported comments (sorted by report count)
+GET {{host}}/cms/comments?status=reported&limit=20
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Hide a comment (mod action; status -> Hidden, resolves open reports)
+POST {{host}}/cms/comments/1/hide
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Soft-delete a comment as a mod (status -> Deleted)
+POST {{host}}/cms/comments/1/delete
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Restore a hidden/deleted comment back to Visible
+POST {{host}}/cms/comments/1/restore
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Hard-delete a comment row (cascades replies/votes/reports)
+DELETE {{host}}/cms/comments/1
+Authorization: Bearer {{login.response.body.accessToken}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@fastify/cors": "^11.2.0",
 				"@fastify/mysql": "^5.0.2",
+				"@fastify/rate-limit": "^10.3.0",
 				"@fastify/swagger": "^9.7.0",
 				"@fastify/swagger-ui": "^5.2.5",
 				"@simplewebauthn/server": "^13.3.0",
@@ -806,6 +807,27 @@
 			"dependencies": {
 				"@fastify/forwarded": "^3.0.0",
 				"ipaddr.js": "^2.1.0"
+			}
+		},
+		"node_modules/@fastify/rate-limit": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+			"integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@lukeed/ms": "^2.0.2",
+				"fastify-plugin": "^5.0.0",
+				"toad-cache": "^3.7.0"
 			}
 		},
 		"node_modules/@fastify/send": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@fastify/cors": "^11.2.0",
 		"@fastify/mysql": "^5.0.2",
+		"@fastify/rate-limit": "^10.3.0",
 		"@fastify/swagger": "^9.7.0",
 		"@fastify/swagger-ui": "^5.2.5",
 		"@simplewebauthn/server": "^13.3.0",

--- a/smoke-test-v1.sh
+++ b/smoke-test-v1.sh
@@ -131,7 +131,14 @@ bold "3. Search"
 check "GET /search?q=test (no Meilisearch)" GET "/search?q=test" 503
 
 bold ""
-bold "4. Swagger docs"
+bold "4. Comments (public reads)"
+
+check "GET /comments?scope=site" GET "/comments?scope=site" 200
+check "GET /comments?thingId=1" GET "/comments?thingId=1" 200
+check "GET /comments?thingId=1&scope=site (rejected)" GET "/comments?thingId=1&scope=site" 400
+
+bold ""
+bold "5. Swagger docs"
 
 check "GET /docs" GET "/docs" 200
 

--- a/smoke-tests/11b-comments.sh
+++ b/smoke-tests/11b-comments.sh
@@ -1,0 +1,59 @@
+# 11b. Comments
+bold ""
+bold "11b. Comments"
+
+if [ -n "$ACCESS_TOKEN" ]; then
+    parse_response "$(request GET /comments?thingId=1)"
+    assert_status "GET /comments?thingId=1 (public)" 200 "$RESPONSE_STATUS"
+
+    parse_response "$(request GET "/comments?scope=site")"
+    assert_status "GET /comments?scope=site (guestbook)" 200 "$RESPONSE_STATUS"
+
+    # Conflicting params: thingId + scope=site
+    parse_response "$(request GET "/comments?thingId=1&scope=site")"
+    assert_status "GET /comments?thingId=1&scope=site (rejected)" 400 "$RESPONSE_STATUS"
+
+    # Post a guestbook entry
+    parse_response "$(request POST /comments "{\"text\":\"smoke test guestbook ${TIMESTAMP}\"}" "$ACCESS_TOKEN")"
+    assert_status "POST /comments (guestbook)" 201 "$RESPONSE_STATUS"
+    GUESTBOOK_COMMENT_ID=$(echo "$RESPONSE_BODY" | grep -o '"id":[[:space:]]*[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "$GUESTBOOK_COMMENT_ID" ]; then
+        # Vote on own comment (self-vote allowed by design)
+        parse_response "$(request PUT "/comments/${GUESTBOOK_COMMENT_ID}/vote" "{\"vote\":1}" "$ACCESS_TOKEN")"
+        assert_status "PUT /comments/:id/vote (+1)" 200 "$RESPONSE_STATUS"
+
+        parse_response "$(request PUT "/comments/${GUESTBOOK_COMMENT_ID}/vote" "{\"vote\":0}" "$ACCESS_TOKEN")"
+        assert_status "PUT /comments/:id/vote (remove)" 200 "$RESPONSE_STATUS"
+
+        # Edit within window
+        parse_response "$(request PUT "/comments/${GUESTBOOK_COMMENT_ID}" "{\"text\":\"edited smoke test ${TIMESTAMP}\"}" "$ACCESS_TOKEN")"
+        assert_status "PUT /comments/:id (edit)" 200 "$RESPONSE_STATUS"
+
+        # Self-delete (sets status=Deleted)
+        parse_response "$(request DELETE "/comments/${GUESTBOOK_COMMENT_ID}" "" "$ACCESS_TOKEN")"
+        assert_status "DELETE /comments/:id (self-delete)" 200 "$RESPONSE_STATUS"
+
+        # Edit after delete should fail
+        parse_response "$(request PUT "/comments/${GUESTBOOK_COMMENT_ID}" "{\"text\":\"too late\"}" "$ACCESS_TOKEN")"
+        assert_status "PUT /comments/:id (after delete)" 409 "$RESPONSE_STATUS"
+    else
+        red "  SKIP  Comment lifecycle (no comment id parsed)"
+        FAIL=$((FAIL + 6))
+    fi
+
+    # Auth gates
+    parse_response "$(request POST /comments "{\"text\":\"anonymous post\"}")"
+    assert_status "POST /comments (no token)" 401 "$RESPONSE_STATUS"
+
+    # Sanitization rejects empty / flooded text
+    parse_response "$(request POST /comments "{\"text\":\"\"}" "$ACCESS_TOKEN")"
+    assert_status "POST /comments (empty)" 400 "$RESPONSE_STATUS"
+
+    # CMS access denied for non-editor
+    parse_response "$(request GET /cms/comments "" "$ACCESS_TOKEN")"
+    assert_status "GET /cms/comments (non-editor)" 403 "$RESPONSE_STATUS"
+else
+    red "  SKIP  Comments (no access token)"
+    FAIL=$((FAIL + 12))
+fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import rateLimit from '@fastify/rate-limit';
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
 import { sectionsPlugin } from './plugins/sections/sections.js';
 import { databasePlugin } from './plugins/database/database.js';
@@ -16,6 +17,7 @@ import { votesPlugin } from './plugins/votes/votes.js';
 import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
 import { authorPlugin } from './plugins/author/author.js';
 import { cmsPlugin } from './plugins/cms/cms.js';
+import { commentsPlugin } from './plugins/comments/comments.js';
 import searchPlugin from './plugins/search/search.js';
 import { searchRoutes } from './plugins/search/searchRoutes.js';
 
@@ -41,6 +43,10 @@ fastify.register(cors, {
 	allowedHeaders: ['Content-Type', 'Authorization'],
 	credentials: true,
 });
+// Global rate limit is opt-in per route via `config: { rateLimit }`.
+// Keyed by IP — the rate-limit hook runs before verifyJwt, so request.user
+// is not yet populated; auth-gated routes still get the auth check on top.
+fastify.register(rateLimit, { global: false });
 fastify.register(databasePlugin);
 fastify.register(searchPlugin);
 fastify.register(authPlugin);
@@ -55,6 +61,7 @@ fastify.register(votesPlugin, { prefix: '/things' });
 fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
 fastify.register(authorPlugin, { prefix: '/author' });
 fastify.register(cmsPlugin, { prefix: '/cms' });
+fastify.register(commentsPlugin, { prefix: '/comments' });
 fastify.register(searchRoutes, { prefix: '/search' });
 
 async function main() {

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -108,6 +108,40 @@ export const accountDeletedEmail = (login: string): EmailMessage => ({
 	html: `<p>Пользователь <strong>${login}</strong> удалил аккаунт.</p>`,
 });
 
+const escapeHtml = (s: string): string =>
+	s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+export const commentReportedEmail = (
+	reporterLogin: string,
+	commentId: number,
+	reason: string | null,
+): EmailMessage => ({
+	subject: `Жалоба на комментарий #${commentId}`,
+	html: `<p><strong>${reporterLogin}</strong> пожаловался(ась) на комментарий #${commentId}.</p>${
+		reason ? `<p>Причина: <em>${escapeHtml(reason)}</em></p>` : ''
+	}`,
+});
+
+export const commentReplyEmail = (
+	siteOrigin: string,
+	recipientLogin: string,
+	replierLogin: string,
+	replyText: string,
+	threadHref: string,
+): EmailMessage => ({
+	subject: `${replierLogin} ответил(а) на ваш комментарий`,
+	html: layout(siteOrigin, recipientLogin, `<p style="color:#333;font-size:14px;"><strong>${replierLogin}</strong> ответил(а) на ваш комментарий:</p>
+<blockquote style="margin:15px 0;padding:10px 15px;background:#f7f7f7;
+border-left:3px solid #999;color:#333;font-size:14px;
+white-space:pre-wrap;">${escapeHtml(replyText)}</blockquote>
+<p style="text-align:center;margin:25px 0;">
+<a href="${threadHref}" style="display:inline-block;background:#333;color:#fff;
+padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
+Перейти к обсуждению</a></p>
+<p style="color:#999;font-size:12px;">Или скопируйте ссылку:
+<a href="${threadHref}" style="color:#666;">${threadHref}</a></p>`),
+});
+
 export const passwordChangedEmail = (siteOrigin: string, login: string, resetHref: string): EmailMessage => ({
 	subject: 'Пароль изменён',
 	html: layout(siteOrigin, login, `<p style="color:#333;font-size:14px;">Пароль для вашего

--- a/src/plugins/auth/auth.test.ts
+++ b/src/plugins/auth/auth.test.ts
@@ -80,7 +80,7 @@ describe('POST /auth/login', () => {
 		expect(body.refreshToken).toBeDefined();
 		expect(body.user.id).toBe(1);
 		expect(body.user.login).toBe('testuser');
-		expect(body.user.rights).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
+		expect(body.user.rights).toEqual({ canVote: true, canComment: true, canEditContent: false, canEditUsers: false });
 	});
 
 	it('returns 401 for wrong password', async () => {

--- a/src/plugins/auth/jwt.test.ts
+++ b/src/plugins/auth/jwt.test.ts
@@ -15,7 +15,7 @@ describe('JWT access tokens', () => {
 			isAdmin: false,
 			isEditor: true,
 			tokenVersion: 1,
-			rights: { canVote: true, canEditContent: false, canEditUsers: false },
+			rights: { canVote: true, canComment: true, canEditContent: false, canEditUsers: false },
 		};
 
 		const token = await signAccessToken(payload, secret);
@@ -26,11 +26,11 @@ describe('JWT access tokens', () => {
 		expect(decoded.isAdmin).toBe(false);
 		expect(decoded.isEditor).toBe(true);
 		expect(decoded.tokenVersion).toBe(1);
-		expect(decoded.rights).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
+		expect(decoded.rights).toEqual({ canVote: true, canComment: true, canEditContent: false, canEditUsers: false });
 	});
 
 	it('rejects a token with wrong secret', async () => {
-		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false, canEditContent: false, canEditUsers: false } };
+		const payload = { sub: 1, login: 'user', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: false, canComment: false, canEditContent: false, canEditUsers: false } };
 		const token = await signAccessToken(payload, secret);
 		const wrongSecret = new TextEncoder().encode('wrong-secret-that-is-at-least-32-chars-long');
 

--- a/src/plugins/auth/rights.test.ts
+++ b/src/plugins/auth/rights.test.ts
@@ -12,23 +12,31 @@ import {
 describe('resolveRights', () => {
 	// Bits 3..10 rule: (!group) && user
 	it('canVote: false when neither side has bit 3', () => {
-		expect(resolveRights(0, 0)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(0, 0)).toEqual({ canVote: false, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: true when user opts in (group has no bit 3)', () => {
-		expect(resolveRights(8, 0)).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(8, 0)).toEqual({ canVote: true, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: false when group blocks (group has bit 3, user does not)', () => {
-		expect(resolveRights(0, 8)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(0, 8)).toEqual({ canVote: false, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('canVote: false when group blocks (both sides have bit 3)', () => {
-		expect(resolveRights(8, 8)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(8, 8)).toEqual({ canVote: false, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('resolves default new user rights (24 = can_vote + can_comment)', () => {
-		expect(resolveRights(24, 0)).toEqual({ canVote: true, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(24, 0)).toEqual({ canVote: true, canComment: true, canEditContent: false, canEditUsers: false });
+	});
+
+	it('canComment: true when user opts in (group has no bit 4)', () => {
+		expect(resolveRights(16, 0).canComment).toBe(true);
+	});
+
+	it('canComment: false when group blocks (group has bit 4)', () => {
+		expect(resolveRights(16, 16).canComment).toBe(false);
 	});
 
 	// Bits 11..15 rule: XOR (group default, user override)
@@ -65,11 +73,11 @@ describe('resolveRights', () => {
 
 	// Banned override
 	it('zeros all rights when user is banned (bit 2)', () => {
-		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(8 | 4, 0)).toEqual({ canVote: false, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('zeros all rights when group is banned (bit 2)', () => {
-		expect(resolveRights(8, 4)).toEqual({ canVote: false, canEditContent: false, canEditUsers: false });
+		expect(resolveRights(8, 4)).toEqual({ canVote: false, canComment: false, canEditContent: false, canEditUsers: false });
 	});
 
 	it('zeros canEditContent when banned even if group has bit 12', () => {

--- a/src/plugins/auth/rights.ts
+++ b/src/plugins/auth/rights.ts
@@ -3,12 +3,14 @@ const RIGHT_BITS = {
 	passwordResetRequested: 1,
 	banned: 2,
 	canVote: 3,
+	canComment: 4,
 	canEditContent: 12,
 	canEditUsers: 14,
 } as const;
 
 export interface ResolvedRights {
 	canVote: boolean;
+	canComment: boolean;
 	canEditContent: boolean;
 	canEditUsers: boolean;
 }
@@ -40,6 +42,7 @@ export const resolveRights = (userRights: number, groupRights: number): Resolved
 
 	return {
 		canVote: resolveBit(g, u, RIGHT_BITS.canVote),
+		canComment: resolveBit(g, u, RIGHT_BITS.canComment),
 		canEditContent: resolveBit(g, u, RIGHT_BITS.canEditContent),
 		canEditUsers: resolveBit(g, u, RIGHT_BITS.canEditUsers),
 	};

--- a/src/plugins/auth/schemas.ts
+++ b/src/plugins/auth/schemas.ts
@@ -7,6 +7,7 @@ const loginSchema = z.string()
 
 export const resolvedRightsSchema = z.object({
 	canVote: z.boolean(),
+	canComment: z.boolean(),
 	canEditContent: z.boolean(),
 	canEditUsers: z.boolean(),
 });

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -63,7 +63,7 @@ const getEditorToken = async (canEditContent = true) =>
 		isAdmin: false,
 		isEditor: true,
 		tokenVersion: 0,
-		rights: { canVote: true, canEditContent, canEditUsers: false },
+		rights: { canVote: true, canComment: true, canEditContent, canEditUsers: false },
 	}, secret);
 
 const getNonEditorToken = async () =>
@@ -73,7 +73,7 @@ const getNonEditorToken = async () =>
 		isAdmin: false,
 		isEditor: false,
 		tokenVersion: 0,
-		rights: { canVote: true, canEditContent: false, canEditUsers: false },
+		rights: { canVote: true, canComment: true, canEditContent: false, canEditUsers: false },
 	}, secret);
 
 const getAdminToken = async (canEditUsers = true) =>
@@ -83,7 +83,7 @@ const getAdminToken = async (canEditUsers = true) =>
 		isAdmin: true,
 		isEditor: true,
 		tokenVersion: 0,
-		rights: { canVote: true, canEditContent: true, canEditUsers },
+		rights: { canVote: true, canComment: true, canEditContent: true, canEditUsers },
 	}, secret);
 
 const sectionRow = {

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -5,6 +5,7 @@ import { sectionThingRoutes } from './sectionThingRoutes.js';
 import { thingRoutes } from './thingRoutes.js';
 import { searchCmsRoutes } from './searchCmsRoutes.js';
 import { userRoutes } from './userRoutes.js';
+import { commentsCmsRoutes } from './commentsCmsRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -24,6 +25,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(thingRoutes);
 	fastify.register(searchCmsRoutes);
 	fastify.register(userRoutes);
+	fastify.register(commentsCmsRoutes);
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/commentsCmsRoutes.ts
+++ b/src/plugins/cms/commentsCmsRoutes.ts
@@ -1,0 +1,172 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import { requireCanEditContent } from './hooks.js';
+import {
+	getCommentMeta,
+	setCommentStatus,
+	hardDeleteComment,
+	listCommentsForCms,
+} from '../comments/databaseHelpers.js';
+import {
+	commentParams,
+	cmsCommentListQuery,
+	cmsCommentListResponse,
+	okResponse,
+	COMMENT_STATUS,
+	type CommentParams,
+	type CmsCommentListQuery,
+} from '../comments/schemas.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const errorBody = (code: string, message?: string) => ({ error: code, ...(message ? { message } : {}) });
+
+const STATUS_NAME_TO_ID: Record<string, number> = {
+	visible: COMMENT_STATUS.visible,
+	hidden: COMMENT_STATUS.hidden,
+	deleted: COMMENT_STATUS.deleted,
+};
+
+export async function commentsCmsRoutes(fastify: FastifyInstance) {
+	fastify.get('/comments', {
+		schema: {
+			description: 'Moderation feed of comments. Filter by status, scope, thingId, userId, or status=reported.',
+			tags: ['CMS'],
+			querystring: cmsCommentListQuery,
+			response: {
+				200: cmsCommentListResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: requireCanEditContent,
+		handler: async (request: FastifyRequest<{ Querystring: CmsCommentListQuery }>) => {
+			const { status, scope, thingId, userId, limit, offset } = request.query;
+			const effectiveLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+			const effectiveOffset = offset ?? 0;
+
+			const result = await listCommentsForCms(fastify.mysql, {
+				statusId: status && status !== 'reported' ? STATUS_NAME_TO_ID[status] : undefined,
+				onlyReported: status === 'reported' || undefined,
+				scopeFilter: scope,
+				thingId,
+				userId,
+				limit: effectiveLimit,
+				offset: effectiveOffset,
+			});
+
+			return {
+				items: result.items,
+				total: result.total,
+				hasMore: result.items.length === effectiveLimit,
+			};
+		},
+	});
+
+	fastify.post('/comments/:commentId/hide', {
+		schema: {
+			description: 'Mark a comment as hidden by a moderator (status=2). Resolves any open reports against it.',
+			tags: ['CMS'],
+			params: commentParams,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: requireCanEditContent,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+
+			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.hidden, userId);
+			request.log.info({ commentId, modUserId: userId }, 'Comment hidden by mod');
+			return { ok: true as const };
+		},
+	});
+
+	fastify.post('/comments/:commentId/delete', {
+		schema: {
+			description: 'Soft-delete a comment as a moderator (status=3). Same outcome label as a self-delete.',
+			tags: ['CMS'],
+			params: commentParams,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: requireCanEditContent,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+
+			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.deleted, userId);
+			request.log.info({ commentId, modUserId: userId }, 'Comment soft-deleted by mod');
+			return { ok: true as const };
+		},
+	});
+
+	fastify.post('/comments/:commentId/restore', {
+		schema: {
+			description: 'Restore a hidden or deleted comment back to visible (status=1).',
+			tags: ['CMS'],
+			params: commentParams,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: requireCanEditContent,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+
+			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.visible, userId);
+			request.log.info({ commentId, modUserId: userId }, 'Comment restored by mod');
+			return { ok: true as const };
+		},
+	});
+
+	fastify.delete('/comments/:commentId', {
+		schema: {
+			description: 'Hard-delete a comment row. Cascades to replies, votes, and reports. Use sparingly — soft-delete is preferred.',
+			tags: ['CMS'],
+			params: commentParams,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: requireCanEditContent,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+
+			await hardDeleteComment(fastify.mysql, commentId);
+			request.log.warn({ commentId, modUserId: userId }, 'Comment hard-deleted by mod');
+			return { ok: true as const };
+		},
+	});
+}

--- a/src/plugins/comments/comments.test.ts
+++ b/src/plugins/comments/comments.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { authPlugin } from '../auth/auth.js';
+import { commentsPlugin } from './comments.js';
+import { signAccessToken } from '../auth/jwt.js';
+
+const JWT_SECRET = 'test-jwt-secret-that-is-at-least-32-characters-long';
+const secret = new TextEncoder().encode(JWT_SECRET);
+
+beforeEach(() => {
+	vi.stubEnv('JWT_SECRET', JWT_SECRET);
+	vi.stubEnv('JWT_ACCESS_TOKEN_TTL', '900');
+	vi.stubEnv('JWT_REFRESH_TOKEN_TTL', '2592000');
+	vi.stubEnv('ACTIVATION_KEY_TTL', '86400');
+	vi.stubEnv('RESET_KEY_TTL', '3600');
+});
+
+// listComments runs multiple queries on one connection, so the mock advances
+// per query call rather than per getConnection (which is the simpler pattern
+// used by votes.test.ts where each route call does a single query).
+function createMockMysql(...responses: Record<string, unknown>[][]): MySQLPromisePool {
+	let queryIndex = 0;
+
+	return {
+		getConnection: vi.fn().mockImplementation(() =>
+			Promise.resolve({
+				query: vi.fn().mockImplementation(() =>
+					Promise.resolve([responses[queryIndex++] ?? []])
+				),
+				release: vi.fn(),
+			})
+		),
+	} as unknown as MySQLPromisePool;
+}
+
+async function buildApp(mysql: MySQLPromisePool) {
+	const app = Fastify({ logger: false });
+	app.setValidatorCompiler(validatorCompiler);
+	app.setSerializerCompiler(serializerCompiler);
+	app.decorate('mysql', mysql);
+	app.register(authPlugin);
+	app.register(commentsPlugin, { prefix: '/comments' });
+	return app;
+}
+
+const buildToken = (overrides: Partial<{ canVote: boolean; canComment: boolean; sub: number }> = {}) =>
+	signAccessToken({
+		sub: overrides.sub ?? 1,
+		login: 'testuser',
+		isAdmin: false,
+		isEditor: false,
+		tokenVersion: 0,
+		rights: {
+			canVote: overrides.canVote ?? true,
+			canComment: overrides.canComment ?? true,
+			canEditContent: false,
+			canEditUsers: false,
+		},
+	}, secret);
+
+const visibleRow = {
+	id: 10,
+	parentId: null,
+	thingId: 5,
+	userId: 1,
+	authorLogin: 'testuser',
+	text: 'Hello world',
+	statusId: 1,
+	createdAt: new Date('2026-04-27T12:00:00Z'),
+	updatedAt: new Date('2026-04-27T12:00:00Z'),
+	likes: 0,
+	dislikes: 0,
+	userVote: 0,
+	hasVisibleChild: 0,
+};
+
+describe('GET /comments', () => {
+	it('lists comments for a thing without auth', async () => {
+		const mysql = createMockMysql([visibleRow], [{ total: 1 }], []);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments?thingId=5' });
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0].text).toBe('Hello world');
+		expect(body.total).toBe(1);
+	});
+
+	it('rejects combining thingId with scope=site', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({ method: 'GET', url: '/comments?thingId=5&scope=site' });
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('omits text/author for tombstone top-level rows that have no visible children', async () => {
+		const tombstone = { ...visibleRow, statusId: 3, hasVisibleChild: 0 };
+		const mysql = createMockMysql([tombstone], [{ total: 0 }]);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments?thingId=5' });
+		expect(response.statusCode).toBe(200);
+		expect(response.json().items).toHaveLength(0);
+	});
+
+	it('includes tombstone top-level row when it has visible children, with text masked', async () => {
+		const tombstone = { ...visibleRow, statusId: 3, hasVisibleChild: 1 };
+		const reply = { ...visibleRow, id: 11, parentId: 10, statusId: 1 };
+		const mysql = createMockMysql([tombstone], [{ total: 1 }], [reply]);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments?thingId=5' });
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0].text).toBeNull();
+		expect(body.items[0].authorLogin).toBeNull();
+		expect(body.items[0].replies).toHaveLength(1);
+		expect(body.items[0].replies[0].text).toBe('Hello world');
+	});
+});
+
+describe('GET /comments/:id', () => {
+	it('bundles replies for a top-level comment (single-thread shape)', async () => {
+		const top = { ...visibleRow, parentId: null, hasVisibleChild: 1 };
+		const reply = { ...visibleRow, id: 11, parentId: 10, hasVisibleChild: 0 };
+		const mysql = createMockMysql([top], [reply]);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments/10' });
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.id).toBe(10);
+		expect(body.replies).toHaveLength(1);
+		expect(body.replies[0].id).toBe(11);
+	});
+
+	it('returns a reply without bundling further replies (one-level threading)', async () => {
+		const reply = { ...visibleRow, id: 11, parentId: 10, hasVisibleChild: 0 };
+		const mysql = createMockMysql([reply]);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments/11' });
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.id).toBe(11);
+		expect(body.parentId).toBe(10);
+		expect(body.replies).toBeUndefined();
+	});
+
+	it('returns 404 for unknown id', async () => {
+		const mysql = createMockMysql([]);
+		const app = await buildApp(mysql);
+		const response = await app.inject({ method: 'GET', url: '/comments/999' });
+		expect(response.statusCode).toBe(404);
+	});
+});
+
+describe('POST /comments', () => {
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments',
+			payload: { thingId: 5, text: 'hello there' },
+		});
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns 403 without canComment', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await buildToken({ canComment: false });
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { thingId: 5, text: 'hello there' },
+		});
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('rejects empty text', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { thingId: 5, text: '' },
+		});
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects flooded text', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await buildToken();
+		const flood = 'a'.repeat(60);
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { thingId: 5, text: flood },
+		});
+		expect(response.statusCode).toBe(400);
+		expect(response.json().error).toBe('TEXT_FLOOD');
+	});
+});
+
+describe('PUT /comments/:id/vote', () => {
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/comments/10/vote',
+			payload: { vote: 1 },
+		});
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns 403 without canVote', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await buildToken({ canVote: false });
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/comments/10/vote',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { vote: 1 },
+		});
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('returns 404 when comment does not exist', async () => {
+		const mysql = createMockMysql([]);
+		const app = await buildApp(mysql);
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/comments/10/vote',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { vote: 1 },
+		});
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('returns 409 when comment is not visible', async () => {
+		const mysql = createMockMysql([{ id: 10, userId: 2, thingId: 5, parentId: null, statusId: 3, createdAt: new Date() }]);
+		const app = await buildApp(mysql);
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/comments/10/vote',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { vote: 1 },
+		});
+		expect(response.statusCode).toBe(409);
+	});
+});
+
+describe('POST /comments/:id/report', () => {
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments/10/report',
+			payload: {},
+		});
+		expect(response.statusCode).toBe(401);
+	});
+});

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -1,0 +1,346 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import { sendEmail } from '../../lib/email.js';
+import { commentReportedEmail, commentReplyEmail } from '../../lib/emailTemplates.js';
+import { sanitizeCommentText } from './sanitizeCommentText.js';
+import {
+	listComments,
+	getCommentById,
+	getCommentMeta,
+	getRepliesForTopLevel,
+	getCommentReplyContext,
+	createComment,
+	updateCommentText,
+	setCommentStatus,
+	upsertCommentVote,
+	deleteCommentVote,
+	getCommentVoteSummary,
+	reportComment,
+	type CommentReplyContext,
+} from './databaseHelpers.js';
+import {
+	commentParams,
+	commentListQuery,
+	commentListResponse,
+	commentWithRepliesSchema,
+	createCommentRequest,
+	updateCommentRequest,
+	voteCommentRequest,
+	voteCommentResponse,
+	reportCommentRequest,
+	okResponse,
+	COMMENT_STATUS,
+	COMMENT_EDIT_WINDOW_MS,
+	type CommentParams,
+	type CommentListQuery,
+	type CreateCommentRequest,
+	type UpdateCommentRequest,
+	type VoteCommentRequest,
+	type ReportCommentRequest,
+} from './schemas.js';
+
+const ADMIN_NOTIFY_EMAIL = process.env.ADMIN_NOTIFY_EMAIL;
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const POST_RATE_LIMIT = { max: 1, timeWindow: '30 seconds' };
+const VOTE_RATE_LIMIT = { max: 5, timeWindow: '1 minute' };
+const REPORT_RATE_LIMIT = { max: 1, timeWindow: '5 minutes' };
+
+const errorBody = (code: string, message?: string) => ({ error: code, ...(message ? { message } : {}) });
+
+// nextjs is configured without trailing slashes — paths end at the last
+// segment, query starts at `?`. Only the bare root `/` keeps its slash.
+const buildThreadHref = (siteOrigin: string, ctx: CommentReplyContext, threadCommentId: number): string => {
+	if (ctx.thingId === null) {
+		return `${siteOrigin}/guestbook?thread=${threadCommentId}`;
+	}
+	if (!ctx.sectionIdentifier || ctx.positionInSection === null) {
+		// Thing has no section row (shouldn't happen for published things) — fall
+		// back to the site root so the email still has *some* href.
+		return `${siteOrigin}/?thread=${threadCommentId}`;
+	}
+	return `${siteOrigin}/sections/${encodeURIComponent(ctx.sectionIdentifier)}/${ctx.positionInSection}?thread=${threadCommentId}`;
+};
+
+export async function commentsPlugin(fastify: FastifyInstance) {
+	fastify.log.info('[PLUGIN] Registering: comments...');
+
+	fastify.get('/', {
+		schema: {
+			description: 'List comments. Filter by thingId for per-thing comments, or scope=site for the guestbook feed.',
+			tags: ['Comments'],
+			querystring: commentListQuery,
+			response: {
+				200: commentListResponse,
+				400: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: fastify.optionalVerifyJwt,
+		handler: async (request: FastifyRequest<{ Querystring: CommentListQuery }>, reply) => {
+			const { thingId, scope, limit, offset } = request.query;
+
+			if (thingId !== undefined && scope === 'site') {
+				return reply.code(400).send(errorBody('invalid_query', 'Cannot combine thingId with scope=site'));
+			}
+
+			const effectiveThingId: number | null = thingId ?? null;
+			const userId = request.user?.sub ?? 0;
+
+			return await listComments(fastify.mysql, {
+				thingId: effectiveThingId,
+				userId,
+				limit: Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT),
+				offset: offset ?? 0,
+			});
+		},
+	});
+
+	fastify.get('/:commentId', {
+		schema: {
+			description: 'Fetch a single comment by id. Top-level rows include their replies (single-thread view); reply rows are returned bare.',
+			tags: ['Comments'],
+			params: commentParams,
+			response: {
+				200: commentWithRepliesSchema,
+				404: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: fastify.optionalVerifyJwt,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user?.sub ?? 0;
+			const comment = await getCommentById(fastify.mysql, request.params.commentId, userId);
+			if (!comment) return reply.code(404).send(errorBody('not_found'));
+
+			if (comment.parentId === null) {
+				const replies = await getRepliesForTopLevel(fastify.mysql, comment.id, userId);
+				return { ...comment, replies };
+			}
+
+			return comment;
+		},
+	});
+
+	fastify.post('/', {
+		schema: {
+			description: 'Post a new comment. thingId omitted = guestbook entry. parentId required for a reply.',
+			tags: ['Comments'],
+			body: createCommentRequest,
+			response: {
+				201: commentWithRepliesSchema,
+				400: errorResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		config: { rateLimit: POST_RATE_LIMIT },
+		preHandler: [fastify.verifyJwt, fastify.requireRight('canComment')],
+		handler: async (request: FastifyRequest<{ Body: CreateCommentRequest }>, reply) => {
+			const userId = request.user!.sub;
+			const { thingId = null, parentId = null, text } = request.body;
+
+			const sanitized = sanitizeCommentText(text);
+			if (!sanitized.ok) return reply.code(400).send(errorBody(sanitized.error));
+
+			let resolvedThingId: number | null = thingId;
+
+			if (parentId !== null) {
+				const parent = await getCommentMeta(fastify.mysql, parentId);
+				if (!parent) return reply.code(404).send(errorBody('parent_not_found'));
+				if (parent.parentId !== null) {
+					return reply.code(409).send(errorBody('reply_depth_exceeded', 'Replies are limited to one level'));
+				}
+				if (parent.statusId !== COMMENT_STATUS.visible) {
+					return reply.code(409).send(errorBody('parent_not_visible'));
+				}
+				// Inherit scope from parent — caller's thingId is ignored to keep
+				// reply scope consistent with its parent.
+				resolvedThingId = parent.thingId;
+			}
+
+			const commentId = await createComment(fastify.mysql, {
+				userId,
+				thingId: resolvedThingId,
+				parentId,
+				text: sanitized.text,
+			});
+			request.log.info({ commentId, userId, thingId: resolvedThingId, parentId }, 'Comment created');
+
+			// Reply notification: fire-and-forget. The thread deep link points to
+			// the parent (top-level), since pagination is on top-level — opening
+			// the parent shows the new reply under it in single-thread mode.
+			if (parentId !== null) {
+				const ctx = await getCommentReplyContext(fastify.mysql, parentId);
+				if (ctx?.parentAuthor && ctx.parentAuthor.userId !== userId && !ctx.parentAuthor.isBanned) {
+					const recipient = ctx.parentAuthor;
+					const replierLogin = request.user!.login;
+					const siteOrigin = fastify.resolveOrigin(request);
+					const threadHref = buildThreadHref(siteOrigin, ctx, parentId);
+					sendEmail(
+						recipient.email,
+						commentReplyEmail(siteOrigin, recipient.login, replierLogin, sanitized.text, threadHref),
+					).catch((err) => request.log.warn(err, 'Comment-reply notification email failed'));
+				}
+			}
+
+			const created = await getCommentById(fastify.mysql, commentId, userId);
+			return reply.code(201).send(created);
+		},
+	});
+
+	fastify.put('/:commentId', {
+		schema: {
+			description: 'Edit own comment within the edit window. Triggers no re-moderation under the post-moderation model.',
+			tags: ['Comments'],
+			params: commentParams,
+			body: updateCommentRequest,
+			response: {
+				200: commentWithRepliesSchema,
+				400: errorResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Params: CommentParams; Body: UpdateCommentRequest }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+			if (meta.userId !== userId) return reply.code(403).send(errorBody('forbidden'));
+			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('not_editable'));
+
+			const age = Date.now() - meta.createdAt.getTime();
+			if (age > COMMENT_EDIT_WINDOW_MS) {
+				return reply.code(409).send(errorBody('edit_window_closed'));
+			}
+
+			const sanitized = sanitizeCommentText(request.body.text);
+			if (!sanitized.ok) return reply.code(400).send(errorBody(sanitized.error));
+
+			await updateCommentText(fastify.mysql, commentId, sanitized.text);
+			request.log.info({ commentId, userId }, 'Comment edited');
+
+			return await getCommentById(fastify.mysql, commentId, userId);
+		},
+	});
+
+	fastify.delete('/:commentId', {
+		schema: {
+			description: 'Delete own comment (sets status=Deleted). Mods use the CMS routes for moderation actions.',
+			tags: ['Comments'],
+			params: commentParams,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Params: CommentParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+			if (meta.userId !== userId) return reply.code(403).send(errorBody('forbidden'));
+			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('already_removed'));
+
+			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.deleted, userId);
+			request.log.info({ commentId, userId }, 'Comment self-deleted');
+			return { ok: true as const };
+		},
+	});
+
+	fastify.put('/:commentId/vote', {
+		schema: {
+			description: 'Vote on a comment: +1 like, -1 dislike, 0 to remove your vote.',
+			tags: ['Comments'],
+			params: commentParams,
+			body: voteCommentRequest,
+			response: {
+				200: voteCommentResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		config: { rateLimit: VOTE_RATE_LIMIT },
+		preHandler: [fastify.verifyJwt, fastify.requireRight('canVote')],
+		handler: async (request: FastifyRequest<{ Params: CommentParams; Body: VoteCommentRequest }>, reply) => {
+			const userId = request.user!.sub;
+			const { commentId } = request.params;
+			const { vote } = request.body;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('not_votable'));
+
+			if (vote === 0) {
+				await deleteCommentVote(fastify.mysql, commentId, userId);
+				request.log.info({ commentId, userId }, 'Comment vote removed');
+			} else {
+				await upsertCommentVote(fastify.mysql, commentId, userId, vote as 1 | -1);
+				request.log.info({ commentId, userId, vote }, 'Comment vote recorded');
+			}
+
+			return await getCommentVoteSummary(fastify.mysql, commentId, userId);
+		},
+	});
+
+	fastify.post('/:commentId/report', {
+		schema: {
+			description: 'Flag a comment as inappropriate. One report per (user, comment); resubmitting overwrites the reason.',
+			tags: ['Comments'],
+			params: commentParams,
+			body: reportCommentRequest,
+			response: {
+				200: okResponse,
+				401: authErrorResponse,
+				404: errorResponse,
+				409: errorResponse,
+				500: errorResponse,
+			},
+		},
+		config: { rateLimit: REPORT_RATE_LIMIT },
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Params: CommentParams; Body: ReportCommentRequest }>, reply) => {
+			const userId = request.user!.sub;
+			const login = request.user!.login;
+			const { commentId } = request.params;
+			const { reason } = request.body;
+			const meta = await getCommentMeta(fastify.mysql, commentId);
+
+			if (!meta) return reply.code(404).send(errorBody('not_found'));
+			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('not_reportable'));
+
+			await reportComment(fastify.mysql, commentId, userId, reason ?? null);
+			request.log.warn({ commentId, userId }, 'Comment reported');
+
+			if (ADMIN_NOTIFY_EMAIL) {
+				sendEmail(ADMIN_NOTIFY_EMAIL, commentReportedEmail(login, commentId, reason ?? null))
+					.catch((err) => request.log.warn(err, 'Comment-report notification email failed'));
+			}
+
+			return { ok: true as const };
+		},
+	});
+
+	fastify.log.info('[PLUGIN] Registered: comments');
+}

--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -1,0 +1,393 @@
+import type { MySQLPromisePool, MySQLRowDataPacket, MySQLResultSetHeader } from '@fastify/mysql';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { isBanned } from '../auth/rights.js';
+import {
+	topLevelCommentsQuery,
+	repliesByParentIdsQuery,
+	repliesByParentIdQuery,
+	topLevelCommentCountQuery,
+	commentByIdQuery,
+	commentMetaByIdQuery,
+	commentReplyContextQuery,
+	insertCommentQuery,
+	updateCommentTextQuery,
+	setCommentStatusQuery,
+	hardDeleteCommentQuery,
+	upsertCommentVoteQuery,
+	deleteCommentVoteQuery,
+	commentVoteCountsQuery,
+	userCommentVoteQuery,
+	upsertCommentReportQuery,
+	resolveReportsForCommentQuery,
+	buildCmsCommentListQuery,
+} from './queries.js';
+import { COMMENT_STATUS, type CommentBase, type CommentWithReplies } from './schemas.js';
+
+export interface CommentMeta {
+	id: number;
+	userId: number | null;
+	thingId: number | null;
+	parentId: number | null;
+	statusId: number;
+	createdAt: Date;
+}
+
+interface RawCommentRow {
+	id: number;
+	parentId: number | null;
+	thingId: number | null;
+	userId: number | null;
+	authorLogin: string | null;
+	text: string;
+	statusId: number;
+	createdAt: Date;
+	updatedAt: Date;
+	likes: number | string;
+	dislikes: number | string;
+	userVote: number | string;
+	hasVisibleChild?: number;
+}
+
+const toIso = (d: Date | string): string => (d instanceof Date ? d.toISOString() : new Date(d).toISOString());
+const toInt = (v: number | string): number => (typeof v === 'string' ? parseInt(v, 10) : v);
+
+// Tombstones (status 2/3): hide text, author and votes. Caller decides whether
+// to include them at all (by hasVisibleChild for top-level, never for replies).
+const projectRow = (row: RawCommentRow): CommentBase => {
+	const isVisible = row.statusId === COMMENT_STATUS.visible;
+	return {
+		id: row.id,
+		parentId: row.parentId,
+		thingId: row.thingId,
+		userId: isVisible ? row.userId : null,
+		authorLogin: isVisible ? row.authorLogin : null,
+		text: isVisible ? row.text : null,
+		statusId: row.statusId,
+		createdAt: toIso(row.createdAt),
+		updatedAt: toIso(row.updatedAt),
+		votes: {
+			likes: isVisible ? toInt(row.likes) : 0,
+			dislikes: isVisible ? toInt(row.dislikes) : 0,
+		},
+		userVote: isVisible ? toInt(row.userVote) as -1 | 0 | 1 : 0,
+	};
+};
+
+export interface ListCommentsArgs {
+	thingId: number | null;
+	userId: number;
+	limit: number;
+	offset: number;
+}
+
+export interface ListCommentsResult {
+	items: CommentWithReplies[];
+	total: number;
+	hasMore: boolean;
+}
+
+export const listComments = async (
+	mysql: MySQLPromisePool,
+	{ thingId, userId, limit, offset }: ListCommentsArgs,
+): Promise<ListCommentsResult> =>
+	withConnection(mysql, async (connection) => {
+		const [topRows] = await connection.query<MySQLRowDataPacket[]>(
+			topLevelCommentsQuery,
+			[userId, thingId, limit, offset],
+		);
+		const [countRows] = await connection.query<MySQLRowDataPacket[]>(
+			topLevelCommentCountQuery,
+			[thingId],
+		);
+
+		const total = toInt(countRows[0]?.total as number | string ?? 0);
+
+		// Drop tombstone top-level rows that have no visible children — they'd
+		// just be empty placeholders.
+		const keptTop = (topRows as unknown as (RawCommentRow & { hasVisibleChild: number })[]).filter(
+			(r) => r.statusId === COMMENT_STATUS.visible || r.hasVisibleChild === 1,
+		);
+
+		if (keptTop.length === 0) {
+			return { items: [], total, hasMore: topRows.length === limit };
+		}
+
+		const topIds = keptTop.map((r) => r.id);
+
+		const [replyRows] = await connection.query<MySQLRowDataPacket[]>(
+			repliesByParentIdsQuery,
+			[topIds],
+		);
+
+		const repliesByParent = new Map<number, CommentBase[]>();
+		for (const raw of replyRows as unknown as RawCommentRow[]) {
+			// One-level threading: replies can't have descendants, so any non-visible
+			// reply is omitted entirely (no tombstone).
+			if (raw.statusId !== COMMENT_STATUS.visible) continue;
+			const projected = projectRow(raw);
+			const list = repliesByParent.get(raw.parentId!) ?? [];
+			list.push(projected);
+			repliesByParent.set(raw.parentId!, list);
+		}
+
+		const items: CommentWithReplies[] = keptTop.map((raw) => ({
+			...projectRow(raw),
+			replies: repliesByParent.get(raw.id) ?? [],
+		}));
+
+		return {
+			items,
+			total,
+			hasMore: topRows.length === limit,
+		};
+	});
+
+export const getCommentById = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	userId: number,
+): Promise<CommentBase | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(commentByIdQuery, [userId, commentId]);
+		const row = rows[0] as unknown as (RawCommentRow & { hasVisibleChild: number }) | undefined;
+		if (!row) return null;
+		if (row.statusId !== COMMENT_STATUS.visible && row.hasVisibleChild !== 1) return null;
+		return projectRow(row);
+	});
+
+// Fetch all visible replies for a top-level comment. Replies that are not
+// Visible (status 2/3) are omitted entirely — one-level threading means they
+// can't have descendants, so a tombstone reply would be a dead placeholder.
+export const getRepliesForTopLevel = async (
+	mysql: MySQLPromisePool,
+	parentId: number,
+	userId: number,
+): Promise<CommentBase[]> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(repliesByParentIdQuery, [userId, parentId]);
+		return (rows as unknown as RawCommentRow[])
+			.filter((r) => r.statusId === COMMENT_STATUS.visible)
+			.map(projectRow);
+	});
+
+export interface CommentReplyContext {
+	parentAuthor:
+		| {
+			userId: number;
+			login: string;
+			email: string;
+			isBanned: boolean;
+		}
+		| null;
+	thingId: number | null;
+	sectionIdentifier: string | null;
+	positionInSection: number | null;
+}
+
+// Returns the parent comment's author info (for the email recipient) and the
+// section/position needed to construct a deep link. Returns null parentAuthor
+// when the parent's author was deleted (r_user_id is NULL).
+export const getCommentReplyContext = async (
+	mysql: MySQLPromisePool,
+	parentCommentId: number,
+): Promise<CommentReplyContext | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(commentReplyContextQuery, [parentCommentId]);
+		const row = rows[0];
+		if (!row) return null;
+
+		const userRights = (row.authorUserRights as number | null) ?? 0;
+		const groupRights = (row.authorGroupRights as number | null) ?? 0;
+		const banned = isBanned(userRights) || isBanned(groupRights);
+
+		const parentAuthor = row.authorUserId
+			? {
+				userId: row.authorUserId as number,
+				login: row.authorLogin as string,
+				email: row.authorEmail as string,
+				isBanned: banned,
+			}
+			: null;
+
+		return {
+			parentAuthor,
+			thingId: (row.thingId as number | null) ?? null,
+			sectionIdentifier: (row.sectionIdentifier as string | null) ?? null,
+			positionInSection: (row.positionInSection as number | null) ?? null,
+		};
+	});
+
+export const getCommentMeta = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+): Promise<CommentMeta | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(commentMetaByIdQuery, [commentId]);
+		if (!rows[0]) return null;
+		const r = rows[0];
+		return {
+			id: r.id as number,
+			userId: r.userId as number | null,
+			thingId: r.thingId as number | null,
+			parentId: r.parentId as number | null,
+			statusId: r.statusId as number,
+			createdAt: r.createdAt instanceof Date ? r.createdAt : new Date(r.createdAt as string),
+		};
+	});
+
+export interface CreateCommentArgs {
+	userId: number;
+	thingId: number | null;
+	parentId: number | null;
+	text: string;
+}
+
+export const createComment = async (
+	mysql: MySQLPromisePool,
+	{ userId, thingId, parentId, text }: CreateCommentArgs,
+): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		const [result] = await connection.query<MySQLResultSetHeader>(insertCommentQuery, [
+			userId,
+			thingId,
+			parentId,
+			text,
+			userId,
+		]);
+		return result.insertId;
+	});
+
+export const updateCommentText = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	text: string,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(updateCommentTextQuery, [text, commentId]);
+	});
+};
+
+export const setCommentStatus = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	statusId: number,
+	actorUserId: number,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(setCommentStatusQuery, [statusId, actorUserId, commentId]);
+		// When a comment is taken out of visible state by a mod, mark any
+		// outstanding reports as resolved by that mod — same effect either way.
+		if (statusId !== COMMENT_STATUS.visible) {
+			await connection.query(resolveReportsForCommentQuery, [actorUserId, commentId]);
+		}
+	});
+};
+
+export const hardDeleteComment = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(hardDeleteCommentQuery, [commentId]);
+	});
+};
+
+export interface CommentVoteCounts {
+	likes: number;
+	dislikes: number;
+}
+
+export const upsertCommentVote = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	userId: number,
+	vote: 1 | -1,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(upsertCommentVoteQuery, [commentId, userId, vote]);
+	});
+};
+
+export const deleteCommentVote = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	userId: number,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(deleteCommentVoteQuery, [commentId, userId]);
+	});
+};
+
+export const getCommentVoteSummary = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	userId: number,
+): Promise<CommentVoteCounts & { userVote: -1 | 0 | 1 }> =>
+	withConnection(mysql, async (connection) => {
+		const [counts] = await connection.query<MySQLRowDataPacket[]>(commentVoteCountsQuery, [commentId]);
+		const [own] = await connection.query<MySQLRowDataPacket[]>(userCommentVoteQuery, [commentId, userId]);
+		return {
+			likes: toInt(counts[0]?.likes as number | string ?? 0),
+			dislikes: toInt(counts[0]?.dislikes as number | string ?? 0),
+			userVote: (own[0]?.vote ?? 0) as -1 | 0 | 1,
+		};
+	});
+
+export const reportComment = async (
+	mysql: MySQLPromisePool,
+	commentId: number,
+	userId: number,
+	reason: string | null,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(upsertCommentReportQuery, [commentId, userId, reason]);
+	});
+};
+
+export interface CmsListArgs {
+	statusId?: number;
+	scopeFilter?: 'site' | 'thing';
+	thingId?: number;
+	userId?: number;
+	onlyReported?: boolean;
+	limit: number;
+	offset: number;
+}
+
+export const listCommentsForCms = async (
+	mysql: MySQLPromisePool,
+	args: CmsListArgs,
+) =>
+	withConnection(mysql, async (connection) => {
+		const { list, count } = buildCmsCommentListQuery(args);
+
+		const params: (number | string)[] = [];
+		if (args.statusId !== undefined) params.push(args.statusId);
+		if (args.thingId !== undefined) params.push(args.thingId);
+		if (args.userId !== undefined) params.push(args.userId);
+
+		const [items] = await connection.query<MySQLRowDataPacket[]>(list, [...params, args.limit, args.offset]);
+		const [totals] = await connection.query<MySQLRowDataPacket[]>(count, params);
+
+		return {
+			items: items.map((r) => ({
+				id: r.id as number,
+				parentId: r.parentId as number | null,
+				thingId: r.thingId as number | null,
+				userId: r.userId as number | null,
+				authorLogin: r.authorLogin as string | null,
+				text: r.text as string,
+				statusId: r.statusId as number,
+				createdAt: toIso(r.createdAt as Date),
+				updatedAt: toIso(r.updatedAt as Date),
+				statusChangedAt: toIso(r.statusChangedAt as Date),
+				statusChangedByUserId: r.statusChangedByUserId as number | null,
+				votes: {
+					likes: toInt(r.likes as number | string),
+					dislikes: toInt(r.dislikes as number | string),
+				},
+				reportCount: toInt(r.reportCount as number | string),
+			})),
+			total: toInt(totals[0]?.total as number | string ?? 0),
+		};
+	});

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -1,0 +1,222 @@
+// Common SELECT body for a comment row, parameterized by the caller's userId
+// (or 0 for anonymous — never matches a real auth_user.id, so userVote stays 0).
+const commentRowFields = `
+  c.id,
+  c.parent_id AS parentId,
+  c.r_thing_id AS thingId,
+  c.r_user_id AS userId,
+  u.login AS authorLogin,
+  c.text,
+  c.r_comment_status_id AS statusId,
+  c.created_at AS createdAt,
+  c.updated_at AS updatedAt,
+  COALESCE(SUM(CASE WHEN cv.vote = 1 THEN 1 ELSE 0 END), 0) AS likes,
+  COALESCE(SUM(CASE WHEN cv.vote = -1 THEN 1 ELSE 0 END), 0) AS dislikes,
+  COALESCE(SUM(CASE WHEN cv.r_user_id = ? THEN cv.vote ELSE 0 END), 0) AS userVote
+`;
+
+// <=> is MySQL's NULL-safe equality: r_thing_id IS NULL when ? is NULL,
+// r_thing_id = ? when ? is a number. Lets one query serve both
+// "guestbook" (?=NULL) and "per-thing" (?=N) reads.
+export const topLevelCommentsQuery = `
+  SELECT
+    ${commentRowFields},
+    EXISTS(
+      SELECT 1 FROM comment c2
+      WHERE c2.parent_id = c.id AND c2.r_comment_status_id = 1
+    ) AS hasVisibleChild
+  FROM comment c
+  LEFT JOIN auth_user u ON u.id = c.r_user_id
+  LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+  WHERE c.parent_id IS NULL AND c.r_thing_id <=> ?
+  GROUP BY c.id
+  ORDER BY c.created_at DESC, c.id DESC
+  LIMIT ? OFFSET ?
+`;
+
+export const repliesByParentIdsQuery = `
+  SELECT ${commentRowFields}
+  FROM comment c
+  LEFT JOIN auth_user u ON u.id = c.r_user_id
+  LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+  WHERE c.parent_id IN (?)
+  GROUP BY c.id
+  ORDER BY c.parent_id, c.created_at ASC, c.id ASC
+`;
+
+export const topLevelCommentCountQuery = `
+  SELECT COUNT(*) AS total
+  FROM comment
+  WHERE parent_id IS NULL
+    AND r_thing_id <=> ?
+    AND r_comment_status_id = 1
+`;
+
+export const commentByIdQuery = `
+  SELECT
+    ${commentRowFields},
+    EXISTS(
+      SELECT 1 FROM comment c2
+      WHERE c2.parent_id = c.id AND c2.r_comment_status_id = 1
+    ) AS hasVisibleChild
+  FROM comment c
+  LEFT JOIN auth_user u ON u.id = c.r_user_id
+  LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+  WHERE c.id = ?
+  GROUP BY c.id
+`;
+
+// Used for parent validation on insert + edit-window / ownership / status checks
+// on update / delete.
+export const commentMetaByIdQuery = `
+  SELECT
+    id,
+    r_user_id AS userId,
+    r_thing_id AS thingId,
+    parent_id AS parentId,
+    r_comment_status_id AS statusId,
+    created_at AS createdAt
+  FROM comment
+  WHERE id = ?
+`;
+
+export const insertCommentQuery = `
+  INSERT INTO comment
+    (r_user_id, r_thing_id, parent_id, text, r_comment_status_id,
+     status_changed_at, status_changed_by_user_id)
+  VALUES (?, ?, ?, ?, 1, NOW(), ?)
+`;
+
+export const updateCommentTextQuery = `
+  UPDATE comment SET text = ? WHERE id = ?
+`;
+
+export const setCommentStatusQuery = `
+  UPDATE comment
+  SET r_comment_status_id = ?,
+      status_changed_at = NOW(),
+      status_changed_by_user_id = ?
+  WHERE id = ?
+`;
+
+export const hardDeleteCommentQuery = `
+  DELETE FROM comment WHERE id = ?
+`;
+
+export const upsertCommentVoteQuery = `
+  INSERT INTO comment_vote (r_comment_id, r_user_id, vote)
+  VALUES (?, ?, ?)
+  ON DUPLICATE KEY UPDATE vote = VALUES(vote)
+`;
+
+export const deleteCommentVoteQuery = `
+  DELETE FROM comment_vote WHERE r_comment_id = ? AND r_user_id = ?
+`;
+
+export const commentVoteCountsQuery = `
+  SELECT
+    COALESCE(SUM(CASE WHEN vote = 1 THEN 1 ELSE 0 END), 0) AS likes,
+    COALESCE(SUM(CASE WHEN vote = -1 THEN 1 ELSE 0 END), 0) AS dislikes
+  FROM comment_vote WHERE r_comment_id = ?
+`;
+
+export const userCommentVoteQuery = `
+  SELECT vote FROM comment_vote WHERE r_comment_id = ? AND r_user_id = ?
+`;
+
+// Lookup for reply notifications: parent author email/login + ban check, plus
+// section identifier + position for the deep-link URL when the comment is on
+// a thing. Returns at most one section row per thing — picks any when a thing
+// belongs to multiple sections (acceptable: any link lands on the comment).
+export const commentReplyContextQuery = `
+  SELECT
+    pc.r_user_id  AS authorUserId,
+    pc.r_thing_id AS thingId,
+    u.login       AS authorLogin,
+    u.email       AS authorEmail,
+    u.rights      AS authorUserRights,
+    g.rights      AS authorGroupRights,
+    s.identifier               AS sectionIdentifier,
+    ti.thing_position_in_section AS positionInSection
+  FROM comment pc
+  LEFT JOIN auth_user u  ON u.id = pc.r_user_id
+  LEFT JOIN auth_group g ON g.id = u.r_group_id
+  LEFT JOIN thing_identifier ti ON ti.r_thing_id = pc.r_thing_id
+  LEFT JOIN section s    ON s.id = ti.r_section_id
+  WHERE pc.id = ?
+  LIMIT 1
+`;
+
+export const repliesByParentIdQuery = `
+  SELECT ${commentRowFields}
+  FROM comment c
+  LEFT JOIN auth_user u ON u.id = c.r_user_id
+  LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+  WHERE c.parent_id = ?
+  GROUP BY c.id
+  ORDER BY c.created_at ASC, c.id ASC
+`;
+
+export const upsertCommentReportQuery = `
+  INSERT INTO comment_report (r_comment_id, r_user_id, reason)
+  VALUES (?, ?, ?)
+  ON DUPLICATE KEY UPDATE reason = VALUES(reason), created_at = CURRENT_TIMESTAMP
+`;
+
+export const resolveReportsForCommentQuery = `
+  UPDATE comment_report
+  SET resolved_at = NOW(), resolved_by_user_id = ?
+  WHERE r_comment_id = ? AND resolved_at IS NULL
+`;
+
+// CMS list — same row shape as public, plus unresolved report count.
+const cmsCommentRowFields = `
+  c.id,
+  c.parent_id AS parentId,
+  c.r_thing_id AS thingId,
+  c.r_user_id AS userId,
+  u.login AS authorLogin,
+  c.text,
+  c.r_comment_status_id AS statusId,
+  c.created_at AS createdAt,
+  c.updated_at AS updatedAt,
+  c.status_changed_at AS statusChangedAt,
+  c.status_changed_by_user_id AS statusChangedByUserId,
+  COALESCE(SUM(CASE WHEN cv.vote = 1 THEN 1 ELSE 0 END), 0) AS likes,
+  COALESCE(SUM(CASE WHEN cv.vote = -1 THEN 1 ELSE 0 END), 0) AS dislikes,
+  (SELECT COUNT(*) FROM comment_report cr
+   WHERE cr.r_comment_id = c.id AND cr.resolved_at IS NULL) AS reportCount
+`;
+
+export const buildCmsCommentListQuery = (filters: {
+	statusId?: number;
+	scopeFilter?: 'site' | 'thing';
+	thingId?: number;
+	userId?: number;
+	onlyReported?: boolean;
+}) => {
+	const wheres: string[] = [];
+	if (filters.statusId !== undefined) wheres.push('c.r_comment_status_id = ?');
+	if (filters.scopeFilter === 'site') wheres.push('c.r_thing_id IS NULL');
+	if (filters.scopeFilter === 'thing') wheres.push('c.r_thing_id IS NOT NULL');
+	if (filters.thingId !== undefined) wheres.push('c.r_thing_id = ?');
+	if (filters.userId !== undefined) wheres.push('c.r_user_id = ?');
+	if (filters.onlyReported) wheres.push('EXISTS(SELECT 1 FROM comment_report cr WHERE cr.r_comment_id = c.id AND cr.resolved_at IS NULL)');
+
+	const where = wheres.length ? `WHERE ${wheres.join(' AND ')}` : '';
+
+	const list = `
+    SELECT ${cmsCommentRowFields}
+    FROM comment c
+    LEFT JOIN auth_user u ON u.id = c.r_user_id
+    LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+    ${where}
+    GROUP BY c.id
+    ORDER BY reportCount DESC, c.created_at DESC, c.id DESC
+    LIMIT ? OFFSET ?
+  `;
+
+	const count = `SELECT COUNT(*) AS total FROM comment c ${where}`;
+
+	return { list, count };
+};

--- a/src/plugins/comments/sanitizeCommentText.test.ts
+++ b/src/plugins/comments/sanitizeCommentText.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+	sanitizeCommentText,
+	COMMENT_MAX_LENGTH,
+} from './sanitizeCommentText.js';
+
+describe('sanitizeCommentText', () => {
+	it('rejects non-string input', () => {
+		expect(sanitizeCommentText(undefined)).toEqual({ ok: false, error: 'TEXT_INVALID' });
+		expect(sanitizeCommentText(null)).toEqual({ ok: false, error: 'TEXT_INVALID' });
+		expect(sanitizeCommentText(42)).toEqual({ ok: false, error: 'TEXT_INVALID' });
+	});
+
+	it('rejects empty / whitespace-only', () => {
+		expect(sanitizeCommentText('').error).toBe('TEXT_EMPTY');
+		expect(sanitizeCommentText('   \n\n\t').error).toBe('TEXT_EMPTY');
+	});
+
+	it('rejects too short after trim', () => {
+		expect(sanitizeCommentText('a').error).toBe('TEXT_TOO_SHORT');
+	});
+
+	it('rejects too long', () => {
+		const long = 'a'.repeat(COMMENT_MAX_LENGTH + 1);
+		expect(sanitizeCommentText(long).error).toBe('TEXT_TOO_LONG');
+	});
+
+	it('accepts valid text and trims whitespace', () => {
+		const result = sanitizeCommentText('  hello world  ');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('hello world');
+	});
+
+	it('strips control characters but keeps tab and newline', () => {
+		const result = sanitizeCommentText('hi\u0000there\u0008\nnext\tline');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('hithere\nnext\tline');
+	});
+
+	it('normalizes CRLF to LF', () => {
+		const result = sanitizeCommentText('a\r\nb\rc');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('a\nb\nc');
+	});
+
+	it('collapses runs of 3+ blank lines to a double break', () => {
+		const result = sanitizeCommentText('a\n\n\n\n\nb');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('a\n\nb');
+	});
+
+	it('strips trailing whitespace per line', () => {
+		const result = sanitizeCommentText('alpha   \nbeta\t\ngamma');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('alpha\nbeta\ngamma');
+	});
+
+	it('NFC-normalizes Unicode (composed forms compare equal)', () => {
+		const decomposed = 'cafe\u0301';
+		const composed = 'caf\u00e9';
+		const a = sanitizeCommentText(decomposed);
+		const b = sanitizeCommentText(composed);
+		expect(a.ok && b.ok).toBe(true);
+		if (a.ok && b.ok) expect(a.text).toBe(b.text);
+	});
+
+	it('rejects flooding (single char repeated 50+ times)', () => {
+		const flood = 'spam' + 'a'.repeat(50);
+		expect(sanitizeCommentText(flood).error).toBe('TEXT_FLOOD');
+	});
+
+	it('preserves Cyrillic and emoji', () => {
+		const result = sanitizeCommentText('Это тест 🎭');
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.text).toBe('Это тест 🎭');
+	});
+});

--- a/src/plugins/comments/sanitizeCommentText.ts
+++ b/src/plugins/comments/sanitizeCommentText.ts
@@ -1,0 +1,25 @@
+export const COMMENT_MIN_LENGTH = 2;
+export const COMMENT_MAX_LENGTH = 4000;
+
+export type SanitizeResult =
+	| { ok: true; text: string }
+	| { ok: false; error: 'TEXT_INVALID' | 'TEXT_EMPTY' | 'TEXT_TOO_SHORT' | 'TEXT_TOO_LONG' | 'TEXT_FLOOD' };
+
+export const sanitizeCommentText = (input: unknown): SanitizeResult => {
+	if (typeof input !== 'string') return { ok: false, error: 'TEXT_INVALID' };
+
+	let t = input.normalize('NFC');
+	t = t.replace(/\r\n?/g, '\n');
+	t = t.replace(/[\u0000-\u0008\u000B-\u001F\u007F]/g, '');
+	t = t.replace(/\n{3,}/g, '\n\n');
+	t = t.replace(/[ \t]+\n/g, '\n').replace(/[ \t]+$/g, '');
+	t = t.trim();
+
+	if (t.length === 0) return { ok: false, error: 'TEXT_EMPTY' };
+	if (t.length < COMMENT_MIN_LENGTH) return { ok: false, error: 'TEXT_TOO_SHORT' };
+	if (t.length > COMMENT_MAX_LENGTH) return { ok: false, error: 'TEXT_TOO_LONG' };
+
+	if (/(.)\1{49,}/u.test(t)) return { ok: false, error: 'TEXT_FLOOD' };
+
+	return { ok: true, text: t };
+};

--- a/src/plugins/comments/schemas.ts
+++ b/src/plugins/comments/schemas.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+import { COMMENT_MAX_LENGTH, COMMENT_MIN_LENGTH } from './sanitizeCommentText.js';
+
+export const COMMENT_STATUS = {
+	visible: 1,
+	hidden: 2,
+	deleted: 3,
+} as const;
+
+export const COMMENT_EDIT_WINDOW_MS = 15 * 60 * 1000;
+
+const commentParams = z.object({
+	commentId: z.coerce.number().int().positive(),
+});
+
+const commentVotes = z.object({
+	likes: z.number().int().min(0),
+	dislikes: z.number().int().min(0),
+});
+
+const commentBaseSchema = z.object({
+	id: z.number().int().positive(),
+	parentId: z.number().int().positive().nullable(),
+	thingId: z.number().int().positive().nullable(),
+	userId: z.number().int().positive().nullable(),
+	authorLogin: z.string().nullable(),
+	text: z.string().nullable(),
+	statusId: z.number().int().min(1).max(3),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	votes: commentVotes,
+	userVote: z.optional(z.number().int().min(-1).max(1)),
+});
+
+const commentWithRepliesSchema = commentBaseSchema.extend({
+	replies: z.optional(z.array(commentBaseSchema)),
+});
+
+const commentListQuery = z.object({
+	thingId: z.optional(z.coerce.number().int().positive()),
+	scope: z.optional(z.enum(['site', 'thing'])),
+	limit: z.optional(z.coerce.number().int().min(1).max(100)),
+	offset: z.optional(z.coerce.number().int().min(0)),
+});
+
+const commentListResponse = z.object({
+	items: z.array(commentWithRepliesSchema),
+	total: z.number().int().min(0),
+	hasMore: z.boolean(),
+});
+
+const createCommentRequest = z.object({
+	thingId: z.optional(z.number().int().positive().nullable()),
+	parentId: z.optional(z.number().int().positive().nullable()),
+	text: z.string().min(COMMENT_MIN_LENGTH).max(COMMENT_MAX_LENGTH),
+});
+
+const updateCommentRequest = z.object({
+	text: z.string().min(COMMENT_MIN_LENGTH).max(COMMENT_MAX_LENGTH),
+});
+
+const voteCommentRequest = z.object({
+	vote: z.number().int().min(-1).max(1),
+});
+
+const voteCommentResponse = commentVotes.extend({
+	userVote: z.number().int().min(-1).max(1),
+});
+
+const reportCommentRequest = z.object({
+	reason: z.optional(z.string().max(500)),
+});
+
+const cmsCommentListQuery = z.object({
+	status: z.optional(z.enum(['visible', 'hidden', 'deleted', 'reported'])),
+	thingId: z.optional(z.coerce.number().int().positive()),
+	userId: z.optional(z.coerce.number().int().positive()),
+	scope: z.optional(z.enum(['site', 'thing'])),
+	limit: z.optional(z.coerce.number().int().min(1).max(100)),
+	offset: z.optional(z.coerce.number().int().min(0)),
+});
+
+const cmsCommentRow = commentBaseSchema.extend({
+	reportCount: z.number().int().min(0),
+	statusChangedAt: z.string(),
+	statusChangedByUserId: z.number().int().positive().nullable(),
+});
+
+const cmsCommentListResponse = z.object({
+	items: z.array(cmsCommentRow),
+	total: z.number().int().min(0),
+	hasMore: z.boolean(),
+});
+
+const okResponse = z.object({ ok: z.literal(true) });
+
+export {
+	commentParams,
+	commentBaseSchema,
+	commentWithRepliesSchema,
+	commentListQuery,
+	commentListResponse,
+	createCommentRequest,
+	updateCommentRequest,
+	voteCommentRequest,
+	voteCommentResponse,
+	reportCommentRequest,
+	cmsCommentListQuery,
+	cmsCommentListResponse,
+	okResponse,
+};
+
+export type CommentParams = z.infer<typeof commentParams>;
+export type CommentBase = z.infer<typeof commentBaseSchema>;
+export type CommentWithReplies = z.infer<typeof commentWithRepliesSchema>;
+export type CommentListQuery = z.infer<typeof commentListQuery>;
+export type CreateCommentRequest = z.infer<typeof createCommentRequest>;
+export type UpdateCommentRequest = z.infer<typeof updateCommentRequest>;
+export type VoteCommentRequest = z.infer<typeof voteCommentRequest>;
+export type ReportCommentRequest = z.infer<typeof reportCommentRequest>;
+export type CmsCommentListQuery = z.infer<typeof cmsCommentListQuery>;

--- a/src/plugins/users/users.test.ts
+++ b/src/plugins/users/users.test.ts
@@ -51,7 +51,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async () =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true, canEditContent: false, canEditUsers: false } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote: true, canComment: true, canEditContent: false, canEditUsers: false } }, secret);
 
 describe('PATCH /users/:id/password', () => {
 	it('returns 401 without auth token', async () => {

--- a/src/plugins/votes/votes.test.ts
+++ b/src/plugins/votes/votes.test.ts
@@ -43,7 +43,7 @@ async function buildApp(mysql: MySQLPromisePool) {
 }
 
 const getToken = async (canVote = true) =>
-	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote, canEditContent: false, canEditUsers: false } }, secret);
+	signAccessToken({ sub: 1, login: 'testuser', isAdmin: false, isEditor: false, tokenVersion: 0, rights: { canVote, canComment: true, canEditContent: false, canEditUsers: false } }, secret);
 
 describe('PUT /things/:thingId/vote', () => {
 	it('returns 401 without auth token', async () => {


### PR DESCRIPTION
## Summary
- Adds `/comments` plugin: site-wide guestbook (`r_thing_id IS NULL`) and per-thing comments in one schema, with one-level threading and post-moderation.
- Adds `/cms/comments` moderation routes (gated by editor + `canEditContent`).
- Exposes `canComment` (bit 4) on `ResolvedRights` in the JWT — fixture updates across auth/votes/cms/users tests.
- Adds `commentReplyEmail` (to parent author on reply) and `commentReportedEmail` (to admin on report) templates.
- Adds `@fastify/rate-limit` (in-memory, IP-keyed, per-route opt-in via `config.rateLimit`). Used on `POST /comments`, `PUT /vote`, `POST /report`.
- Sanitization (`sanitizeCommentText.ts`): NFC normalize → CRLF→LF → strip control chars → collapse blanks → length 2–4000 → flood reject. Plain-text only on the wire.
- Tombstone rule: removed comments are returned only when they have at least one direct visible child; text/author/votes are masked. One-level threading bounds the check.
- Reply email deep-link: `<origin>/sections/<id>/<pos>?thread=<parentId>` (no trailing slash, matching nextjs routing) or `<origin>/guestbook?thread=<parentId>`.
- 28 new tests; 161 passing total.

Depends on: www.mellonis.ru#41 (schema) — must deploy first.
Followed by: poetry-nextjs PR for the UI (separate, after this merges).

## Test plan
- [ ] CI green (lint + tests)
- [ ] After www#41 deploys + the migration is applied on the VPS, redeploy api
- [ ] Smoke test: `./smoke-test.sh https://api.poetry.mellonis.ru` — exercises 11b-comments.sh (post/vote/edit/delete/report/CMS gate)
- [ ] `./smoke-test-v1.sh` confirms public reads (guestbook, per-thing, conflicting-params 400)