### PR TITLE
Comments: edit rate-limit + CORS Retry-After + editor allowList

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,21 @@ fastify.register(cors, {
 	origin: allowedOrigins,
 	methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
 	allowedHeaders: ['Content-Type', 'Authorization'],
+	// Expose Retry-After so the browser lets JS read it on 429 responses
+	// (clients use it for the rate-limit countdown UI). X-Request-Id is
+	// already set by us for tracing — exposing it lets clients echo it back.
+	exposedHeaders: ['Retry-After', 'X-Request-Id'],
 	credentials: true,
 });
 // Global rate limit is opt-in per route via `config: { rateLimit }`.
 // Keyed by IP — the rate-limit hook runs before verifyJwt, so request.user
 // is not yet populated; auth-gated routes still get the auth check on top.
 // errorResponseBuilder localizes the 429 body for our (Russian) clients.
+//
+// `skip` decodes the JWT to bypass rate-limiting for editors/admins. Decode
+// only — signature is NOT verified here (verifyJwt does that later). A forged
+// "isEditor: true" token would still fail verifyJwt and never reach the
+// handler, so the skip is safe to base on the unverified payload.
 fastify.register(rateLimit, {
 	global: false,
 	errorResponseBuilder: (_req, ctx) => ({
@@ -54,6 +63,26 @@ fastify.register(rateLimit, {
 		error: 'rate_limited',
 		message: `Слишком часто. Попробуйте через ${Math.ceil(ctx.ttl / 1000)} с.`,
 	}),
+	allowList: (request) => {
+		const auth = request.headers.authorization;
+
+		if (!auth?.startsWith('Bearer ')) return false;
+
+		try {
+			const part = auth.substring(7).split('.')[1];
+
+			if (!part) return false;
+
+			const payload = JSON.parse(Buffer.from(part, 'base64url').toString('utf8')) as {
+				isEditor?: boolean;
+				isAdmin?: boolean;
+			};
+
+			return payload.isEditor === true || payload.isAdmin === true;
+		} catch {
+			return false;
+		}
+	},
 });
 fastify.register(databasePlugin);
 fastify.register(searchPlugin);

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -47,6 +47,7 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
 const POST_RATE_LIMIT = { max: 1, timeWindow: '30 seconds' };
+const EDIT_RATE_LIMIT = { max: 10, timeWindow: '1 minute' };
 const VOTE_RATE_LIMIT = { max: 5, timeWindow: '1 minute' };
 const REPORT_RATE_LIMIT = { max: 1, timeWindow: '5 minutes' };
 
@@ -212,6 +213,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				500: errorResponse,
 			},
 		},
+		config: { rateLimit: EDIT_RATE_LIMIT },
 		preHandler: fastify.verifyJwt,
 		handler: async (request: FastifyRequest<{ Params: CommentParams; Body: UpdateCommentRequest }>, reply) => {
 			const userId = request.user!.sub;


### PR DESCRIPTION
## Summary
- **PUT /comments/:id (edit)** rate-limited at 10/min. Generous for legitimate typo-fix workflow, bounds the spam-edit ceiling.
- **CORS** now exposes `Retry-After` and `X-Request-Id`. Without these, the browser hides them from JS and the nextjs countdown UI can't read seconds-to-retry from 429 responses.
- **`@fastify/rate-limit` allowList** decodes the JWT and bypasses limits for `isEditor` / `isAdmin`. Decode only — signature is verified later in `verifyJwt`, so a forged \`isEditor: true\` token still fails before reaching any handler.

Three concrete changes, two files, 31 lines added.

## Test plan
- [ ] CI green
- [ ] After deploy: as a regular user, post comments rapidly → see localized 429 with the live countdown ticking down (depends on poetry-nextjs#73 also being deployed)
- [ ] As editor: rapid posts succeed (no 429)