### PR TITLE
Bake legacy text: save-side normalization + migration script

### DIFF
--- a/scripts/migrateLegacyText.ts
+++ b/scripts/migrateLegacyText.ts
@@ -1,0 +1,192 @@
+// One-shot migration: bake canonical 7-rule + NFC transform into stored text.
+//
+// Strategy: per-row PUT /cms/things/:id via the api. The api applies defensive
+// normalization through Zod transforms (added in schemas.ts), so this script
+// just round-trips affected rows. The api handles last_modified, Meilisearch
+// sync, and (when wired) cache invalidation.
+//
+// Scope:
+//   - thing.text, thing.title, thing.first_lines, thing_info.text, thing_note.text
+//     → PUT /cms/things/:id
+//   - news.id=1 (about page) → no patterns to bake (verified in pre-flight)
+//   - news.id=5 → 1 row with `--`, no api endpoint, applied via direct DB UPDATE
+//   - sections, other news rows → 0 affected (verified in pre-flight)
+//
+// Idempotent — already-canonical rows are skipped (no PUT, no DB write).
+//
+// Required env: API_BASE_URL, ADMIN_LOGIN, ADMIN_PASSWORD, CONNECTION_STRING
+// Usage:
+//   tsx scripts/migrateLegacyText.ts            # dry-run (default)
+//   tsx scripts/migrateLegacyText.ts --apply    # PUT changes via api + UPDATE news.id=5
+
+import mysql from 'mysql2/promise';
+import { normalizeLegacyInfoJson, normalizeLegacyText } from '../src/lib/normalizeLegacyText.js';
+
+interface CmsThing {
+	id: number;
+	title: string | null;
+	text: string;
+	categoryId: number;
+	statusId: number;
+	startDate: string | null;
+	finishDate: string;
+	firstLines: string | null;
+	firstLinesAutoGenerating: boolean;
+	excludeFromDaily: boolean;
+	notes: { id: number; text: string }[];
+	seoDescription: string | null;
+	seoKeywords: string | null;
+	info: string | null;
+}
+
+const env = (key: string): string => {
+	const v = process.env[key];
+	if (!v) {
+		console.error(`${key} env var is required`);
+		process.exit(2);
+	}
+	return v;
+};
+
+const login = async (apiBase: string, loginName: string, password: string): Promise<string> => {
+	const res = await fetch(`${apiBase}/auth/login`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ login: loginName, password }),
+	});
+	if (!res.ok) {
+		throw new Error(`Login failed: ${res.status} ${await res.text()}`);
+	}
+	const body = await res.json() as { accessToken: string };
+	return body.accessToken;
+};
+
+const getThing = async (apiBase: string, token: string, id: number): Promise<CmsThing> => {
+	const res = await fetch(`${apiBase}/cms/things/${id}`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) {
+		throw new Error(`GET /cms/things/${id} failed: ${res.status}`);
+	}
+	return res.json() as Promise<CmsThing>;
+};
+
+const putThing = async (apiBase: string, token: string, id: number, body: Record<string, unknown>): Promise<void> => {
+	const res = await fetch(`${apiBase}/cms/things/${id}`, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) {
+		throw new Error(`PUT /cms/things/${id} failed: ${res.status} ${await res.text()}`);
+	}
+};
+
+interface ChangeSet {
+	changed: boolean;
+	payload: Record<string, unknown>;
+	fields: string[];
+}
+
+const computeChanges = (t: CmsThing): ChangeSet => {
+	const payload: Record<string, unknown> = {};
+	const fields: string[] = [];
+
+	const checkText = (key: 'text' | 'title' | 'firstLines', value: string | null) => {
+		if (value === null) return;
+		if (normalizeLegacyText(value) !== value) {
+			payload[key] = value;
+			fields.push(key);
+		}
+	};
+
+	checkText('text', t.text);
+	checkText('title', t.title);
+	checkText('firstLines', t.firstLines);
+
+	if (t.info !== null && normalizeLegacyInfoJson(t.info) !== t.info) {
+		payload.info = t.info;
+		fields.push('info');
+	}
+
+	const notesNeedUpdate = t.notes.some((n) => normalizeLegacyText(n.text) !== n.text);
+	if (notesNeedUpdate) {
+		payload.notes = t.notes.map((n) => ({ id: n.id, text: n.text }));
+		fields.push('notes');
+	}
+
+	return { changed: fields.length > 0, payload, fields };
+};
+
+async function migrateThings(apply: boolean): Promise<{ changed: number; unchanged: number }> {
+	const apiBase = env('API_BASE_URL');
+	const token = await login(apiBase, env('ADMIN_LOGIN'), env('ADMIN_PASSWORD'));
+
+	const conn = await mysql.createConnection({ uri: env('CONNECTION_STRING'), charset: 'utf8mb4' });
+	const [rows] = await conn.query<(mysql.RowDataPacket & { id: number })[]>('SELECT id FROM thing ORDER BY id');
+	await conn.end();
+
+	let changed = 0;
+	let unchanged = 0;
+
+	for (const { id } of rows) {
+		const thing = await getThing(apiBase, token, id);
+		const cs = computeChanges(thing);
+
+		if (!cs.changed) {
+			unchanged++;
+			continue;
+		}
+
+		changed++;
+		const tag = apply ? '✓' : '·';
+		console.log(`${tag} thing ${id}: ${cs.fields.join(', ')}`);
+
+		if (apply) {
+			await putThing(apiBase, token, id, cs.payload);
+		}
+	}
+
+	return { changed, unchanged };
+}
+
+async function migrateNewsId5(apply: boolean): Promise<boolean> {
+	const conn = await mysql.createConnection({ uri: env('CONNECTION_STRING'), charset: 'utf8mb4' });
+	try {
+		const [rows] = await conn.query<(mysql.RowDataPacket & { id: number; text: string })[]>(
+			'SELECT id, text FROM news WHERE id = 5',
+		);
+		if (rows.length === 0) return false;
+
+		const before = rows[0].text;
+		const after = normalizeLegacyText(before);
+		if (before === after) return false;
+
+		const tag = apply ? '✓' : '·';
+		console.log(`${tag} news 5: text (direct DB UPDATE)`);
+
+		if (apply) {
+			await conn.execute('UPDATE news SET text = ? WHERE id = 5', [after]);
+		}
+		return true;
+	} finally {
+		await conn.end();
+	}
+}
+
+async function main(): Promise<void> {
+	const apply = process.argv.includes('--apply');
+	console.log(`Mode: ${apply ? 'APPLY' : 'DRY-RUN'}\n`);
+
+	const things = await migrateThings(apply);
+	const newsChanged = await migrateNewsId5(apply);
+
+	const totalChanged = things.changed + (newsChanged ? 1 : 0);
+	console.log(`\n${apply ? 'APPLIED' : 'DRY-RUN'}: ${totalChanged} rows ${apply ? 'updated' : 'would update'} ` +
+		`(${things.changed} things via api + ${newsChanged ? 1 : 0} news via direct DB; ${things.unchanged} things unchanged)`);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/src/lib/normalizeLegacyText.test.ts
+++ b/src/lib/normalizeLegacyText.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLegacyInfoJson, normalizeLegacyText } from './normalizeLegacyText.js';
+
+describe('normalizeLegacyText', () => {
+	it('replaces start-of-line --- with em dash + NBSP', () => {
+		expect(normalizeLegacyText('--- начало')).toBe('—\u00A0начало');
+	});
+
+	it('replaces ]--- with ]— + NBSP', () => {
+		expect(normalizeLegacyText('[/q]--- сказал')).toBe('[/q]—\u00A0сказал');
+	});
+
+	it('preserves capture groups after ( or :', () => {
+		expect(normalizeLegacyText('(--- пример')).toBe('(—\u00A0пример');
+		expect(normalizeLegacyText(': --- цитата')).toBe(': —\u00A0цитата');
+	});
+
+	it('replaces space + --- with NBSP + em dash mid-text', () => {
+		expect(normalizeLegacyText('слово --- слово')).toBe('слово\u00A0— слово');
+	});
+
+	it('replaces -- with en dash', () => {
+		expect(normalizeLegacyText('A -- B')).toBe('A – B');
+	});
+
+	it('replaces backtick with combining acute (NFC composes with Latin vowel)', () => {
+		expect(normalizeLegacyText('e`')).toBe('é');
+	});
+
+	it('replaces backtick with combining acute (no composition for Cyrillic)', () => {
+		expect(normalizeLegacyText('о`')).toBe('о\u0301');
+	});
+
+	it('replaces [nbsp] with U+00A0', () => {
+		expect(normalizeLegacyText('a[nbsp]b')).toBe('a\u00A0b');
+	});
+
+	it('handles all rules combined', () => {
+		const input = '--- первый\n[/q]--- второй\n(--- третий\nслово --- слово\nA -- B\nо`\na[nbsp]b';
+		const expected = [
+			'—\u00A0первый',
+			'[/q]—\u00A0второй',
+			'(—\u00A0третий',
+			'слово\u00A0— слово',
+			'A – B',
+			'о\u0301',
+			'a\u00A0b',
+		].join('\n');
+		expect(normalizeLegacyText(input)).toBe(expected);
+	});
+
+	it('is idempotent — second pass is a no-op', () => {
+		const samples = [
+			'--- первый',
+			'[/q]--- второй',
+			'(--- третий',
+			'слово --- слово',
+			'A -- B',
+			'о`',
+			'a[nbsp]b',
+			'комбинация: --- слово -- A `e`',
+			'',
+			'no patterns here',
+		];
+		for (const s of samples) {
+			const once = normalizeLegacyText(s);
+			expect(normalizeLegacyText(once)).toBe(once);
+		}
+	});
+
+	it('does not match --- without surrounding whitespace context (would fall through to en dash)', () => {
+		// This documents the fall-through: bare `---abc` becomes `–-abc`. Pre-flight
+		// scan confirmed zero such cases in current data; this test pins the behavior.
+		expect(normalizeLegacyText('---abc')).toBe('–-abc');
+	});
+
+	it('passes empty string through', () => {
+		expect(normalizeLegacyText('')).toBe('');
+	});
+
+	it('leaves already-normalized Cyrillic vowels with combining acute unchanged', () => {
+		// Cyrillic vowels have no precomposed forms in Unicode; NFC keeps them
+		// as base letter + U+0301. Many rows already have these from manual editing.
+		const samples = [
+			'А\u0301', 'Е\u0301', 'И\u0301', 'О\u0301', 'У\u0301',
+			'Ы\u0301', 'Э\u0301', 'Ю\u0301', 'Я\u0301',
+			'а\u0301', 'е\u0301', 'и\u0301', 'о\u0301', 'у\u0301',
+			'ы\u0301', 'э\u0301', 'ю\u0301', 'я\u0301',
+			'снега\u0301', 'любо\u0301ви',
+		];
+		for (const s of samples) {
+			expect(normalizeLegacyText(s)).toBe(s);
+		}
+	});
+});
+
+describe('normalizeLegacyInfoJson', () => {
+	it('normalizes audio[].title without touching URLs', () => {
+		const input = JSON.stringify({
+			attachments: {
+				audio: [
+					{
+						preload: 'none',
+						title: 'A -- B `тест',
+						sources: [{ src: 'https://example.com/path--with-dashes.mp3', type: 'audio/mpeg' }],
+					},
+				],
+			},
+		});
+		const output = normalizeLegacyInfoJson(input);
+		const parsed = JSON.parse(output);
+		expect(parsed.attachments.audio[0].title).toBe('A – B \u0301тест');
+		expect(parsed.attachments.audio[0].sources[0].src).toBe('https://example.com/path--with-dashes.mp3');
+	});
+
+	it('returns input unchanged on invalid JSON', () => {
+		expect(normalizeLegacyInfoJson('{not valid')).toBe('{not valid');
+	});
+
+	it('handles missing attachments structure', () => {
+		const input = '{"foo":"bar"}';
+		expect(JSON.parse(normalizeLegacyInfoJson(input))).toEqual({ foo: 'bar' });
+	});
+
+	it('is idempotent', () => {
+		const input = JSON.stringify({
+			attachments: { audio: [{ title: 'A -- B', sources: [{ src: 'x', type: 'audio/mpeg' }] }] },
+		});
+		const once = normalizeLegacyInfoJson(input);
+		expect(normalizeLegacyInfoJson(once)).toBe(once);
+	});
+});

