### PR TITLE
ISO partial date format on the wire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Shared utilities in `src/lib/`:
 - `schemas.ts` — Zod schemas (shared `thingSchema`, `errorResponse`)
 - `queries.ts` — SQL fragments (thing fields, user vote field)
 - `mappers.ts` — row mappers (`mapThingBaseRow`, `splitLines`, `parseJSON`, `thingDisplayTitle`)
+- `isoDate.ts` — date format conversion at the wire boundary (`dbDateToIso`, `isoDateToDb`, `isValidIsoDate`)
 - `databaseHelpers.ts` — `withConnection` (pool acquire/release)
 - `email.ts` — SMTP transport via nodemailer
 - `emailTemplates.ts` — email templates:
@@ -138,6 +139,8 @@ Validation and serialization use `fastify-type-provider-zod`. All Fastify route 
 **Notes aggregation** uses a correlated subquery with `GROUP_CONCAT(JSON_QUOTE(text) ORDER BY id SEPARATOR ',')` wrapped in `CONCAT('[', ..., ']')` (legacy pattern — `JSON_ARRAYAGG` is available on the current MySQL 8.4.8 if refactored).
 
 **`things-of-the-day` selection** — primary query matches by `MM-DD` ignoring year via `SUBSTRING(thing_finish_date, 6)`, also handles partial dates (`YYYY-MM-00`, `YYYY-00-00`), ordered newest year first. Fallback uses `RAND(TO_DAYS(CURDATE()))` seeded by date for stable daily randomness. Results are grouped by `thing_id` in the app to collect `sections: [{id, position}]`.
+
+**Date format** — thing dates support partial precision. DB columns (`thing.start_date`, `thing.finish_date`) are MySQL `DATE` storing `YYYY-MM-DD` with `00` segments for unknown month/day (e.g. `1990-05-00` = May 1990, `1990-00-00` = year 1990, `0000-00-00` = undated). On the wire the api speaks ISO partial: `YYYY` | `YYYY-MM` | `YYYY-MM-DD`. `lib/isoDate.ts` does the conversion: `dbDateToIso` trims trailing `-00` segments on read (in `mapThingBaseRow` and `cms/databaseHelpers.ts:getCmsThing`); `isoDateToDb` pads back to `YYYY-MM-DD` for INSERT/UPDATE (in `cms/databaseHelpers.ts:createThing`/`updateThing`). The Zod `partialDate` validator in `cms/schemas.ts` accepts only the ISO partial form, including a day-in-month check for full dates. `news.date` is exact-only and round-trips unchanged. The `things-of-the-day` SQL still works on raw DB form because it runs server-side before the mapper.
 
 **`withConnection(mysql, fn)`** in `src/lib/databaseHelpers.ts` — shared helper for all DB access; handles pool acquire/release via try/finally. MySQL server timezone is set to `+03:00` (Moscow) via `default-time-zone` in `mysql.cnf` — all `NOW()`, `CURDATE()`, and timestamp comparisons run in Moscow time. Verification key TTL checks use `Date.now()` (Node.js clock, UTC epoch) against the key's embedded timestamp (also `Date.now()` at generation) — self-consistent regardless of server timezone. These two clocks (DB server vs Node.js) don't cross.
 

