### PR TITLE
CMS: add thingTitle + thingFirstLines to comment list rows

### DIFF
--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -378,6 +378,8 @@ export const listCommentsForCms = async (
 				id: r.id as number,
 				parentId: r.parentId as number | null,
 				thingId: r.thingId as number | null,
+				thingTitle: (r.thingTitle as string | null) ?? null,
+				thingFirstLines: (r.thingFirstLines as string | null) ?? null,
 				userId: r.userId as number | null,
 				authorLogin: r.authorLogin as string | null,
 				text: r.text as string,

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -176,6 +176,8 @@ const cmsCommentRowFields = `
   c.id,
   c.parent_id AS parentId,
   c.r_thing_id AS thingId,
+  t.title AS thingTitle,
+  t.first_lines AS thingFirstLines,
   c.r_user_id AS userId,
   u.login AS authorLogin,
   c.text,
@@ -212,6 +214,7 @@ export const buildCmsCommentListQuery = (filters: {
     FROM comment c
     LEFT JOIN auth_user u ON u.id = c.r_user_id
     LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
+    LEFT JOIN thing t ON t.id = c.r_thing_id
     ${where}
     GROUP BY c.id
     ORDER BY reportCount DESC, c.created_at DESC, c.id DESC

--- a/src/plugins/comments/schemas.ts
+++ b/src/plugins/comments/schemas.ts
@@ -85,6 +85,8 @@ const cmsCommentRow = commentBaseSchema.extend({
 	reportCount: z.number().int().min(0),
 	statusChangedAt: z.string(),
 	statusChangedByUserId: z.number().int().positive().nullable(),
+	thingTitle: z.string().nullable(),
+	thingFirstLines: z.string().nullable(),
 });
 
 const cmsCommentListResponse = z.object({


### PR DESCRIPTION
Lets nextjs CMS show actual thing titles/first-lines instead of `#530`. One JOIN, two columns, backwards-compatible.