### PR TITLE
Set up semantic-release for automated version bumping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,13 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/git", {
+      "assets": ["package.json", "package-lock.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,15 +26,57 @@
 				"zod": "^4.3.6"
 			},
 			"devDependencies": {
+				"@semantic-release/commit-analyzer": "^13.0.1",
+				"@semantic-release/git": "^10.0.1",
+				"@semantic-release/github": "^11.0.6",
+				"@semantic-release/npm": "^12.0.2",
+				"@semantic-release/release-notes-generator": "^14.1.0",
 				"@tsconfig/node24": "^24.0.0",
 				"@types/bcryptjs": "^2.4.6",
 				"@types/node": "^24.0.0",
 				"@types/nodemailer": "^8.0.0",
 				"eslint": "^10.2.0",
+				"semantic-release": "^24.2.9",
 				"tsx": "^4.21.0",
 				"typescript": "^6.0.2",
 				"typescript-eslint": "^8.58.1",
 				"vitest": "^4.1.4"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1036,6 +1078,180 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@octokit/auth-token": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^6.0.0",
+				"@octokit/graphql": "^9.0.3",
+				"@octokit/request": "^10.0.6",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"before-after-hook": "^4.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^10.0.6",
+				"@octokit/types": "^16.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.1.tgz",
+			"integrity": "sha512-Tj4PkZyIL6eBMYcG/76QGsedF0+dWVeLhYprTmuFVVxzDW7PQh23tM0TP0z+1MvSkxB29YFZwnUX+cXfTiSdyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^15.0.1"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.2.tgz",
+			"integrity": "sha512-rR+5VRjhYSer7sC51krfCctQhVTmjyUMAaShfPB8mscVa8tSoLyon3coxQmXu0ahJoLVWl8dSGD/3OGZlFV44Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^26.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+			"integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=7"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
+			"integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^7.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "10.0.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+			"integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"fast-content-type-parse": "^3.0.0",
+				"json-with-bigint": "^3.5.3",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^27.0.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.126.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
@@ -1210,6 +1426,51 @@
 			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
 			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
 			"license": "MIT"
+		},
+		"node_modules/@pnpm/config.env-replace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "4.2.10"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@pnpm/npm-conf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+			"integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pnpm/config.env-replace": "^1.1.0",
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.0.0-rc.16",
@@ -1475,6 +1736,456 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@semantic-release/commit-analyzer": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+			"integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"conventional-changelog-angular": "^8.0.0",
+				"conventional-changelog-writer": "^8.0.0",
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.0.0",
+				"debug": "^4.0.0",
+				"import-from-esm": "^2.0.0",
+				"lodash-es": "^4.17.21",
+				"micromatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/error": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@semantic-release/git": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+			"integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^3.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"micromatch": "^4.0.0",
+				"p-reduce": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/github": {
+			"version": "11.0.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.6.tgz",
+			"integrity": "sha512-ctDzdSMrT3H+pwKBPdyCPty6Y47X8dSrjd3aPZ5KKIKKWTwZBE9De8GtsH3TyAlw3Uyo2stegMx6rJMXKpJwJA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^7.0.0",
+				"@octokit/plugin-paginate-rest": "^13.0.0",
+				"@octokit/plugin-retry": "^8.0.0",
+				"@octokit/plugin-throttling": "^11.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"debug": "^4.3.4",
+				"dir-glob": "^3.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"issue-parser": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"mime": "^4.0.0",
+				"p-filter": "^4.0.0",
+				"tinyglobby": "^0.2.14",
+				"url-join": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=24.1.0"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/clean-stack": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/mime": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+			"integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa"
+			],
+			"license": "MIT",
+			"bin": {
+				"mime": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@semantic-release/npm": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
+			"integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"execa": "^9.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash-es": "^4.17.21",
+				"nerf-dart": "^1.0.0",
+				"normalize-url": "^8.0.0",
+				"npm": "^10.9.3",
+				"rc": "^1.2.8",
+				"read-pkg": "^9.0.0",
+				"registry-auth-token": "^5.0.0",
+				"semver": "^7.1.2",
+				"tempy": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/clean-stack": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/execa": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+			"integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.6",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^8.0.1",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^6.0.0",
+				"pretty-ms": "^9.2.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/human-signals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
+			"integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"conventional-changelog-angular": "^8.0.0",
+				"conventional-changelog-writer": "^8.0.0",
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.0.0",
+				"debug": "^4.0.0",
+				"get-stream": "^7.0.0",
+				"import-from-esm": "^2.0.0",
+				"into-stream": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"read-package-up": "^11.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+			"integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
 		"node_modules/@simplewebauthn/server": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
@@ -1492,6 +2203,32 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@standard-schema/spec": {
@@ -1583,6 +2320,13 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.59.0",
@@ -1956,6 +2700,30 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2010,6 +2778,79 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/ansi-escapes": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+			"integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"environment": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/argv-formatter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/asn1js": {
@@ -2092,6 +2933,20 @@
 				"bcrypt": "bin/bcrypt"
 			}
 		},