--- a/src/lib/isoDate.test.ts
+++ b/src/lib/isoDate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { dbDateToIso, isoDateToDb, isValidIsoDate } from './isoDate.js';
+
+describe('dbDateToIso', () => {
+	it('passes full dates through', () => {
+		expect(dbDateToIso('1990-05-12')).toBe('1990-05-12');
+	});
+
+	it('trims day-only-unknown to YYYY-MM', () => {
+		expect(dbDateToIso('1990-05-00')).toBe('1990-05');
+	});
+
+	it('trims month-and-day-unknown to YYYY', () => {
+		expect(dbDateToIso('1990-00-00')).toBe('1990');
+	});
+
+	it('trims undated 0000-00-00 to 0000', () => {
+		expect(dbDateToIso('0000-00-00')).toBe('0000');
+	});
+
+	it('passes non-DB-shaped strings through unchanged', () => {
+		expect(dbDateToIso('1990')).toBe('1990');
+		expect(dbDateToIso('not a date')).toBe('not a date');
+	});
+});
+
+describe('isoDateToDb', () => {
+	it('passes full ISO dates through', () => {
+		expect(isoDateToDb('1990-05-12')).toBe('1990-05-12');
+	});
+
+	it('pads year-month with -00', () => {
+		expect(isoDateToDb('1990-05')).toBe('1990-05-00');
+	});
+
+	it('pads year-only with -00-00', () => {
+		expect(isoDateToDb('1990')).toBe('1990-00-00');
+	});
+
+	it('throws on invalid ISO shape', () => {
+		expect(() => isoDateToDb('1990-5')).toThrow();
+		expect(() => isoDateToDb('90-05-12')).toThrow();
+		expect(() => isoDateToDb('1990-05-12-extra')).toThrow();
+	});
+});
+
+describe('isValidIsoDate', () => {
+	it('accepts year-only', () => {
+		expect(isValidIsoDate('1990')).toBe(true);
+		expect(isValidIsoDate('0001')).toBe(true);
+	});
+
+	it('accepts year-month', () => {
+		expect(isValidIsoDate('1990-01')).toBe(true);
+		expect(isValidIsoDate('1990-12')).toBe(true);
+	});
+
+	it('accepts full date', () => {
+		expect(isValidIsoDate('1990-05-12')).toBe(true);
+		expect(isValidIsoDate('2020-02-29')).toBe(true); // leap year
+	});
+
+	it('rejects malformed shapes', () => {
+		expect(isValidIsoDate('90')).toBe(false);
+		expect(isValidIsoDate('1990-5')).toBe(false);
+		expect(isValidIsoDate('1990-05-1')).toBe(false);
+		expect(isValidIsoDate('1990-05-12-extra')).toBe(false);
+		expect(isValidIsoDate('')).toBe(false);
+	});
+
+	it('rejects out-of-range months', () => {
+		expect(isValidIsoDate('1990-00')).toBe(false);
+		expect(isValidIsoDate('1990-13')).toBe(false);
+	});
+
+	it('rejects out-of-range days', () => {
+		expect(isValidIsoDate('1990-05-00')).toBe(false);
+		expect(isValidIsoDate('1990-05-32')).toBe(false);
+	});
+
+	it('rejects day-in-month mismatch', () => {
+		expect(isValidIsoDate('1990-02-31')).toBe(false);
+		expect(isValidIsoDate('2021-02-29')).toBe(false); // not a leap year
+		expect(isValidIsoDate('1990-04-31')).toBe(false);
+	});
+});