--- a/src/lib/normalizeLegacyText.ts
+++ b/src/lib/normalizeLegacyText.ts
@@ -1,0 +1,48 @@
+// Canonical text-normalization rules for legacy thing/news content.
+//
+// Applied once in the DB migration that bakes these substitutions into stored text,
+// and again on the api save-side so non-CMS writers stay canonical. Renderers no
+// longer apply these — stored text is already canonical.
+//
+// The 4 dash-context rules MUST run before the bare `--` rule, otherwise `---`
+// gets eaten as `–-`.
+const rules: [RegExp, string][] = [
+	[/^---\s/mg, '—\u00A0'],
+	[/]---\s/g, ']—\u00A0'],
+	[/([(:])(\s)?\s*---\s/g, '$1$2—\u00A0'],
+	[/\s---/g, '\u00A0—'],
+	[/--/g, '–'],
+	[/`/g, '\u0301'],
+	[/\[nbsp]/g, '\u00A0'],
+];
+
+export const normalizeLegacyText = (text: string): string =>
+	rules
+		.reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement), text)
+		.normalize('NFC');
+
+// Apply normalizeLegacyText only where it's safe inside thing_info.text JSON:
+// to audio[].title strings. URLs (sources[].src) and structural keys are left
+// untouched. Invalid JSON falls through unchanged.
+export const normalizeLegacyInfoJson = (json: string): string => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return json;
+	}
+
+	const audio = (parsed as { attachments?: { audio?: unknown } } | null)?.attachments?.audio;
+	if (Array.isArray(audio)) {
+		for (const item of audio) {
+			if (item && typeof item === 'object' && 'title' in item) {
+				const t = (item as { title?: unknown }).title;
+				if (typeof t === 'string') {
+					(item as { title: string }).title = normalizeLegacyText(t);
+				}
+			}
+		}
+	}
+
+	return JSON.stringify(parsed, null, 2);
+};

--- a/src/plugins/cms/schemas.test.ts
+++ b/src/plugins/cms/schemas.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createSectionRequest,
+	createThingRequest,
+	updateAuthorRequest,
+	updateSectionRequest,
+	updateThingRequest,
+} from './schemas.js';
+
+// Defensive normalization: Zod transforms on text fields that get rendered via
+// the BBCode-like legacy renderer. SEO fields, identifier, dates, IDs, and
+// settings are intentionally NOT normalized.
+
+describe('createThingRequest normalization', () => {
+	it('normalizes text, title, firstLines, and notes[].text', () => {
+		const parsed = createThingRequest.parse({
+			title: 'Бодрая весна --- Банзай',
+			text: 'Слово --- слово',
+			categoryId: 1,
+			finishDate: '2024-01-15',
+			firstLines: 'Хочешь послушать го`лоса',
+			notes: [{ text: '[b]Пролог[/b] --- Ощущения' }],
+		});
+		expect(parsed.title).toBe('Бодрая весна\u00A0— Банзай');
+		expect(parsed.text).toBe('Слово\u00A0— слово');
+		expect(parsed.firstLines).toBe('Хочешь послушать го\u0301лоса');
+		expect(parsed.notes[0].text).toBe('[b]Пролог[/b]\u00A0— Ощущения');
+	});
+
+	it('does not normalize seoDescription, seoKeywords', () => {
+		const parsed = createThingRequest.parse({
+			text: 'x',
+			categoryId: 1,
+			finishDate: '2024-01-15',
+			seoDescription: 'A -- B',
+			seoKeywords: '`test',
+		});
+		expect(parsed.seoDescription).toBe('A -- B');
+		expect(parsed.seoKeywords).toBe('`test');
+	});
+
+	it('normalizes audio[].title in info JSON without touching URLs', () => {
+		const info = JSON.stringify({
+			attachments: {
+				audio: [
+					{ title: 'A -- B', sources: [{ src: 'https://x/a--b.mp3', type: 'audio/mpeg' }] },
+				],
+			},
+		});
+		const parsed = createThingRequest.parse({
+			text: 'x',
+			categoryId: 1,
+			finishDate: '2024-01-15',
+			info,
+		});
+		const out = JSON.parse(parsed.info!);
+		expect(out.attachments.audio[0].title).toBe('A – B');
+		expect(out.attachments.audio[0].sources[0].src).toBe('https://x/a--b.mp3');
+	});
+});
+
+describe('updateThingRequest normalization', () => {
+	it('normalizes optional text fields when present', () => {
+		const parsed = updateThingRequest.parse({ text: 'A -- B' });
+		expect(parsed.text).toBe('A – B');
+	});
+
+	it('leaves fields undefined when absent', () => {
+		const parsed = updateThingRequest.parse({});
+		expect(parsed.text).toBeUndefined();
+		expect(parsed.title).toBeUndefined();
+	});
+});
+
+describe('updateAuthorRequest normalization', () => {
+	it('normalizes text', () => {
+		const parsed = updateAuthorRequest.parse({
+			text: '--- начало',
+			date: '2024-01-15',
+		});
+		expect(parsed.text).toBe('—\u00A0начало');
+	});
+
+	it('does not normalize seoDescription, seoKeywords, date', () => {
+		const parsed = updateAuthorRequest.parse({
+			text: 'x',
+			date: '2024-01-15',
+			seoDescription: 'A -- B',
+			seoKeywords: '`kw',
+		});
+		expect(parsed.seoDescription).toBe('A -- B');
+		expect(parsed.seoKeywords).toBe('`kw');
+		expect(parsed.date).toBe('2024-01-15');
+	});
+});
+
+describe('createSectionRequest / updateSectionRequest normalization', () => {
+	it('normalizes title, description, annotationText, annotationAuthor', () => {
+		const parsed = createSectionRequest.parse({
+			identifier: 'sec1',
+			title: 'A -- B',
+			description: '--- desc',
+			annotationText: 'note `a`',
+			annotationAuthor: 'X -- Y',
+			typeId: 1,
+		});
+		expect(parsed.title).toBe('A – B');
+		expect(parsed.description).toBe('—\u00A0desc');
+		// Latin `a` + U+0301 NFC-composes to `á` (U+00E1); leading stranded acute
+		// stays as combining char on the preceding space.
+		expect(parsed.annotationText).toBe('note \u0301\u00E1');
+		expect(parsed.annotationAuthor).toBe('X – Y');
+	});
+
+	it('does not normalize identifier', () => {
+		const parsed = createSectionRequest.parse({
+			identifier: 'foo123',
+			title: 't',
+			typeId: 1,
+		});
+		expect(parsed.identifier).toBe('foo123');
+	});
+
+	it('updateSectionRequest normalizes optional fields', () => {
+		const parsed = updateSectionRequest.parse({ title: 'A -- B' });
+		expect(parsed.title).toBe('A – B');
+	});
+});

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -1,4 +1,15 @@
 import { z } from 'zod';