+		"node_modules/before-after-hook": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2104,6 +2959,29 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2114,11 +2992,197 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"license": "MIT"
+		},
+		"node_modules/compare-func": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^5.1.0"
+			}
+		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
 		},
 		"node_modules/content-disposition": {
 			"version": "1.1.0",
@@ -2131,6 +3195,79 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/conventional-changelog-angular": {
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+			"integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-changelog-writer": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+			"integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0",
+				"conventional-commits-filter": "^5.0.0",
+				"handlebars": "^4.7.7",
+				"meow": "^13.0.0",
+				"semver": "^7.5.2"
+			},
+			"bin": {
+				"conventional-changelog-writer": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-commits-filter": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-commits-parser": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+			"integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0",
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/convert-hrtime": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+			"integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -2153,6 +3290,59 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cosmiconfig": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2166,6 +3356,35 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypto-random-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/crypto-random-string/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/dateformat": {
@@ -2192,6 +3411,16 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/deep-is": {
@@ -2238,6 +3467,56 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-obj": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -2245,6 +3524,197 @@
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-ci": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+			"integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^8.0.0",
+				"java-properties": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
+		},
+		"node_modules/env-ci/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/env-ci/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/env-ci/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/env-ci/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-module-lexer": {
@@ -2294,6 +3764,16 @@
 				"@esbuild/win32-arm64": "0.27.7",
 				"@esbuild/win32-ia32": "0.27.7",
 				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/escape-html": {
@@ -2477,6 +3957,43 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2486,6 +4003,23 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/fast-content-type-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/fast-copy": {
 			"version": "4.0.3",
@@ -2687,6 +4221,22 @@
 				}
 			}
 		},
+		"node_modules/figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2698,6 +4248,19 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/find-my-way": {
@@ -2731,6 +4294,36 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/find-up-simple": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+			"integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-versions": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+			"integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver-regex": "^4.0.5",
+				"super-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -2752,6 +4345,32 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.4",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2767,6 +4386,19 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-timeout": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+			"integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/generate-function": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -2774,6 +4406,29 @@
 			"license": "MIT",
 			"dependencies": {
 				"is-property": "^1.0.2"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-tsconfig": {
@@ -2787,6 +4442,31 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/git-log-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+			"integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argv-formatter": "~1.0.0",
+				"spawn-error-forwarder": "~1.0.0",
+				"split2": "~1.0.0",
+				"stream-combiner2": "~1.1.1",
+				"through2": "~2.0.0",
+				"traverse": "0.6.8"
+			}
+		},
+		"node_modules/git-log-parser/node_modules/split2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+			"integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"through2": "~2.0.0"
 			}
 		},
 		"node_modules/glob": {
@@ -2819,11 +4499,93 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/help-me": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
 			"integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
 			"license": "MIT"
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hook-std": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+			"integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
@@ -2843,6 +4605,44 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -2871,6 +4671,58 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/import-fresh": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-fresh/node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/import-from-esm": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+			"integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"import-meta-resolve": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18.20"
+			}
+		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2881,11 +4733,58 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/index-to-position": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/into-stream": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"from2": "^2.3.0",
+				"p-is-promise": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/ipaddr.js": {
 			"version": "2.3.0",
