### PR TITLE
Add notification settings endpoints and gate comment emails on prefs

### DIFF
--- a/src/plugins/comments/comments.test.ts
+++ b/src/plugins/comments/comments.test.ts
@@ -282,6 +282,7 @@ describe('PUT /comments/:commentId/vote', () => {
 				authorEmail: 'author@example.com',
 				authorUserRights: 24,
 				authorGroupRights: 0,
+				authorNotifyOnVote: 1,
 				sectionIdentifier: 'poems',
 				positionInSection: 3,
 			}],

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -183,7 +183,12 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			// the parent shows the new reply under it in single-thread mode.
 			if (parentId !== null) {
 				const ctx = await getCommentReplyContext(fastify.mysql, parentId);
-				if (ctx?.parentAuthor && ctx.parentAuthor.userId !== userId && !ctx.parentAuthor.isBanned) {
+				if (
+					ctx?.parentAuthor &&
+					ctx.parentAuthor.userId !== userId &&
+					!ctx.parentAuthor.isBanned &&
+					ctx.parentAuthor.notifyAuthorOnCommentReply
+				) {
 					const recipient = ctx.parentAuthor;
 					const replierLogin = request.user!.login;
 					const siteOrigin = fastify.resolveOrigin(request);
@@ -310,7 +315,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				// the comment author) and votes on comments by deleted users.
 				if (meta.userId !== null && meta.userId !== userId) {
 					const ctx = await getCommentVoteContext(fastify.mysql, commentId);
-					if (ctx?.author && !ctx.author.isBanned) {
+					if (ctx?.author && !ctx.author.isBanned && ctx.author.notifyAuthorOnCommentVote) {
 						const siteOrigin = fastify.resolveOrigin(request);
 						const threadHref = buildThreadHref(siteOrigin, ctx, ctx.threadCommentId);
 						sendEmail(

--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -182,6 +182,7 @@ export interface CommentReplyContext {
 			login: string;
 			email: string;
 			isBanned: boolean;
+			notifyAuthorOnCommentReply: boolean;
 		}
 		| null;
 	thingId: number | null;
@@ -211,6 +212,7 @@ export const getCommentReplyContext = async (
 				login: row.authorLogin as string,
 				email: row.authorEmail as string,
 				isBanned: banned,
+				notifyAuthorOnCommentReply: (row.authorNotifyOnReply as number) === 1,
 			}
 			: null;
 
@@ -229,6 +231,7 @@ export interface CommentVoteContext {
 			login: string;
 			email: string;
 			isBanned: boolean;
+			notifyAuthorOnCommentVote: boolean;
 		}
 		| null;
 	commentText: string;
@@ -262,6 +265,7 @@ export const getCommentVoteContext = async (
 				login: row.authorLogin as string,
 				email: row.authorEmail as string,
 				isBanned: banned,
+				notifyAuthorOnCommentVote: (row.authorNotifyOnVote as number) === 1,
 			}
 			: null;
 

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -138,6 +138,7 @@ export const commentReplyContextQuery = `
     u.email       AS authorEmail,
     u.rights      AS authorUserRights,
     g.rights      AS authorGroupRights,
+    u.notify_author_on_comment_reply AS authorNotifyOnReply,
     s.identifier               AS sectionIdentifier,
     ti.thing_position_in_section AS positionInSection
   FROM comment pc
@@ -162,6 +163,7 @@ export const commentVoteContextQuery = `
     u.email       AS authorEmail,
     u.rights      AS authorUserRights,
     g.rights      AS authorGroupRights,
+    u.notify_author_on_comment_vote AS authorNotifyOnVote,
     s.identifier               AS sectionIdentifier,
     ti.thing_position_in_section AS positionInSection
   FROM comment c

--- a/src/plugins/users/databaseHelpers.ts
+++ b/src/plugins/users/databaseHelpers.ts
@@ -4,6 +4,8 @@ import {
 	getUserPasswordAndEmailQuery,
 	updatePasswordQuery,
 	deleteUserQuery,
+	getNotificationSettingsQuery,
+	updateNotificationSettingsQuery,
 } from './queries.js';
 
 export interface UserCredentials {
@@ -28,5 +30,37 @@ export const updatePassword = async (mysql: MySQLPromisePool, userId: number, pa
 export const deleteUser = async (mysql: MySQLPromisePool, userId: number): Promise<void> => {
 	await withConnection(mysql, async (connection) => {
 		await connection.query(deleteUserQuery, [userId]);
+	});
+};
+
+export interface NotificationSettings {
+	notifyAuthorOnCommentReply: boolean;
+	notifyAuthorOnCommentVote: boolean;
+}
+
+export const getNotificationSettings = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+): Promise<NotificationSettings | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(getNotificationSettingsQuery, [userId]);
+		if (!rows[0]) return null;
+		return {
+			notifyAuthorOnCommentReply: rows[0].notify_author_on_comment_reply === 1,
+			notifyAuthorOnCommentVote: rows[0].notify_author_on_comment_vote === 1,
+		};
+	});
+
+export const updateNotificationSettings = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+	settings: NotificationSettings,
+): Promise<void> => {
+	await withConnection(mysql, async (connection) => {
+		await connection.query(updateNotificationSettingsQuery, [
+			settings.notifyAuthorOnCommentReply ? 1 : 0,
+			settings.notifyAuthorOnCommentVote ? 1 : 0,
+			userId,
+		]);
 	});
 };

--- a/src/plugins/users/queries.ts
+++ b/src/plugins/users/queries.ts
@@ -15,3 +15,15 @@ export const deleteUserQuery = `
 	FROM auth_user
 	WHERE id = ?
 `;
+
+export const getNotificationSettingsQuery = `
+	SELECT notify_author_on_comment_reply, notify_author_on_comment_vote
+	FROM auth_user
+	WHERE id = ?
+`;
+
+export const updateNotificationSettingsQuery = `
+	UPDATE auth_user
+	SET notify_author_on_comment_reply = ?, notify_author_on_comment_vote = ?
+	WHERE id = ?
+`;

--- a/src/plugins/users/schemas.ts
+++ b/src/plugins/users/schemas.ts
@@ -13,6 +13,18 @@ export const deleteUserRequest = z.object({
 	password: z.string().min(1),
 });
 
+export const notificationSettingsResponse = z.object({
+	notifyAuthorOnCommentReply: z.boolean(),
+	notifyAuthorOnCommentVote: z.boolean(),
+});
+
+export const updateNotificationSettingsRequest = z.object({
+	notifyAuthorOnCommentReply: z.boolean(),
+	notifyAuthorOnCommentVote: z.boolean(),
+});
+
 export type UserIdParam = z.infer<typeof userIdParam>;
 export type ChangePasswordRequest = z.infer<typeof changePasswordRequest>;
 export type DeleteUserRequest = z.infer<typeof deleteUserRequest>;
+export type NotificationSettingsResponse = z.infer<typeof notificationSettingsResponse>;
+export type UpdateNotificationSettingsRequest = z.infer<typeof updateNotificationSettingsRequest>;

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -5,15 +5,18 @@ import { sendEmail } from '../../lib/email.js';
 import { accountDeletedEmail } from '../../lib/emailTemplates.js';
 import { checkPassword, hashPassword } from '../auth/password.js';
 import { deleteAllUserRefreshTokens } from '../auth/databaseHelpers.js';
-import { getUserCredentials, updatePassword, deleteUser } from './databaseHelpers.js';
+import { getUserCredentials, updatePassword, deleteUser, getNotificationSettings, updateNotificationSettings } from './databaseHelpers.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import {
 	userIdParam,
 	changePasswordRequest,
 	deleteUserRequest,
+	notificationSettingsResponse,
+	updateNotificationSettingsRequest,
 	type UserIdParam,
 	type ChangePasswordRequest,
 	type DeleteUserRequest,
+	type UpdateNotificationSettingsRequest,
 } from './schemas.js';
 
 export async function usersPlugin(fastify: FastifyInstance) {
@@ -127,6 +130,84 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				}
 
 				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.get('/:userId/notification-settings', {
+		schema: {
+			description: 'Get notification preferences for the authenticated user.',
+			tags: ['Users'],
+			params: userIdParam,
+			response: {
+				200: notificationSettingsResponse,
+				403: authErrorResponse,
+				404: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const { userId } = request.params;
+				const user = request.user!;
+
+				if (user.sub !== userId) {
+					return reply.code(403).send({ error: 'forbidden', message: 'Cannot read another user\'s notification settings' });
+				}
+
+				const settings = await getNotificationSettings(fastify.mysql, userId);
+
+				if (!settings) {
+					return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
+				}
+
+				return settings;
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.put('/:userId/notification-settings', {
+		schema: {
+			description: 'Update notification preferences for the authenticated user.',
+			tags: ['Users'],
+			params: userIdParam,
+			body: updateNotificationSettingsRequest,
+			response: {
+				200: notificationSettingsResponse,
+				403: authErrorResponse,
+				404: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (
+			request: FastifyRequest<{ Params: UserIdParam; Body: UpdateNotificationSettingsRequest }>,
+			reply,
+		) => {
+			try {
+				const { userId } = request.params;
+				const user = request.user!;
+
+				if (user.sub !== userId) {
+					return reply.code(403).send({ error: 'forbidden', message: 'Cannot update another user\'s notification settings' });
+				}
+
+				const existing = await getNotificationSettings(fastify.mysql, userId);
+
+				if (!existing) {
+					return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
+				}
+
+				const { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote } = request.body;
+				await updateNotificationSettings(fastify.mysql, userId, { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote });
+				request.log.info({ userId }, 'Notification settings updated');
+
+				return { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote };
 			} catch (error) {
 				request.log.error(error);
 				return reply.code(500).send({ error: 'Internal server error' });


### PR DESCRIPTION
## Summary

- Adds `GET /users/:userId/notification-settings` — returns `{ notifyAuthorOnCommentReply, notifyAuthorOnCommentVote }`
- Adds `PUT /users/:userId/notification-settings` — updates both prefs, self-only, authenticated
- Comment reply and vote notification emails are now skipped when the recipient has the corresponding preference disabled
- Closes #112

## Test plan

- [ ] Ensure DB migration (poetry-old2 PR) is applied before deploying
- [ ] `GET /users/:id/notification-settings` returns correct defaults (`true`/`true`)
- [ ] `PUT` updates both fields; subsequent `GET` reflects changes
- [ ] Reply email not sent when `notifyAuthorOnCommentReply = false`
- [ ] Vote email not sent when `notifyAuthorOnCommentVote = false`