### PR TITLE
Votes: batch GET + unified {likes,dislikes,userVote} shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port ov
 Fastify app using a plugin-based structure under `src/plugins/`:
 
 - **`database/`** — registers the MySQL connection pool on the Fastify instance via `@fastify/mysql`
-- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `requireRight`) visible to all plugins
+- **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `optionalVerifyJwt`, `requireRight`) visible to all plugins
   - `authRoutes.ts` — routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Sends `ADMIN_NOTIFY_EMAIL` on new registration
   - Pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`
   - `passkey/` — WebAuthn passkey routes (`/auth/passkey/*` for registration/login, `/auth/passkeys` for listing/deleting). RP ID configurable via `WEBAUTHN_RP_ID` env var
@@ -68,11 +68,11 @@ Fastify app using a plugin-based structure under `src/plugins/`:
 - **`sections/`** — routes prefixed `/sections`
 - **`thingsOfTheDay/`** — routes prefixed `/things-of-the-day`
 - **`users/`** — routes prefixed `/users` (change password, delete account). Sends `ADMIN_NOTIFY_EMAIL` on account deletion
-- **`votes/`** — routes prefixed `/things` for voting (`GET/PUT /:thingId/vote`)
-  - Requires auth + `canVote` right. Body `{ vote: 'like' | 'dislike' | null }` — `null` removes the vote
-  - Returns updated `{ plus, minus }` counts
-  - Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title)
-  - On the wire, vote values are strings; the DB column stays `tinyint(-1, 0, 1)`. Translation lives in `lib/voteValue.ts` (`voteValueToDb` / `dbToVoteValue`). `userVote` fields in any GET response that includes them (thing schema, comment list/single) follow the same enum
+- **`votes/`** — routes prefixed `/things` for voting
+  - `PUT /:thingId/vote` — `verifyJwt` + `canVote`. Body `{ vote: 'like' | 'dislike' | null }` — `null` removes the vote. Returns the updated `{ likes, dislikes, userVote }` summary (same shape as the batch GET and comment-vote endpoints). Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title).
+  - `GET /votes?thingIds=…` or `?sectionId=…` — `optionalVerifyJwt`. Batch summaries keyed by thingId-as-string: `{ "1": { likes, dislikes, userVote }, ... }`. Anonymous → `userVote: null`. Schema enforces *exactly one* of `thingIds` (1..100 unique positive int ids, comma-separated) or `sectionId` (`section.identifier`, max 64 chars, `[A-Za-z0-9_-]`). `thingIds` mode pre-fills zero summaries for ids with no vote rows so callers get a stable shape. `sectionId` mode joins `v_things_info` to cover every thing in the section (zero-filled for unvoted) and avoids client-side chunking on big `/sections/[id]/all` pages. Vote totals are global (a thing's votes don't change by section).
+  - Auth is per-route (`preHandler`), not a plugin-wide `addHook` — the GET needs to coexist with the auth-required PUT. If you add another route here, attach the appropriate preHandler explicitly.
+  - On the wire, vote values are strings; the DB column stays `tinyint(-1, 0, 1)`. Translation lives in `lib/voteValue.ts` (`voteValueToDb` / `dbToVoteValue`). The shared `voteSummarySchema` (`{ likes, dislikes, userVote }`) is also exported from `lib/voteValue.ts` and reused by both the thing-vote and comment-vote plugins so the wire shape stays in lockstep across the API. `userVote` fields in any GET response that includes them (thing schema, comment list/single, batch votes summary) follow the same enum.
 - **`author/`** — routes prefixed `/author`. `GET /` returns author biography text, date, and optional SEO fields. Sourced from `news` table (id=1). No auth required
 - **`comments/`** — routes prefixed `/comments`. Unified site-wide guestbook + per-thing comments in one table; `r_thing_id IS NULL` rows are guestbook entries. One-level threading (a reply's parent must itself be top-level). Post-moderation: new comments default to `Visible` (status 1). Status set: 1=Visible, 2=Hidden (mod-removed), 3=Deleted (self- or admin-removed)
   - Public: `GET /` (paginated by top-level + replies inline; `optionalVerifyJwt` enriches rows with `userVote`), `GET /:commentId` (top-level rows return `replies: []` bundled in for single-thread view; reply rows are returned bare since one-level threading bounds depth), `POST /` (auth + `canComment` bit 4 + rate-limit 1/30s; reply path also fires `commentReplyEmail` to the parent author when the parent is a different, non-banned user), `PUT /:commentId` (own + 15-min edit window), `DELETE /:commentId` (own → status=Deleted), `PUT /:commentId/vote` (auth + `canVote` + rate-limit 5/min, body `{ vote: 'like' | 'dislike' | null }` — `null` removes the vote; self-vote allowed), `POST /:commentId/report` (auth + rate-limit 1/5min, sends `ADMIN_NOTIFY_EMAIL`)

--- a/api.http
+++ b/api.http
@@ -370,6 +370,16 @@ Authorization: Bearer {{login.response.body.accessToken}}
   "vote": null
 }
 
+### Batch vote summaries by ids (anonymous OK; userVote: null when not signed in)
+GET {{host}}/things/votes?thingIds=1,2,3
+
+### Batch vote summaries by ids — authenticated (userVote enriched)
+GET {{host}}/things/votes?thingIds=1,2,3
+Authorization: Bearer {{login.response.body.accessToken}}
+
+### Batch vote summaries for every thing in a section (covers unvoted with zero counts)
+GET {{host}}/things/votes?sectionId=nnils
+
 ### ---- Comments ----
 
 ### List comments for a thing (public; auth optional for userVote)

--- a/smoke-tests/11-voting.sh
+++ b/smoke-tests/11-voting.sh
@@ -2,9 +2,25 @@
 bold ""
 bold "11. Voting"
 
+# Public batch summary endpoint — exercised even without a token
+parse_response "$(request GET "/things/votes?thingIds=1,2,3")"
+assert_status "GET /things/votes?thingIds=… (anonymous)" 200 "$RESPONSE_STATUS"
+
+# Mutually-exclusive query: providing both must be rejected
+parse_response "$(request GET "/things/votes?thingIds=1&sectionId=nnils")"
+assert_status "GET /things/votes (both params rejected)" 400 "$RESPONSE_STATUS"
+
+# Neither param is also rejected
+parse_response "$(request GET "/things/votes")"
+assert_status "GET /things/votes (no params rejected)" 400 "$RESPONSE_STATUS"
+
 if [ -n "$ACCESS_TOKEN" ]; then
     parse_response "$(request PUT /things/1/vote "{\"vote\":\"like\"}" "$ACCESS_TOKEN")"
     assert_status "PUT /things/1/vote (like)" 200 "$RESPONSE_STATUS"
+
+    # Authenticated batch fetch should now reflect the like
+    parse_response "$(request GET "/things/votes?thingIds=1" "" "$ACCESS_TOKEN")"
+    assert_status "GET /things/votes?thingIds=1 (authenticated)" 200 "$RESPONSE_STATUS"
 
     parse_response "$(request PUT /things/1/vote "{\"vote\":\"dislike\"}" "$ACCESS_TOKEN")"
     assert_status "PUT /things/1/vote (dislike)" 200 "$RESPONSE_STATUS"
@@ -13,5 +29,5 @@ if [ -n "$ACCESS_TOKEN" ]; then
     assert_status "PUT /things/1/vote (remove)" 200 "$RESPONSE_STATUS"
 else
     red "  SKIP  Voting (no access token)"
-    FAIL=$((FAIL + 3))
+    FAIL=$((FAIL + 4))
 fi

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -45,6 +45,6 @@ export const mapThingBaseRow = (row: MySQLRowDataPacket) => ({
 	seoKeywords: row.seoKeywords ?? undefined as string | undefined,
 	info: parseJSON(row.info) as ThingBase['info'],
 	notes: parseJSON(row.notes) as ThingBase['notes'],
-	votes: { plus: row.votesPlus as number, minus: row.votesMinus as number },
+	votes: { likes: row.votesLikes as number, dislikes: row.votesDislikes as number },
 	...(row.userVote !== undefined && { userVote: dbToVoteValue(row.userVote as number | null) }),
 });

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -13,8 +13,8 @@ export const thingFields = `
 	(SELECT CONCAT('[', GROUP_CONCAT(JSON_QUOTE(text) ORDER BY \`order\`, id SEPARATOR ','), ']')
 	 FROM thing_note
 	 WHERE r_thing_id = thing_id)   AS notes,
-	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote > 0) AS votesPlus,
-	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote < 0) AS votesMinus
+	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote > 0) AS votesLikes,
+	(SELECT COUNT(*) FROM vote WHERE r_thing_id = thing_id AND vote < 0) AS votesDislikes
 `;
 
 export const userVoteField = `

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -32,8 +32,8 @@ export const thingSchema = z.object({
 		})),
 	})),
 	votes: z.object({
-		plus: z.number().int().min(0),
-		minus: z.number().int().min(0),
+		likes: z.number().int().min(0),
+		dislikes: z.number().int().min(0),
 	}),
 	userVote: z.optional(voteValueSchema),
 });

--- a/src/lib/voteValue.ts
+++ b/src/lib/voteValue.ts
@@ -5,6 +5,16 @@ import { z } from 'zod';
 export const voteValueSchema = z.enum(['like', 'dislike']).nullable();
 export type VoteValue = z.infer<typeof voteValueSchema>;
 
+// Shared response shape for vote endpoints (thing votes + comment votes).
+// Centralized so the two domains stay in lockstep — adding a field here
+// updates both at once.
+export const voteSummarySchema = z.object({
+	likes: z.number().int().min(0),
+	dislikes: z.number().int().min(0),
+	userVote: voteValueSchema,
+});
+export type VoteSummary = z.infer<typeof voteSummarySchema>;
+
 export const voteValueToDb = (v: VoteValue): -1 | 0 | 1 => {
 	if (v === 'like') return 1;
 	if (v === 'dislike') return -1;

--- a/src/plugins/sections/sections.test.ts
+++ b/src/plugins/sections/sections.test.ts
@@ -60,8 +60,8 @@ const thingRow = {
 	seoKeywords: null,
 	info: null,
 	notes: null,
-	votesPlus: 0,
-	votesMinus: 0,
+	votesLikes: 0,
+	votesDislikes: 0,
 };
 
 function createQueryFailingMysql(firstQueryResult: Record<string, unknown>[], error = new Error('DB error')): MySQLPromisePool {
@@ -191,7 +191,7 @@ describe('GET /sections/:id', () => {
 			firstLines: ['First line', 'Second line'],
 			finishDate: '2024-01-01',
 			text: 'Full poem text',
-			votes: { plus: 0, minus: 0 },
+			votes: { likes: 0, dislikes: 0 },
 		}]);
 	});
 

--- a/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
+++ b/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
@@ -46,8 +46,8 @@ const thingRow = {
 	seoKeywords: null,
 	info: null,
 	notes: null,
-	votesPlus: 0,
-	votesMinus: 0,
+	votesLikes: 0,
+	votesDislikes: 0,
 	sectionId: 'poetry',
 	position: 3,
 };
@@ -65,7 +65,7 @@ describe('GET /things-of-the-day', () => {
 			firstLines: ['First line', 'Second line'],
 			finishDate: '2024-01-01',
 			text: 'Full poem text',
-			votes: { plus: 0, minus: 0 },
+			votes: { likes: 0, dislikes: 0 },
 			sections: [{ id: 'poetry', position: 3 }],
 		}]);
 	});

--- a/src/plugins/votes/databaseHelpers.ts
+++ b/src/plugins/votes/databaseHelpers.ts
@@ -1,7 +1,15 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
 import { withConnection } from '../../lib/databaseHelpers.js';
 import { thingDisplayTitle } from '../../lib/mappers.js';
-import { upsertVoteQuery, deleteVoteQuery, voteCountsQuery, thingTitleQuery } from './queries.js';
+import { dbToVoteValue } from '../../lib/voteValue.js';
+import type { VoteSummary } from '../../lib/voteValue.js';
+import {
+	upsertVoteQuery,
+	deleteVoteQuery,
+	voteSummariesQuery,
+	voteSummariesBySectionQuery,
+	thingTitleQuery,
+} from './queries.js';
 
 export const upsertVote = async (mysql: MySQLPromisePool, thingId: number, userId: number, vote: number): Promise<void> => {
 	await withConnection(mysql, async (connection) => {
@@ -15,16 +23,72 @@ export const deleteVote = async (mysql: MySQLPromisePool, thingId: number, userI
 	});
 };
 
-export interface VoteCounts {
-	plus: number;
-	minus: number;
-}
+export const getVoteSummaries = async (
+	mysql: MySQLPromisePool,
+	thingIds: number[],
+	userId: number,
+): Promise<Record<string, VoteSummary>> => {
+	if (thingIds.length === 0) return {};
 
-export const getVoteCounts = async (mysql: MySQLPromisePool, thingId: number): Promise<VoteCounts> =>
-	withConnection(mysql, async (connection) => {
-		const [rows] = await connection.query<MySQLRowDataPacket[]>(voteCountsQuery, [thingId]);
-		return { plus: rows[0].plus as number, minus: rows[0].minus as number };
+	return withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(
+			voteSummariesQuery(thingIds.length),
+			[userId, ...thingIds],
+		);
+
+		// Pre-fill every requested id so callers get a stable shape even for
+		// things with zero votes.
+		const result: Record<string, VoteSummary> = {};
+		for (const id of thingIds) {
+			result[String(id)] = { likes: 0, dislikes: 0, userVote: null };
+		}
+
+		for (const row of rows) {
+			result[String(row.thingId as number)] = {
+				likes: Number(row.likes ?? 0),
+				dislikes: Number(row.dislikes ?? 0),
+				userVote: dbToVoteValue(Number(row.userVote ?? 0)),
+			};
+		}
+
+		return result;
 	});
+};
+
+// Single-thing summary — wraps the batch helper so the PUT route gets the
+// same `{ likes, dislikes, userVote }` shape callers expect, in one DB query.
+export const getVoteSummary = async (
+	mysql: MySQLPromisePool,
+	thingId: number,
+	userId: number,
+): Promise<VoteSummary> => {
+	const map = await getVoteSummaries(mysql, [thingId], userId);
+	return map[String(thingId)];
+};
+
+export const getVoteSummariesBySection = async (
+	mysql: MySQLPromisePool,
+	sectionId: string,
+	userId: number,
+): Promise<Record<string, VoteSummary>> => {
+	return withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(
+			voteSummariesBySectionQuery,
+			[userId, sectionId],
+		);
+
+		const result: Record<string, VoteSummary> = {};
+		for (const row of rows) {
+			result[String(row.thingId as number)] = {
+				likes: Number(row.likes ?? 0),
+				dislikes: Number(row.dislikes ?? 0),
+				userVote: dbToVoteValue(Number(row.userVote ?? 0)),
+			};
+		}
+
+		return result;
+	});
+};
 
 export const getThingTitle = async (mysql: MySQLPromisePool, thingId: number): Promise<string> =>
 	withConnection(mysql, async (connection) => {

--- a/src/plugins/votes/queries.ts
+++ b/src/plugins/votes/queries.ts
@@ -13,10 +13,35 @@ export const thingTitleQuery = `
 	SELECT title, first_lines AS firstLines FROM thing WHERE id = ?
 `;
 
-export const voteCountsQuery = `
+// Aggregate counts per thing in a single round-trip. The IN-list size is
+// validated/capped at the schema layer (max 100). Anonymous users pass
+// `userId = 0` — that never matches a real auth_user.id (auto-increment
+// starts at 1), so userVote stays 0 → null on the wire.
+export const voteSummariesQuery = (idCount: number) => `
 	SELECT
-		COUNT(CASE WHEN vote > 0 THEN 1 END) AS plus,
-		COUNT(CASE WHEN vote < 0 THEN 1 END) AS minus
+		r_thing_id AS thingId,
+		COUNT(CASE WHEN vote > 0 THEN 1 END) AS likes,
+		COUNT(CASE WHEN vote < 0 THEN 1 END) AS dislikes,
+		COALESCE(SUM(CASE WHEN r_user_id = ? THEN vote ELSE 0 END), 0) AS userVote
 	FROM vote
-	WHERE r_thing_id = ?
+	WHERE r_thing_id IN (${Array(idCount).fill('?').join(',')})
+	GROUP BY r_thing_id
+`;
+
+// All things in a section + their global vote summaries (a thing's votes are
+// global, not section-scoped). LEFT JOIN keeps things with zero votes;
+// anonymous users pass `userId = 0` (no real auth_user.id matches → userVote
+// stays 0 → null on the wire). Uses `v_things_info` to inherit the same
+// canonical-thing filtering the public sections endpoints already use
+// (handles redirect rows etc.).
+export const voteSummariesBySectionQuery = `
+	SELECT
+		ti.thing_id AS thingId,
+		COUNT(CASE WHEN v.vote > 0 THEN 1 END) AS likes,
+		COUNT(CASE WHEN v.vote < 0 THEN 1 END) AS dislikes,
+		COALESCE(SUM(CASE WHEN v.r_user_id = ? THEN v.vote ELSE 0 END), 0) AS userVote
+	FROM v_things_info ti
+	LEFT JOIN vote v ON v.r_thing_id = ti.thing_id
+	WHERE ti.section_identifier = ?
+	GROUP BY ti.thing_id
 `;

--- a/src/plugins/votes/schemas.ts
+++ b/src/plugins/votes/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { voteValueSchema } from '../../lib/voteValue.js';
+import { voteSummarySchema, voteValueSchema } from '../../lib/voteValue.js';
 
 export const voteParams = z.object({
 	thingId: z.coerce.number().int().positive(),
@@ -9,10 +9,58 @@ export const voteRequest = z.object({
 	vote: voteValueSchema,
 });
 
-export const voteCountsResponse = z.object({
-	plus: z.number().int().min(0),
-	minus: z.number().int().min(0),
-});
+// PUT response mirrors the comment-vote PUT shape — same `{ likes, dislikes,
+// userVote }` everywhere across the API.
+export const voteSummaryResponse = voteSummarySchema;
+
+// `thingIds` is a comma-separated list of positive integers; capped to keep
+// the IN-clause bounded. Larger sections should query by `sectionId` instead.
+const thingIdsField = z
+	.string()
+	.transform((v, ctx) => {
+		const parts = v.split(',').map((s) => s.trim()).filter(Boolean);
+		if (parts.length === 0 || parts.length > 100) {
+			ctx.addIssue({ code: 'custom', message: 'thingIds must contain 1..100 entries' });
+			return z.NEVER;
+		}
+		const out = new Set<number>();
+		for (const p of parts) {
+			const n = Number(p);
+			if (!Number.isInteger(n) || n <= 0) {
+				ctx.addIssue({ code: 'custom', message: 'thingIds must be positive integers' });
+				return z.NEVER;
+			}
+			out.add(n);
+		}
+		return Array.from(out);
+	});
+
+// `sectionId` is the public string identifier (`section.identifier`, e.g.
+// `nnils`). Same character set the URL accepts; loose enough to cover legacy
+// section slugs.
+const sectionIdField = z.string().min(1).max(64).regex(/^[A-Za-z0-9_-]+$/);
+
+// Caller must provide exactly one of `thingIds` or `sectionId`.
+// thingIds → batch by id; sectionId → all things in that section,
+// zero-filled for unvoted ones.
+export const voteListQuery = z
+	.object({
+		thingIds: thingIdsField.optional(),
+		sectionId: sectionIdField.optional(),
+	})
+	.superRefine((val, ctx) => {
+		const hasIds = val.thingIds !== undefined;
+		const hasSection = val.sectionId !== undefined;
+		if (hasIds === hasSection) {
+			ctx.addIssue({ code: 'custom', message: 'Provide exactly one of `thingIds` (up to 100) or `sectionId`' });
+		}
+	});
+
+// Map keyed by thingId-as-string (JSON object keys are always strings on the
+// wire). Clients re-key on number when consuming.
+export const voteListResponse = z.record(z.string(), voteSummarySchema);
 
 export type VoteParams = z.infer<typeof voteParams>;
 export type VoteRequest = z.infer<typeof voteRequest>;
+export type VoteListQuery = z.infer<typeof voteListQuery>;
+export type { VoteSummary } from '../../lib/voteValue.js';

--- a/src/plugins/votes/votes.test.ts
+++ b/src/plugins/votes/votes.test.ts
@@ -72,8 +72,10 @@ describe('PUT /things/:thingId/vote', () => {
 		expect(response.statusCode).toBe(403);
 	});
 
-	it('records a vote and returns updated counts', async () => {
-		const app = await buildApp(createMockMysql([], [{ plus: 3, minus: 1 }]));
+	it('records a vote and returns the updated summary', async () => {
+		// First mock response: upsertVote (no rows). Second: getVoteSummary
+		// (which runs voteSummariesQuery internally).
+		const app = await buildApp(createMockMysql([], [{ thingId: 1, likes: 3, dislikes: 1, userVote: 1 }]));
 		const token = await getToken();
 
 		const response = await app.inject({
@@ -84,7 +86,7 @@ describe('PUT /things/:thingId/vote', () => {
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual({ plus: 3, minus: 1 });
+		expect(response.json()).toEqual({ likes: 3, dislikes: 1, userVote: 'like' });
 	});
 
 	it('rejects invalid vote values', async () => {
@@ -101,8 +103,9 @@ describe('PUT /things/:thingId/vote', () => {
 		expect(response.statusCode).toBe(400);
 	});
 
-	it('removes vote when vote is null and returns updated counts', async () => {
-		const app = await buildApp(createMockMysql([], [{ plus: 2, minus: 0 }]));
+	it('removes vote when vote is null and returns the updated summary', async () => {
+		// deleteVote (no rows), then getVoteSummary returning userVote=0 → null.
+		const app = await buildApp(createMockMysql([], [{ thingId: 1, likes: 2, dislikes: 0, userVote: 0 }]));
 		const token = await getToken();
 
 		const response = await app.inject({
@@ -113,6 +116,133 @@ describe('PUT /things/:thingId/vote', () => {
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual({ plus: 2, minus: 0 });
+		expect(response.json()).toEqual({ likes: 2, dislikes: 0, userVote: null });
+	});
+});
+
+describe('GET /things/votes', () => {
+	it('returns summaries for anonymous callers with userVote: null', async () => {
+		const app = await buildApp(createMockMysql([
+			{ thingId: 1, likes: '4', dislikes: '1', userVote: 0 },
+			{ thingId: 2, likes: '0', dislikes: '2', userVote: 0 },
+		]));
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?thingIds=1,2,3',
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			1: { likes: 4, dislikes: 1, userVote: null },
+			2: { likes: 0, dislikes: 2, userVote: null },
+			// 3 has no vote rows — pre-filled zero summary.
+			3: { likes: 0, dislikes: 0, userVote: null },
+		});
+	});
+
+	it('returns userVote for authenticated callers', async () => {
+		const app = await buildApp(createMockMysql([
+			{ thingId: 7, likes: '5', dislikes: '0', userVote: 1 },
+		]));
+		const token = await getToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?thingIds=7',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			7: { likes: 5, dislikes: 0, userVote: 'like' },
+		});
+	});
+
+	it('rejects an empty ids list', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?thingIds=',
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects non-integer ids', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?thingIds=1,abc,3',
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('caps the ids list at 100 entries', async () => {
+		const app = await buildApp(createMockMysql());
+		const ids = Array.from({ length: 101 }, (_, i) => i + 1).join(',');
+
+		const response = await app.inject({
+			method: 'GET',
+			url: `/things/votes?thingIds=${ids}`,
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('returns summaries for every thing in a section by sectionId', async () => {
+		const app = await buildApp(createMockMysql([
+			{ thingId: 11, likes: '2', dislikes: '1', userVote: 0 },
+			{ thingId: 12, likes: '0', dislikes: '0', userVote: 0 },
+			{ thingId: 13, likes: '4', dislikes: '0', userVote: 0 },
+		]));
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?sectionId=nnils',
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			11: { likes: 2, dislikes: 1, userVote: null },
+			12: { likes: 0, dislikes: 0, userVote: null },
+			13: { likes: 4, dislikes: 0, userVote: null },
+		});
+	});
+
+	it('rejects providing both ids and sectionId', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?thingIds=1,2&sectionId=nnils',
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects providing neither ids nor sectionId', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes',
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects invalid sectionId characters', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/things/votes?sectionId=has spaces',
+		});
+
+		expect(response.statusCode).toBe(400);
 	});
 });

--- a/src/plugins/votes/votes.ts
+++ b/src/plugins/votes/votes.ts
@@ -4,13 +4,23 @@ import { authErrorResponse } from '../auth/schemas.js';
 import { sendEmail } from '../../lib/email.js';
 import { thingVotedEmail } from '../../lib/emailTemplates.js';
 import { voteValueToDb } from '../../lib/voteValue.js';
-import { upsertVote, deleteVote, getVoteCounts, getThingTitle } from './databaseHelpers.js';
+import {
+	upsertVote,
+	deleteVote,
+	getVoteSummary,
+	getVoteSummaries,
+	getVoteSummariesBySection,
+	getThingTitle,
+} from './databaseHelpers.js';
 import {
 	voteParams,
 	voteRequest,
-	voteCountsResponse,
+	voteSummaryResponse,
+	voteListQuery,
+	voteListResponse,
 	type VoteParams,
 	type VoteRequest,
+	type VoteListQuery,
 } from './schemas.js';
 
 const ADMIN_NOTIFY_EMAIL = process.env.ADMIN_NOTIFY_EMAIL;
@@ -18,22 +28,50 @@ const ADMIN_NOTIFY_EMAIL = process.env.ADMIN_NOTIFY_EMAIL;
 export async function votesPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: votes...');
 
-	fastify.addHook('onRequest', fastify.verifyJwt);
-	fastify.addHook('onRequest', fastify.requireRight('canVote'));
+	fastify.get('/votes', {
+		schema: {
+			description: 'Batch fetch vote summaries (likes/dislikes counts + caller\'s own vote). Provide either `thingIds` (up to 100 thing ids) or `sectionId` (string identifier — covers every thing in that section, zero-filled for unvoted ones). Anonymous callers receive userVote: null.',
+			tags: ['Votes'],
+			querystring: voteListQuery,
+			response: {
+				200: voteListResponse,
+				400: errorResponse,
+				500: errorResponse,
+			},
+		},
+		preHandler: fastify.optionalVerifyJwt,
+		handler: async (request: FastifyRequest<{ Querystring: VoteListQuery }>, reply) => {
+			try {
+				const { thingIds, sectionId } = request.query;
+				const userId = request.user?.sub ?? 0;
+
+				if (sectionId !== undefined) {
+					return await getVoteSummariesBySection(fastify.mysql, sectionId, userId);
+				}
+
+				// Schema guarantees `thingIds` is set when `sectionId` isn't.
+				return await getVoteSummaries(fastify.mysql, thingIds!, userId);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
 
 	fastify.put('/:thingId/vote', {
 		schema: {
-			description: 'Cast, update, or remove a vote for a thing. Vote 0 removes the vote.',
+			description: 'Cast, update, or remove a vote for a thing. vote=null removes. Returns the updated `{ likes, dislikes, userVote }` summary — same shape as the batch GET and the comment-vote endpoints.',
 			tags: ['Votes'],
 			params: voteParams,
 			body: voteRequest,
 			response: {
-				200: voteCountsResponse,
+				200: voteSummaryResponse,
 				401: authErrorResponse,
 				403: authErrorResponse,
 				500: errorResponse,
 			},
 		},
+		preHandler: [fastify.verifyJwt, fastify.requireRight('canVote')],
 		handler: async (request: FastifyRequest<{ Params: VoteParams; Body: VoteRequest }>, reply) => {
 			try {
 				const { thingId } = request.params;
@@ -58,7 +96,7 @@ export async function votesPlugin(fastify: FastifyInstance) {
 					});
 				}
 
-				return await getVoteCounts(fastify.mysql, thingId);
+				return await getVoteSummary(fastify.mysql, thingId, userId);
 			} catch (error) {
 				request.log.error(error);
 				return reply.code(500).send({ error: 'Internal server error' });


### PR DESCRIPTION
## Summary

- New `GET /things/votes?thingIds=…|sectionId=…` (optionalVerifyJwt) — batch summaries keyed by thingId. `thingIds` mode caps at 100; `sectionId` mode joins `v_things_info` and covers every thing in a section.
- `PUT /things/:id/vote` now returns the full `{likes, dislikes, userVote}` summary (same shape as the batch GET and comment-vote endpoints).
- `thingSchema.votes` flipped from `{plus, minus}` to `{likes, dislikes}`; SQL aliases renamed accordingly.
- Shared `voteSummarySchema` lives in `lib/voteValue.ts` so the wire shape stays in lockstep across the API.
- Auth is now per-route (`preHandler`) instead of a plugin-wide `addHook`, so the public batch GET coexists with the auth-only PUT.

## Deploy ordering

This is a **breaking change** to the PUT response shape (`plus`/`minus` → `likes`/`dislikes`). Companion PRs in `www.mellonis.ru` and `poetry-nextjs` consume the new shape — they should land **after** this PR is merged and deployed.

## Test plan

- [x] `npm test` → 170/170 pass (votes plugin: 14 cases including new GET modes, both-params/no-params rejection, sectionId character validation)
- [x] `npm run lint` clean
- [x] Smoke: `GET /things/votes?thingIds=1,2,3` returns `{ "1":{likes,dislikes,userVote}, ... }`
- [x] Smoke: `GET /things/votes?sectionId=nnils` returns every thing in the section
- [x] Smoke: missing-both / both-supplied → 400