@@ -2896,6 +4795,13 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2904,6 +4810,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
@@ -2919,10 +4835,76 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
 			"integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+			"license": "MIT"
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isexe": {
@@ -2931,6 +4913,33 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/issue-parser": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+			"integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash.capitalize": "^4.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.uniqby": "^4.7.0"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
+		},
+		"node_modules/java-properties": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
 		},
 		"node_modules/jose": {
 			"version": "6.2.2",
@@ -2950,10 +4959,44 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3006,6 +5049,26 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-with-bigint": {
+			"version": "3.5.8",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+			"integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -3329,6 +5392,43 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/load-json-file/node_modules/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3344,6 +5444,55 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash-es": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.capitalize": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/long": {
 			"version": "5.3.2",
@@ -3385,6 +5534,59 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/make-asynchronous": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+			"integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-event": "^6.0.0",
+				"type-fest": "^4.6.0",
+				"web-worker": "^1.5.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/marked-terminal": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+			"integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"ansi-regex": "^6.1.0",
+				"chalk": "^5.4.1",
+				"cli-highlight": "^2.1.11",
+				"cli-table3": "^0.6.5",
+				"node-emoji": "^2.2.0",
+				"supports-hyperlinks": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"marked": ">=1 <16"
+			}
+		},
 		"node_modules/meilisearch": {
 			"version": "0.57.0",
 			"resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.57.0.tgz",
@@ -3392,6 +5594,53 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mime": {
@@ -3404,6 +5653,16 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -3467,6 +5726,18 @@
 				"@types/node": ">= 8"
 			}
 		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"node_modules/named-placeholders": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
