### PR TITLE
Add workflow to auto-link new issues and PRs to project #1

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/mellonis/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,4 +146,4 @@ Validation and serialization use `fastify-type-provider-zod`. All Fastify route 
 
 **Logging** uses `pino-pretty` only when `NODE_ENV !== 'production'`; raw Pino otherwise.
 
-**Deployment**: image at `ghcr.io/mellonis/poetry-api`. Workflow pattern lives in workspace `CLAUDE.md`. PRs touching only `.md` files, `api.http`, or `smoke-test*.sh` skip the workflow entirely. When upgrading Node.js, keep the version in sync across `Dockerfile`, `.github/workflows/deploy.yml` (`node-version`), `tsconfig.json` (`@tsconfig/nodeXX`), and `package.json` (`@tsconfig/nodeXX` + `@types/node`).
+**Deployment**: image at `ghcr.io/mellonis/poetry-api`. Workflow pattern lives in `mellonis/vps` (`vps/CLAUDE.md`). PRs touching only `.md` files, `api.http`, or `smoke-test*.sh` skip the workflow entirely. When upgrading Node.js, keep the version in sync across `Dockerfile`, `.github/workflows/deploy.yml` (`node-version`), `tsconfig.json` (`@tsconfig/nodeXX`), and `package.json` (`@tsconfig/nodeXX` + `@types/node`).


### PR DESCRIPTION
Adds `.github/workflows/add-to-project.yml` — any newly opened issue or PR is automatically added to the [mellonis project board](https://github.com/users/mellonis/projects/1) via `actions/add-to-project`. Requires the `ADD_TO_PROJECT_PAT` secret (already set).