--- a/src/lib/isoDate.ts
+++ b/src/lib/isoDate.ts
@@ -1,0 +1,53 @@
+// Date format conversion at the api boundary.
+//
+// DB stores dates as YYYY-MM-DD with `00` segments for unknown month/day
+// (e.g. `1990-05-00` = May 1990, `1990-00-00` = year 1990, `0000-00-00` = undated).
+// This is a legacy storage convention that lets us keep MySQL DATE columns and
+// their date functions (`MAX`, `YEAR(...)`, etc.) while still recording partial
+// precision.
+//
+// On the wire the api speaks ISO partial format: `YYYY` | `YYYY-MM` |
+// `YYYY-MM-DD`. Trim trailing `-00` segments on read; pad them back on write.
+// `0000-00-00` (undated) trims to `0000` — clients detect "undated" by year=0,
+// same as before.
+
+const DB_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const ISO_DATE_PATTERN = /^\d{4}(-\d{2}(-\d{2})?)?$/;
+
+export const dbDateToIso = (db: string): string => {
+	const match = DB_DATE_PATTERN.exec(db);
+	if (!match) return db;
+	const [, year, month, day] = match;
+	if (month === '00') return year;
+	if (day === '00') return `${year}-${month}`;
+	return db;
+};
+
+export const isoDateToDb = (iso: string): string => {
+	if (!ISO_DATE_PATTERN.test(iso)) {
+		throw new Error(`Invalid ISO date: ${iso}`);
+	}
+	const parts = iso.split('-');
+	while (parts.length < 3) {
+		parts.push('00');
+	}
+	return parts.join('-');
+};
+
+// Validates ISO partial format. For full dates, also verifies day-in-month
+// correctness (rejects `1990-02-31`). Year 0 is allowed for the "undated"
+// sentinel that callers never write but may need to round-trip.
+export const isValidIsoDate = (value: string): boolean => {
+	if (!ISO_DATE_PATTERN.test(value)) return false;
+	const parts = value.split('-');
+	const year = Number(parts[0]);
+	if (!Number.isInteger(year) || year < 0 || year > 9999) return false;
+	if (parts.length === 1) return true;
+	const month = Number(parts[1]);
+	if (month < 1 || month > 12) return false;
+	if (parts.length === 2) return true;
+	const day = Number(parts[2]);
+	if (day < 1 || day > 31) return false;
+	const dt = new Date(`${parts[0]}-${parts[1]}-${parts[2]}`);
+	return dt.getUTCMonth() + 1 === month && dt.getUTCDate() === day;
+};

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -1,6 +1,7 @@
 import type { MySQLRowDataPacket } from '@fastify/mysql';
 import type { z } from 'zod';
 import type { thingSchema } from './schemas.js';
+import { dbDateToIso } from './isoDate.js';
 import { dbToVoteValue } from './voteValue.js';
 
 type ThingBase = z.infer<typeof thingSchema>;
@@ -37,8 +38,8 @@ export const mapThingBaseRow = (row: MySQLRowDataPacket) => ({
 	categoryId: row.categoryId,
 	title: row.title ?? undefined as string | undefined,
 	firstLines: (row.firstLines ?? undefined) ? splitLines(row.firstLines as string) : undefined,
-	startDate: row.startDate ?? undefined as string | undefined,
-	finishDate: row.finishDate ?? undefined as string | undefined,
+	startDate: row.startDate ? dbDateToIso(row.startDate as string) : undefined,
+	finishDate: dbDateToIso(row.finishDate as string),
 	lastModified: row.lastModified ?? undefined as string | undefined,
 	text: row.text as string,
 	seoDescription: row.seoDescription ?? undefined as string | undefined,

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -353,6 +353,177 @@ describe('PUT /cms/sections/:sectionId/things/reorder', () => {
 	});
 });
 