@@ -3505,6 +5776,36 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nerf-dart": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-emoji": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+			"integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/nodemailer": {
 			"version": "8.0.5",
 			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
@@ -3512,6 +5813,2578 @@
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-url": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+			"integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm": {
+			"version": "10.9.8",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
+			"integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
+			"bundleDependencies": [
+				"@isaacs/string-locale-compare",
+				"@npmcli/arborist",
+				"@npmcli/config",
+				"@npmcli/fs",
+				"@npmcli/map-workspaces",
+				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
+				"@npmcli/redact",
+				"@npmcli/run-script",
+				"@sigstore/tuf",
+				"abbrev",
+				"archy",
+				"cacache",
+				"chalk",
+				"ci-info",
+				"cli-columns",
+				"fastest-levenshtein",
+				"fs-minipass",
+				"glob",
+				"graceful-fs",
+				"hosted-git-info",
+				"ini",
+				"init-package-json",
+				"is-cidr",
+				"json-parse-even-better-errors",
+				"libnpmaccess",
+				"libnpmdiff",
+				"libnpmexec",
+				"libnpmfund",
+				"libnpmhook",
+				"libnpmorg",
+				"libnpmpack",
+				"libnpmpublish",
+				"libnpmsearch",
+				"libnpmteam",
+				"libnpmversion",
+				"make-fetch-happen",
+				"minimatch",
+				"minipass",
+				"minipass-pipeline",
+				"ms",
+				"node-gyp",
+				"nopt",
+				"normalize-package-data",
+				"npm-audit-report",
+				"npm-install-checks",
+				"npm-package-arg",
+				"npm-pick-manifest",
+				"npm-profile",
+				"npm-registry-fetch",
+				"npm-user-validate",
+				"p-map",
+				"pacote",
+				"parse-conflict-json",
+				"proc-log",
+				"qrcode-terminal",
+				"read",
+				"semver",
+				"spdx-expression-parse",
+				"ssri",
+				"supports-color",
+				"tar",
+				"text-table",
+				"tiny-relative-date",
+				"treeverse",
+				"validate-npm-package-name",
+				"which",
+				"write-file-atomic"
+			],
+			"dev": true,
+			"license": "Artistic-2.0",
+			"workspaces": [
+				"docs",
+				"smoke-tests",
+				"mock-globals",
+				"mock-registry",
+				"workspaces/*"
+			],
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^8.0.5",
+				"@npmcli/config": "^9.0.0",
+				"@npmcli/fs": "^4.0.0",
+				"@npmcli/map-workspaces": "^4.0.2",
+				"@npmcli/package-json": "^6.2.0",
+				"@npmcli/promise-spawn": "^8.0.3",
+				"@npmcli/redact": "^3.2.2",
+				"@npmcli/run-script": "^9.1.0",
+				"@sigstore/tuf": "^3.1.1",
+				"abbrev": "^3.0.1",
+				"archy": "~1.0.0",
+				"cacache": "^19.0.1",
+				"chalk": "^5.6.2",
+				"ci-info": "^4.4.0",
+				"cli-columns": "^4.0.0",
+				"fastest-levenshtein": "^1.0.16",
+				"fs-minipass": "^3.0.3",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"hosted-git-info": "^8.1.0",
+				"ini": "^5.0.0",
+				"init-package-json": "^7.0.2",
+				"is-cidr": "^5.1.1",
+				"json-parse-even-better-errors": "^4.0.0",
+				"libnpmaccess": "^9.0.0",
+				"libnpmdiff": "^7.0.5",
+				"libnpmexec": "^9.0.5",
+				"libnpmfund": "^6.0.5",
+				"libnpmhook": "^11.0.0",
+				"libnpmorg": "^7.0.0",
+				"libnpmpack": "^8.0.5",
+				"libnpmpublish": "^10.0.2",
+				"libnpmsearch": "^8.0.0",
+				"libnpmteam": "^7.0.0",
+				"libnpmversion": "^7.0.0",
+				"make-fetch-happen": "^14.0.3",
+				"minimatch": "^9.0.9",
+				"minipass": "^7.1.3",
+				"minipass-pipeline": "^1.2.4",
+				"ms": "^2.1.2",
+				"node-gyp": "^11.5.0",
+				"nopt": "^8.1.0",
+				"normalize-package-data": "^7.0.1",
+				"npm-audit-report": "^6.0.0",
+				"npm-install-checks": "^7.1.2",
+				"npm-package-arg": "^12.0.2",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-profile": "^11.0.1",
+				"npm-registry-fetch": "^18.0.2",
+				"npm-user-validate": "^3.0.0",
+				"p-map": "^7.0.4",
+				"pacote": "^19.0.1",
+				"parse-conflict-json": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "^4.1.0",
+				"semver": "^7.7.4",
+				"spdx-expression-parse": "^4.0.0",
+				"ssri": "^12.0.0",
+				"supports-color": "^9.4.0",
+				"tar": "^7.5.11",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^3.0.0",
+				"validate-npm-package-name": "^6.0.2",
+				"which": "^5.0.0",
+				"write-file-atomic": "^6.0.0"
+			},
+			"bin": {
+				"npm": "bin/npm-cli.js",
+				"npx": "bin/npx-cli.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/@npmcli/agent": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/arborist": {
+			"version": "8.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/fs": "^4.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/metavuln-calculator": "^8.0.0",
+				"@npmcli/name-from-folder": "^3.0.0",
+				"@npmcli/node-gyp": "^4.0.0",
+				"@npmcli/package-json": "^6.0.1",
+				"@npmcli/query": "^4.0.0",
+				"@npmcli/redact": "^3.0.0",
+				"@npmcli/run-script": "^9.0.1",
+				"bin-links": "^5.0.0",
+				"cacache": "^19.0.1",
+				"common-ancestor-path": "^1.0.1",
+				"hosted-git-info": "^8.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
+				"json-stringify-nice": "^1.1.4",
+				"lru-cache": "^10.2.2",
+				"minimatch": "^9.0.4",
+				"nopt": "^8.0.0",
+				"npm-install-checks": "^7.1.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.1",
+				"pacote": "^19.0.0",
+				"parse-conflict-json": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"proggy": "^3.0.0",
+				"promise-all-reject-late": "^1.0.0",
+				"promise-call-limit": "^3.0.1",
+				"promise-retry": "^2.0.1",
+				"read-package-json-fast": "^4.0.0",
+				"semver": "^7.3.7",
+				"ssri": "^12.0.0",
+				"treeverse": "^3.0.0",
+				"walk-up-path": "^3.0.1"
+			},
+			"bin": {
+				"arborist": "bin/index.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/config": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/package-json": "^6.0.1",
+				"ci-info": "^4.0.0",
+				"ini": "^5.0.0",
+				"nopt": "^8.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.5",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/fs": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/git": {
+			"version": "6.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/promise-spawn": "^8.0.0",
+				"ini": "^5.0.0",
+				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^10.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^4.0.0",
+				"npm-normalize-package-bin": "^4.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
+			"version": "4.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/name-from-folder": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"glob": "^10.2.2",
+				"minimatch": "^9.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+			"version": "8.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cacache": "^19.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
+				"pacote": "^20.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+			"version": "20.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^6.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/run-script": "^9.0.0",
+				"cacache": "^19.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^12.0.0",
+				"npm-packlist": "^9.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"sigstore": "^3.0.0",
+				"ssri": "^12.0.0",
+				"tar": "^7.5.10"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/package-json": {
+			"version": "6.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^6.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^8.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.5.3",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
+			"version": "8.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/query": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/redact": {
+			"version": "3.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/run-script": {
+			"version": "9.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/node-gyp": "^4.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"node-gyp": "^11.0.0",
+				"proc-log": "^5.0.0",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.4.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+			"version": "0.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.0",
+				"make-fetch-happen": "^14.0.2",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.4.1",
+				"tuf-js": "^3.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
+			"version": "2.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/canonical-json": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/abbrev": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/agent-base": {
+			"version": "7.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/aproba": {
+			"version": "2.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/archy": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/bin-links": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cmd-shim": "^7.0.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"read-cmd-shim": "^5.0.0",
+				"write-file-atomic": "^6.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/cacache": {
+			"version": "19.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^4.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^7.0.2",
+				"ssri": "^12.0.0",
+				"tar": "^7.4.3",
+				"unique-filename": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/chalk": {
+			"version": "5.6.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/chownr": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/ci-info": {
+			"version": "4.4.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/cidr-regex": {
+			"version": "4.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"ip-regex": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/cli-columns": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/npm/node_modules/cmd-shim": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/common-ancestor-path": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cssesc": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/debug": {
+			"version": "4.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/diff": {
+			"version": "5.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/npm/node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/encoding": {
+			"version": "0.1.13",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
+		},
+		"node_modules/npm/node_modules/env-paths": {
+			"version": "2.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/err-code": {
+			"version": "2.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/exponential-backoff": {
+			"version": "3.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/npm/node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/npm/node_modules/fdir": {
+			"version": "6.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/foreground-child": {
+			"version": "3.3.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/fs-minipass": {
+			"version": "3.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/glob": {
+			"version": "10.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/hosted-git-info": {
+			"version": "8.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npm/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm/node_modules/ignore-walk": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^9.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/npm/node_modules/ini": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/init-package-json": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/package-json": "^6.0.0",
+				"npm-package-arg": "^12.0.0",
+				"promzard": "^2.0.0",
+				"read": "^4.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4",
+				"validate-npm-package-name": "^6.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/ip-address": {
+			"version": "10.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/npm/node_modules/ip-regex": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/is-cidr": {
+			"version": "5.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"cidr-regex": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/isexe": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-stringify-nice": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/jsonparse": {
+			"version": "1.3.1",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff-apply": {
+			"version": "5.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/libnpmaccess": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^12.0.0",
+				"npm-registry-fetch": "^18.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmdiff": {
+			"version": "7.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^8.0.5",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"binary-extensions": "^2.3.0",
+				"diff": "^5.1.0",
+				"minimatch": "^9.0.4",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0",
+				"tar": "^7.5.11"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmexec": {
+			"version": "9.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^8.0.5",
+				"@npmcli/run-script": "^9.0.1",
+				"ci-info": "^4.0.0",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0",
+				"proc-log": "^5.0.0",
+				"read": "^4.0.0",
+				"read-package-json-fast": "^4.0.0",
+				"semver": "^7.3.7",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmfund": {
+			"version": "6.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^8.0.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmhook": {
+			"version": "11.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^18.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmorg": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^18.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "8.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^8.0.5",
+				"@npmcli/run-script": "^9.0.1",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpublish": {
+			"version": "10.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ci-info": "^4.0.0",
+				"normalize-package-data": "^7.0.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-registry-fetch": "^18.0.1",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.7",
+				"sigstore": "^3.0.0",
+				"ssri": "^12.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmsearch": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^18.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmteam": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^18.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmversion": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^6.0.1",
+				"@npmcli/run-script": "^9.0.1",
+				"json-parse-even-better-errors": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/make-fetch-happen": {
+			"version": "14.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^3.0.0",
+				"cacache": "^19.0.1",
+				"http-cache-semantics": "^4.1.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^4.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^1.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"ssri": "^12.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/minimatch": {
+			"version": "9.0.9",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/minipass": {
+			"version": "7.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-collect": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-fetch": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^3.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush": {
+			"version": "1.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/minipass-pipeline": {
+			"version": "1.2.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/minipass-sized": {
+			"version": "1.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/minizlib": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/npm/node_modules/ms": {
+			"version": "2.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/mute-stream": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp": {
+			"version": "11.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^14.0.3",
+				"nopt": "^8.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.5",
+				"tar": "^7.4.3",
+				"tinyglobby": "^0.2.12",
+				"which": "^5.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "8.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^3.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/normalize-package-data": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^8.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-audit-report": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-install-checks": {
+			"version": "7.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^7.1.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-normalize-package-bin": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-package-arg": {
+			"version": "12.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^8.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^6.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-packlist": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^7.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest": {
+			"version": "10.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^7.1.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"npm-package-arg": "^12.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-profile": {
+			"version": "11.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch": {
+			"version": "18.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/redact": "^3.0.0",
+				"jsonparse": "^1.3.1",
+				"make-fetch-happen": "^14.0.0",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^4.0.0",
+				"minizlib": "^3.0.1",
+				"npm-package-arg": "^12.0.0",
+				"proc-log": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-user-validate": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/p-map": {
+			"version": "7.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/npm/node_modules/pacote": {
+			"version": "19.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^6.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/run-script": "^9.0.0",
+				"cacache": "^19.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^12.0.0",
+				"npm-packlist": "^9.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"sigstore": "^3.0.0",
+				"ssri": "^12.0.0",
+				"tar": "^7.5.10"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/parse-conflict-json": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^4.0.0",
+				"just-diff": "^6.0.0",
+				"just-diff-apply": "^5.2.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/path-key": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/picomatch": {
+			"version": "4.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/npm/node_modules/postcss-selector-parser": {
+			"version": "7.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/proc-log": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/proggy": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/promise-all-reject-late": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-call-limit": {
+			"version": "3.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-retry": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"err-code": "^2.0.2",
+				"retry": "^0.12.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/promzard": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"read": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/qrcode-terminal": {
+			"version": "0.12.0",
+			"dev": true,
+			"inBundle": true,
+			"bin": {
+				"qrcode-terminal": "bin/qrcode-terminal.js"
+			}
+		},
+		"node_modules/npm/node_modules/read": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "^2.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json-fast": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^4.0.0",
+				"npm-normalize-package-bin": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/retry": {
+			"version": "0.12.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/npm/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/npm/node_modules/semver": {
+			"version": "7.7.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/sigstore": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^3.1.0",
+				"@sigstore/core": "^2.0.0",
+				"@sigstore/protobuf-specs": "^0.4.0",
+				"@sigstore/sign": "^3.1.0",
+				"@sigstore/tuf": "^3.1.0",
+				"@sigstore/verify": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks": {
+			"version": "2.8.7",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/npm/node_modules/spdx-expression-parse": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-license-ids": {
+			"version": "3.0.23",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/npm/node_modules/ssri": {
+			"version": "12.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/string-width": {
+			"version": "4.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/supports-color": {
+			"version": "9.4.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/tar": {
+			"version": "7.5.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/text-table": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tiny-relative-date": {
+			"version": "1.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/npm/node_modules/treeverse": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/models": "3.0.1",
+				"debug": "^4.4.1",
+				"make-fetch-happen": "^14.0.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^9.0.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-filename": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-slug": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/validate-npm-package-name": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/walk-up-path": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/which": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/which/node_modules/isexe": {
+			"version": "3.1.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/write-file-atomic": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/yallist": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/obug": {
@@ -3543,6 +8416,22 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/openapi-types": {
 			"version": "12.1.3",
 			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -3565,6 +8454,61 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-each-series": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+			"integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-event": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+			"integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-timeout": "^6.1.2"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-filter": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-map": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-is-promise": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-limit": {
@@ -3598,6 +8542,120 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-reduce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -3635,6 +8693,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3660,6 +8728,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/pino": {
@@ -3723,6 +8801,83 @@
 			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
 			"license": "MIT"
 		},
+		"node_modules/pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.10",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -3762,6 +8917,29 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/pretty-ms": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+			"integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse-ms": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/process-warning": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3777,6 +8955,13 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/pump": {
 			"version": "3.0.4",
@@ -3822,6 +9007,86 @@
 			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
 			"license": "MIT"
 		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"node_modules/real-require": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -3837,6 +9102,29 @@
 			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/registry-auth-token": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+			"integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pnpm/npm-conf": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3844,6 +9132,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/resolve-pkg-maps": {
@@ -3915,6 +9213,13 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/safe-regex2": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
@@ -3968,6 +9273,301 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/semantic-release": {
+			"version": "24.2.9",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.9.tgz",
+			"integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@semantic-release/commit-analyzer": "^13.0.0-beta.1",
+				"@semantic-release/error": "^4.0.0",
+				"@semantic-release/github": "^11.0.0",
+				"@semantic-release/npm": "^12.0.2",
+				"@semantic-release/release-notes-generator": "^14.0.0-beta.1",
+				"aggregate-error": "^5.0.0",
+				"cosmiconfig": "^9.0.0",
+				"debug": "^4.0.0",
+				"env-ci": "^11.0.0",
+				"execa": "^9.0.0",
+				"figures": "^6.0.0",
+				"find-versions": "^6.0.0",
+				"get-stream": "^6.0.0",
+				"git-log-parser": "^1.2.0",
+				"hook-std": "^4.0.0",
+				"hosted-git-info": "^8.0.0",
+				"import-from-esm": "^2.0.0",
+				"lodash-es": "^4.17.21",
+				"marked": "^15.0.0",
+				"marked-terminal": "^7.3.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^3.0.0",
+				"p-reduce": "^3.0.0",
+				"read-package-up": "^11.0.0",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.3.2",
+				"semver-diff": "^5.0.0",
+				"signale": "^1.2.1",
+				"yargs": "^17.5.1"
+			},
+			"bin": {
+				"semantic-release": "bin/semantic-release.js"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/semantic-release/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/clean-stack": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+			"integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.6",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^8.0.1",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^6.0.0",
+				"pretty-ms": "^9.2.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/hosted-git-info": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/semantic-release/node_modules/human-signals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/semantic-release/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/semantic-release/node_modules/npm-run-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/p-reduce": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/semantic-release/node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3978,6 +9578,36 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/semver-diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-5.0.0.tgz",
+			"integrity": "sha512-0HbGtOm+S7T6NGQ/pxJSJipJvc4DK3FcRVMRkhsIwJDJ4Jcz5DQC1cPPzB5GhzyHjwttW878HaWQq46CkL3cqg==",
+			"deprecated": "Deprecated as the semver package now supports this built-in.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semver-regex": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+			"integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/set-cookie-parser": {
@@ -4022,6 +9652,132 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/signale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+			"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^2.3.2",
+				"figures": "^2.0.0",
+				"pkg-conf": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/signale/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/signale/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/signale/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/signale/node_modules/figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/sonic-boom": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -4029,6 +9785,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -4040,6 +9806,49 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/spawn-error-forwarder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+			"integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/split2": {
 			"version": "4.2.0",
@@ -4088,6 +9897,85 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/strip-json-comments": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -4100,6 +9988,132 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/super-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+			"integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-timeout": "^1.0.1",
+				"make-asynchronous": "^1.0.1",
+				"time-span": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+			}
+		},
+		"node_modules/temp-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/tempy": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+			"integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-stream": "^3.0.0",
+				"temp-dir": "^3.0.0",
+				"type-fest": "^2.12.2",
+				"unique-string": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/thread-stream": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -4110,6 +10124,33 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"node_modules/time-span": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+			"integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"convert-hrtime": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tinybench": {
@@ -4156,6 +10197,19 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
 		"node_modules/toad-cache": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
@@ -4172,6 +10226,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/traverse": {
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+			"integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -4244,6 +10311,19 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -4282,11 +10362,81 @@
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"license": "MIT"
+		},
+		"node_modules/unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/unique-string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crypto-random-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -4296,6 +10446,34 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/vite": {
@@ -4466,6 +10644,13 @@
 				}
 			}
 		},
+		"node_modules/web-worker": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+			"integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4509,11 +10694,56 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC"
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/yaml": {
 			"version": "2.8.3",
@@ -4530,6 +10760,35 @@
 				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4538,6 +10797,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -36,11 +36,17 @@
 		}
 	},
 	"devDependencies": {
+		"@semantic-release/commit-analyzer": "^13.0.1",
+		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/github": "^11.0.6",
+		"@semantic-release/npm": "^12.0.2",
+		"@semantic-release/release-notes-generator": "^14.1.0",
 		"@tsconfig/node24": "^24.0.0",
 		"@types/bcryptjs": "^2.4.6",
 		"@types/node": "^24.0.0",
 		"@types/nodemailer": "^8.0.0",
 		"eslint": "^10.2.0",
+		"semantic-release": "^24.2.9",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
 		"typescript-eslint": "^8.58.1",


### PR DESCRIPTION
## Summary

- Installs `semantic-release` and plugins (`@semantic-release/commit-analyzer`, `release-notes-generator`, `npm`, `git`, `github`)
- Adds `.releaserc.json`: branches `master`, `npmPublish: false`, commits version bump with `[skip ci]`
- Adds `.github/workflows/release.yml` triggered on push to master — runs `npx semantic-release`

## How it works

| Commit prefix | Version bump |
|---|---|
| `fix:` | patch |
| `feat:` | minor |
| `BREAKING CHANGE` footer | major |

Commits without a recognized prefix produce no release. The first release will happen on the first qualifying merge to master after this PR lands.

## Setup required (one-time, before merging)

- [ ] Create a classic PAT with `repo` scope and store it as `RELEASE_PAT` secret in this repo
- [ ] Add the PAT owner to the branch protection bypass list for `master` (so semantic-release can push the version bump commit)

Closes #115