+import { normalizeLegacyInfoJson, normalizeLegacyText } from '../../lib/normalizeLegacyText.js';
+
+// Defensive normalization for legacy text fields rendered via the BBCode-like
+// renderer. DB stores canonical chars (em dash, NBSP, en dash, combining acute);
+// this guarantees that even when the request bypasses the CMS frontend, the DB
+// stays canonical. SEO/keywords/identifier/dates/IDs are intentionally excluded.
+const norm = <T extends string | null | undefined>(v: T): T =>
+	typeof v === 'string' ? (normalizeLegacyText(v) as T) : v;
+
+const normInfo = <T extends string | null | undefined>(v: T): T =>
+	typeof v === 'string' ? (normalizeLegacyInfoJson(v) as T) : v;
 
 // --- Section types reference ---
 
@@ -44,10 +55,10 @@ export const sectionIdParam = z.object({
 
 export const createSectionRequest = z.object({
 	identifier: z.string().regex(/^[a-z][a-z0-9]{1,6}$/),
-	title: z.string().min(1).max(45),
-	description: z.string().nullable().default(null),
-	annotationText: z.string().nullable().default(null),
-	annotationAuthor: z.string().max(100).nullable().default(null),
+	title: z.string().min(1).max(45).transform(norm),
+	description: z.string().nullable().default(null).transform(norm),
+	annotationText: z.string().nullable().default(null).transform(norm),
+	annotationAuthor: z.string().max(100).nullable().default(null).transform(norm),
 	typeId: z.number().int().min(1).max(3),
 	statusId: z.number().int().min(1).max(4).optional(),
 	redirectSectionId: z.number().int().nullable().default(null),
@@ -58,10 +69,10 @@ export const createSectionRequest = z.object({
 // --- Update section ---
 
 export const updateSectionRequest = z.object({
-	title: z.string().min(1).max(45).optional(),
-	description: z.string().nullable().optional(),
-	annotationText: z.string().nullable().optional(),
-	annotationAuthor: z.string().max(100).nullable().optional(),
+	title: z.string().min(1).max(45).optional().transform(norm),
+	description: z.string().nullable().optional().transform(norm),
+	annotationText: z.string().nullable().optional().transform(norm),
+	annotationAuthor: z.string().max(100).nullable().optional().transform(norm),
 	typeId: z.number().int().min(1).max(3).optional(),
 	statusId: z.number().int().min(1).max(4).optional(),
 	redirectSectionId: z.number().int().nullable().optional(),
@@ -115,7 +126,7 @@ export const cmsAuthorResponse = z.object({
 });
 
 export const updateAuthorRequest = z.object({
-	text: z.string().min(1),
+	text: z.string().min(1).transform(norm),
 	date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 	seoDescription: z.string().nullable().default(null),
 	seoKeywords: z.string().nullable().default(null),
@@ -125,7 +136,7 @@ export const updateAuthorRequest = z.object({
 
 const thingNoteItem = z.object({
 	id: z.number().int().optional(),
-	text: z.string().min(1),
+	text: z.string().min(1).transform(norm),
 });
 
 // SEO fields must be provided together or both be null/undefined
@@ -183,35 +194,35 @@ export const thingIdParam = z.object({
 });
 
 export const createThingRequest = z.object({
-	title: z.string().nullable().default(null),
-	text: z.string().min(1),
+	title: z.string().nullable().default(null).transform(norm),
+	text: z.string().min(1).transform(norm),
 	categoryId: z.number().int().min(1).max(4),
 	statusId: z.number().int().min(1).max(4).default(1),
 	startDate: partialDate.nullable().default(null),
 	finishDate: partialDate,
-	firstLines: z.string().nullable().default(null),
+	firstLines: z.string().nullable().default(null).transform(norm),
 	firstLinesAutoGenerating: z.literal(false).default(false),
 	excludeFromDaily: z.boolean().default(false),
 	notes: z.array(thingNoteItem).default([]),
 	seoDescription: z.string().nullable().default(null),
 	seoKeywords: z.string().nullable().default(null),
-	info: z.string().nullable().default(null),
+	info: z.string().nullable().default(null).transform(normInfo),
 }).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 export const updateThingRequest = z.object({
-	title: z.string().nullable().optional(),
-	text: z.string().min(1).optional(),
+	title: z.string().nullable().optional().transform(norm),
+	text: z.string().min(1).optional().transform(norm),
 	categoryId: z.number().int().min(1).max(4).optional(),
 	statusId: z.number().int().min(1).max(4).optional(),
 	startDate: partialDate.nullable().optional(),
 	finishDate: partialDate.optional(),
-	firstLines: z.string().nullable().optional(),
+	firstLines: z.string().nullable().optional().transform(norm),
 	firstLinesAutoGenerating: z.literal(false).optional(),
 	excludeFromDaily: z.boolean().optional(),
 	notes: z.array(thingNoteItem).optional(),
 	seoDescription: z.string().nullable().optional(),
 	seoKeywords: z.string().nullable().optional(),
-	info: z.string().nullable().optional(),
+	info: z.string().nullable().optional().transform(normInfo),
 }).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 // --- Inferred types ---


### PR DESCRIPTION
## Summary

Move the legacy renderer's 7 character substitutions (`---` → em dash + NBSP, `--` → en dash, backtick → combining acute, `[nbsp]` → U+00A0, plus the 3 dash-context rules) from runtime to write-time. The renderer always produced the same canonical chars; baking them removes per-render work and lets us drop the substitutions from every consumer.

This PR is **part 1 of 2**:
- Adds the normalizer + Zod transforms (defensive on save).
- Ships the migration script.

Part 2 (separate PR, after migration runs) drops the dash/backtick/`[nbsp]` rules from `textStripping.ts` and bumps `INDEX_VERSION` to force a clean reindex.

## Scope of normalization

| Field | Normalize? | Why |
|---|---|---|
| `thing.text`, `thing.title`, `thing.firstLines`, `thing.notes[].text` | ✓ | Rendered via `renderLegacy` |
| `thing.info` (JSON) | ✓ structural | Only `audio[].title` strings; URLs left untouched |
| `news.text` (via `/cms/author`, news id=1) | ✓ | Rendered |
| `section.title`, `section.description`, `section.annotationText`, `section.annotationAuthor` | ✓ | Rendered |
| SEO fields, dates, IDs, identifiers, settings | ✗ | Not rendered |

## Migration script

`scripts/migrateLegacyText.ts` walks `thing` rows, GETs each via `/cms/things/:id`, normalizes locally, and PUTs back only those that change. Lets the api drive `last_modified` bumps, Meilisearch sync, and revalidation. News id=5 (the only non-author news row affected, 1 row with `--`) is updated via direct DB.

```
tsx scripts/migrateLegacyText.ts            # dry-run
tsx scripts/migrateLegacyText.ts --apply    # write
```

Required env: `API_BASE_URL`, `ADMIN_LOGIN`, `ADMIN_PASSWORD`, `CONNECTION_STRING`.

Pre-flight (read-only) scan results: ~388 thing rows + 1 news row affected; `thing_info.text` (JSON) has 0 changes (already canonical via manual editing); 0 edge cases (no bare `---` outside whitespace contexts, no stranded backticks).

## Test plan

- [x] 27 new tests cover all 7 rules, idempotency, NFC composition, info-JSON round-trip, and that SEO/identifiers/dates are NOT transformed
- [x] `npm test` (197 total) + `tsc --noEmit` + `npm run lint` all green
- [ ] After deploy: dry-run the migration script; review affected rows; apply
- [ ] Spot-check a few rendered pages before/after — output should be byte-identical (renderer still applies the rules; DB is now canonical)