+// --- CMS thing date format ---
+
+const thingRow = {
+	id: 42,
+	title: 'Test',
+	text: 'Body',
+	categoryId: 1,
+	statusId: 2,
+	startDate: null,
+	finishDate: '1990-05-12',
+	firstLines: null,
+	firstLinesAutoGenerating: 0,
+	excludeFromDaily: 0,
+	seoDescription: null,
+	seoKeywords: null,
+	info: null,
+};
+
+describe('GET /cms/things/:thingId — date format', () => {
+	it('returns full date as YYYY-MM-DD', async () => {
+		const app = await buildApp(createMockMysql([thingRow], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().finishDate).toBe('1990-05-12');
+	});
+
+	it('trims YYYY-MM-00 to YYYY-MM', async () => {
+		const app = await buildApp(createMockMysql([{ ...thingRow, finishDate: '1990-05-00' }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.json().finishDate).toBe('1990-05');
+	});
+
+	it('trims YYYY-00-00 to YYYY', async () => {
+		const app = await buildApp(createMockMysql([{ ...thingRow, finishDate: '1990-00-00' }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.json().finishDate).toBe('1990');
+	});
+
+	it('returns startDate trimmed too', async () => {
+		const app = await buildApp(createMockMysql([{ ...thingRow, startDate: '1989-00-00', finishDate: '1990-05-00' }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.json().startDate).toBe('1989');
+		expect(response.json().finishDate).toBe('1990-05');
+	});
+});
+
+describe('POST /cms/things — date format', () => {
+	const basePayload = {
+		title: null,
+		text: 'Body',
+		categoryId: 1,
+		notes: [],
+	};
+
+	it('accepts ISO year-only and pads to YYYY-00-00 on write', async () => {
+		const app = await buildApp(createMockMysql(
+			[{ insertId: 99 }],
+			[thingRow],
+			[],
+		));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990' },
+		});
+
+		expect(response.statusCode).toBe(201);
+	});
+
+	it('accepts ISO year-month', async () => {
+		const app = await buildApp(createMockMysql([{ insertId: 99 }], [thingRow], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990-05' },
+		});
+
+		expect(response.statusCode).toBe(201);
+	});
+
+	it('accepts ISO full date', async () => {
+		const app = await buildApp(createMockMysql([{ insertId: 99 }], [thingRow], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990-05-12' },
+		});
+
+		expect(response.statusCode).toBe(201);
+	});
+
+	it('rejects legacy YYYY-MM-00 form', async () => {
+		const app = await buildApp(createMockMysql([{ insertId: 99 }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990-05-00' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects invalid month', async () => {
+		const app = await buildApp(createMockMysql([{ insertId: 99 }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990-13' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects day-in-month mismatch', async () => {
+		const app = await buildApp(createMockMysql([{ insertId: 99 }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { ...basePayload, finishDate: '1990-02-31' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+});
+
 // --- User management ---
 
 const userRow = {

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -1,5 +1,6 @@
 import type { MySQLPromisePool, MySQLResultSetHeader, MySQLRowDataPacket } from '@fastify/mysql';
 import { withConnection } from '../../lib/databaseHelpers.js';
+import { dbDateToIso, isoDateToDb } from '../../lib/isoDate.js';
 import { parseJSON, splitLines } from '../../lib/mappers.js';
 import {
 	sectionTypesQuery,
@@ -457,8 +458,8 @@ export const getCmsThing = async (mysql: MySQLPromisePool, thingId: number): Pro
 			text: row.text as string,
 			categoryId: row.categoryId as number,
 			statusId: row.statusId as number,
-			startDate: (row.startDate as string) ?? null,
-			finishDate: row.finishDate as string,
+			startDate: row.startDate ? dbDateToIso(row.startDate as string) : null,
+			finishDate: dbDateToIso(row.finishDate as string),
 			firstLines: (row.firstLines as string) ?? null,
 			firstLinesAutoGenerating: Boolean(row.firstLinesAutoGenerating),
 			excludeFromDaily: Boolean(row.excludeFromDaily),
@@ -484,7 +485,8 @@ export const createThing = async (
 		try {
 			const [result] = await connection.query<MySQLResultSetHeader>(createThingQuery, [
 				data.title, data.text, data.categoryId, data.statusId,
-				data.startDate, data.finishDate,
+				data.startDate ? isoDateToDb(data.startDate) : null,
+				isoDateToDb(data.finishDate),
 				data.firstLines, data.firstLinesAutoGenerating ? 1 : 0, data.excludeFromDaily ? 1 : 0,
 			]);
 			const thingId = result.insertId;
@@ -524,13 +526,15 @@ export const updateThing = async (
 	withConnection(mysql, async (connection) => {
 		await connection.beginTransaction();
 		try {
+			const nextStart = data.startDate !== undefined ? data.startDate : current.startDate;
+			const nextFinish = data.finishDate ?? current.finishDate;
 			await connection.query(updateThingQuery, [
 				data.title ?? current.title,
 				data.text ?? current.text,
 				data.categoryId ?? current.categoryId,
 				data.statusId ?? current.statusId,
-				data.startDate !== undefined ? data.startDate : current.startDate,
-				data.finishDate ?? current.finishDate,
+				nextStart ? isoDateToDb(nextStart) : null,
+				isoDateToDb(nextFinish),
 				data.firstLines !== undefined ? data.firstLines : current.firstLines,
 				(data.firstLinesAutoGenerating ?? current.firstLinesAutoGenerating) ? 1 : 0,
 				(data.excludeFromDaily ?? current.excludeFromDaily) ? 1 : 0,

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isValidIsoDate } from '../../lib/isoDate.js';
 import { normalizeLegacyInfoJson, normalizeLegacyText } from '../../lib/normalizeLegacyText.js';
 
 // Defensive normalization for legacy text fields rendered via the BBCode-like
@@ -149,28 +150,10 @@ const seoFieldsTogether = (d: { seoDescription?: string | null; seoKeywords?: st
 };
 const seoFieldsTogetherMessage = { message: 'seoDescription and seoKeywords must be provided together or both be null' };
 
-// Partial date: YYYY-00-00 (year), YYYY-MM-00 (year-month), YYYY-MM-DD (full)
-// YYYY-00-DD is invalid (month=0 with day≠0)
-const partialDateRegex = /^\d{4}-(00-00|(0[1-9]|1[0-2])-(00|0[1-9]|[12]\d|3[01]))$/;
-
-const isValidPartialDate = (value: string): boolean => {
-	if (!partialDateRegex.test(value)) {
-		return false;
-	}
-
-	const [, mm, dd] = value.split('-');
-
-	// Partial dates (with 00) are valid by format alone
-	if (mm === '00' || dd === '00') {
-		return true;
-	}
-
-	// Full dates: verify the day is valid for the month
-	const date = new Date(value);
-	return date.getMonth() + 1 === Number(mm) && date.getDate() === Number(dd);
-};
-
-const partialDate = z.string().refine(isValidPartialDate, { message: 'Invalid date' });
+// ISO partial date: YYYY (year), YYYY-MM (year-month), YYYY-MM-DD (full).
+// Wire format; the cms helpers pad to YYYY-MM-DD with -00 segments before
+// inserting into the legacy MySQL DATE columns.
+const partialDate = z.string().refine(isValidIsoDate, { message: 'Invalid date' });
 
 export const cmsThingResponse = z.object({
 	id: z.number().int(),

--- a/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
+++ b/src/plugins/thingsOfTheDay/thingsOfTheDay.test.ts
@@ -77,12 +77,12 @@ describe('GET /things-of-the-day', () => {
 		expect(response.json()[0].firstLines).toBeUndefined();
 	});
 
-	it('returns things with unknown day (YYYY-MM-00)', async () => {
+	it('returns things with unknown day (DB YYYY-MM-00 → wire YYYY-MM)', async () => {
 		const app = buildApp(createMockMysql([{ ...thingRow, finishDate: '2024-01-00' }]));
 		const response = await app.inject({ method: 'GET', url: '/things-of-the-day' });
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()[0].finishDate).toBe('2024-01-00');
+		expect(response.json()[0].finishDate).toBe('2024-01');
 	});
 
 	it('uses fallback when no things match today\'s date', async () => {


### PR DESCRIPTION
## Summary
- Thing dates now go over the wire as ISO partial (`YYYY` | `YYYY-MM` | `YYYY-MM-DD`) instead of `YYYY-MM-DD` with `-00` padding
- DB stays unchanged: `MySQL DATE` columns with `-00` segments — `lib/isoDate.ts` converts at the api boundary
- CMS schemas reject the legacy `YYYY-MM-00` form on input; only ISO partial accepted now (with day-in-month check for full dates)

## Wire-format change

This is a breaking change for clients consuming `thing.startDate` / `thing.finishDate`. After this deploys:
- Public api: `finishDate: '1990-05'` (was `'1990-05-00'`), `'1990'` (was `'1990-00-00'`)
- CMS api: same trim on GET; PUT/POST require ISO partial

Coordinating client PRs (poetry-nextjs renderer + DateInput, www `<time datetime>` emission, poetry-ios) ship right after this deploys.

## Test plan
- [x] `npm test` — 220 tests pass (16 new isoDate unit tests, 11 new CMS round-trip tests)
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Smoke test on staging once deployed