### PR TITLE
fix: update docker actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: |


### PR DESCRIPTION
Closes #120

Updates `docker/login-action` from v3 to v4 and `docker/build-push-action` from v6 to v7. These versions support Node.js 24, which becomes the default GitHub Actions runner in June 2026.