### PR TITLE
Privacy-safe logging: actorFingerprint helper, call-site migration, CI guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ WEBAUTHN_RP_ID=localhost
 ADMIN_NOTIFY_EMAIL=
 MEILI_URL=http://poetry-meilisearch:7700
 MEILI_MASTER_KEY=
+LOG_HMAC_KEY_CURRENT=dev-placeholder-do-not-use-in-prod-this-is-only-for-local-tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ WEBAUTHN_RP_ID=poetry.mellonis.ru       # optional, WebAuthn Relying Party ID (d
 ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions, comment reports
 MEILI_URL=http://poetry-meilisearch:7700  # optional, Meilisearch host (default: http://poetry-meilisearch:7700)
 MEILI_MASTER_KEY=<key>               # optional (required for search to work), shared with Meilisearch container
+LOG_HMAC_KEY_CURRENT=<32-byte hex>      # required, HMAC key for actorFingerprint() log helper. In prod, written by the VPS rotation script (see mellonis/poetry docs/superpowers/specs/2026-05-05-privacy-safe-logging-design.md). In dev, any non-empty string works.
+LOG_HMAC_KEY_PREVIOUS=<32-byte hex>     # optional, prior HMAC key during rotation overlap; not read by emitters but kept in env for log analysts.
 ```
 
 See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead. If `MEILI_MASTER_KEY` is not set, search is disabled (sync calls become no-ops, `GET /search` returns 503).
@@ -146,5 +148,7 @@ Validation and serialization use `fastify-type-provider-zod`. All Fastify route 
 **`withConnection(mysql, fn)`** in `src/lib/databaseHelpers.ts` — shared helper for all DB access; handles pool acquire/release via try/finally. MySQL server timezone is set to `+03:00` (Moscow) via `default-time-zone` in `mysql.cnf` — all `NOW()`, `CURDATE()`, and timestamp comparisons run in Moscow time. Verification key TTL checks use `Date.now()` (Node.js clock, UTC epoch) against the key's embedded timestamp (also `Date.now()` at generation) — self-consistent regardless of server timezone. These two clocks (DB server vs Node.js) don't cross.
 
 **Logging** uses `pino-pretty` only when `NODE_ENV !== 'production'`; raw Pino otherwise.
+
+**Privacy-safe logging** — log call sites MUST NOT include raw `userId`, `user_id`, `login`, or unmasked `email`. Use `actorFingerprint(id)` from `src/lib/actorFingerprint.ts` for actor identity (`HMAC-SHA256` of the user id, truncated to 16 hex chars, keyed by `LOG_HMAC_KEY_CURRENT`). Field naming convention: `actorFingerprint` (action-taker), `subjectFingerprint` (target of an admin action), `recipientFingerprint` (recipient of a notification). Email values use the existing `maskEmail()`. The CI guard at `src/lib/__tests__/no-raw-identifiers.test.ts` blocks regressions. Spec: `mellonis/poetry docs/superpowers/specs/2026-05-05-privacy-safe-logging-design.md`.
 
 **Deployment**: image at `ghcr.io/mellonis/poetry-api`. Workflow pattern lives in `mellonis/vps` (`vps/CLAUDE.md`). PRs touching only `.md` files, `api.http`, or `smoke-test*.sh` skip the workflow entirely. When upgrading Node.js, keep the version in sync across `Dockerfile`, `.github/workflows/deploy.yml` (`node-version`), `tsconfig.json` (`@tsconfig/nodeXX`), and `package.json` (`@tsconfig/nodeXX` + `@types/node`).

--- a/src/lib/__tests__/__fixtures__/allowed-log.ts
+++ b/src/lib/__tests__/__fixtures__/allowed-log.ts
@@ -1,0 +1,13 @@
+// Fixture: this file must NOT be flagged by the CI guard. It uses the
+// migrated pattern (actorFingerprint instead of raw userId). If the guard
+// ever flags this file, the regex has a false-positive bug.
+import { actorFingerprint } from '../../actorFingerprint.js';
+
+type LogShape = { log: { info: (obj: object, msg: string) => void } };
+
+export const ALLOWED_SAMPLE = ((): null => {
+	const request: LogShape = { log: { info: () => {} } };
+	const userId = 1;
+	request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Allowed: migrated pattern');
+	return null;
+})();

--- a/src/lib/__tests__/__fixtures__/forbidden-log.ts
+++ b/src/lib/__tests__/__fixtures__/forbidden-log.ts
@@ -1,0 +1,16 @@
+// Fixture: this file MUST be flagged by the CI guard. It contains a forbidden
+// pattern (raw `userId` as a shorthand property in a `request.log.*` call).
+// The CI guard scans all of src/, and `__tests__/__fixtures__/` is intentionally
+// NOT excluded — the guard must catch this file. This is the regex's self-test:
+// if it ever stops catching this fixture, the regex is silently broken and the
+// guard becomes useless.
+//
+// No runtime side-effects: the IIFE returns null and stores it in a const.
+type LogShape = { log: { info: (obj: object, msg: string) => void } };
+
+export const FORBIDDEN_SAMPLE = ((): null => {
+	const request: LogShape = { log: { info: () => {} } };
+	const userId = 1;
+	request.log.info({ userId }, 'Forbidden: raw userId as shorthand property');
+	return null;
+})();

--- a/src/lib/__tests__/no-raw-identifiers.test.ts
+++ b/src/lib/__tests__/no-raw-identifiers.test.ts
@@ -2,18 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
-// Forbidden patterns: a `request.log.*` or `fastify.log.*` call whose
-// first argument object contains `userId`, `user_id`, or `login` as a
-// property name (shorthand or explicit key). Uses `[{,]` followed by
-// optional whitespace so it catches both `{ userId }` (shorthand) and
-// `{ login: user.login, userId }` (explicit key after comma). Does NOT
-// catch `actorFingerprint(userId)` because `userId` there follows `(`,
-// not `{` or `,`.
+// Forbidden patterns: a log call whose first argument object contains
+// `userId`, `user_id`, or `login` as a property name (shorthand or explicit
+// key). Uses `[{,]` followed by optional whitespace so it catches both
+// `{ userId }` (shorthand) and `{ login: user.login, userId }` (explicit
+// key after comma). Does NOT catch `actorFingerprint(userId)` because
+// `userId` there follows `(`, not `{` or `,`.
+//
+// Covers three logger styles:
+//   - `request.log.*`  — route handlers
+//   - `fastify.log.*`  — plugin-level code
+//   - `*.logger.*`     — class-level loggers (e.g. `this.logger.*` in
+//                        EmailAuthNotifier / ConsoleAuthNotifier)
 //
 // Limitation: multi-line log calls are not checked. This is intentional —
 // keeping calls on one line is itself a style constraint the migration enforced.
 const FORBIDDEN_REGEX =
-	String.raw`(request|fastify)\.log\.(info|warn|error|debug)\([^)]*[{,][[:space:]]*\b(userId|user_id|login)\b`;
+	String.raw`((request|fastify)\.log|\.logger)\.(info|warn|error|debug)\([^)]*[{,][[:space:]]*\b(userId|user_id|login)\b`;
 
 const SRC_ROOT = resolve(__dirname, '../../..');
 

--- a/src/lib/__tests__/no-raw-identifiers.test.ts
+++ b/src/lib/__tests__/no-raw-identifiers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+// Forbidden patterns: a `request.log.*` or `fastify.log.*` call whose
+// first argument object contains `userId`, `user_id`, or `login` as a
+// property name (shorthand or explicit key). Uses `[{,]` followed by
+// optional whitespace so it catches both `{ userId }` (shorthand) and
+// `{ login: user.login, userId }` (explicit key after comma). Does NOT
+// catch `actorFingerprint(userId)` because `userId` there follows `(`,
+// not `{` or `,`.
+//
+// Limitation: multi-line log calls are not checked. This is intentional —
+// keeping calls on one line is itself a style constraint the migration enforced.
+const FORBIDDEN_REGEX =
+	String.raw`(request|fastify)\.log\.(info|warn|error|debug)\([^)]*[{,][[:space:]]*\b(userId|user_id|login)\b`;
+
+const SRC_ROOT = resolve(__dirname, '../../..');
+
+const ALLOWED_FILES = [
+	'src/lib/__tests__/__fixtures__/allowed-log.ts',
+];
+
+const FORBIDDEN_FIXTURE = 'src/lib/__tests__/__fixtures__/forbidden-log.ts';
+
+function grep(pattern: string): string[] {
+	try {
+		const output = execSync(
+			`grep -rEn '${pattern}' src/ --include='*.ts'`,
+			{ encoding: 'utf8', cwd: SRC_ROOT },
+		);
+		return output.split('\n').filter(Boolean);
+	} catch (e) {
+		// grep exits 1 when there are no matches; that's expected for the
+		// "no production violations" assertion.
+		const err = e as { status?: number };
+		if (err.status === 1) return [];
+		throw e;
+	}
+}
+
+describe('no raw user identifiers in production log call sites', () => {
+	it('flags the forbidden fixture (proves the regex works)', () => {
+		const matches = grep(FORBIDDEN_REGEX);
+		const flaggedFixture = matches.some((m) => m.startsWith(`${FORBIDDEN_FIXTURE}:`));
+		expect(flaggedFixture).toBe(true);
+	});
+
+	it('does NOT flag the allowed fixture', () => {
+		const matches = grep(FORBIDDEN_REGEX);
+		const flagged = matches.filter((m) => ALLOWED_FILES.some((f) => m.startsWith(`${f}:`)));
+		expect(flagged).toEqual([]);
+	});
+
+	it('does not flag any production source outside of the forbidden fixture', () => {
+		const matches = grep(FORBIDDEN_REGEX);
+		const productionMatches = matches.filter((m) => !m.startsWith(`${FORBIDDEN_FIXTURE}:`));
+		expect(productionMatches).toEqual([]);
+	});
+});

--- a/src/lib/actorFingerprint.test.ts
+++ b/src/lib/actorFingerprint.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+describe('actorFingerprint', () => {
+	const TEST_KEY = 'test-key-do-not-use-in-prod-test-key-do-not-use-in-prod-padding';
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubEnv('LOG_HMAC_KEY_CURRENT', TEST_KEY);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('produces a 16-char lowercase hex digest', async () => {
+		const { actorFingerprint } = await import('./actorFingerprint.js');
+		const fp = actorFingerprint('123');
+		expect(fp).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it('is deterministic for the same input + key', async () => {
+		const { actorFingerprint } = await import('./actorFingerprint.js');
+		expect(actorFingerprint('42')).toBe(actorFingerprint('42'));
+	});
+
+	it('produces different outputs for different inputs', async () => {
+		const { actorFingerprint } = await import('./actorFingerprint.js');
+		expect(actorFingerprint('1')).not.toBe(actorFingerprint('2'));
+	});
+
+	it('treats number and string inputs equivalently (String coercion)', async () => {
+		const { actorFingerprint } = await import('./actorFingerprint.js');
+		expect(actorFingerprint(123)).toBe(actorFingerprint('123'));
+	});
+
+	it('throws at module load if LOG_HMAC_KEY_CURRENT is unset', async () => {
+		vi.unstubAllEnvs();
+		vi.stubEnv('LOG_HMAC_KEY_CURRENT', '');
+		await expect(import('./actorFingerprint.js')).rejects.toThrow(/LOG_HMAC_KEY_CURRENT/);
+	});
+});

--- a/src/lib/actorFingerprint.ts
+++ b/src/lib/actorFingerprint.ts
@@ -1,0 +1,11 @@
+import { createHmac } from 'node:crypto';
+
+const key = process.env.LOG_HMAC_KEY_CURRENT;
+
+if (!key) {
+	throw new Error('LOG_HMAC_KEY_CURRENT not set — required for privacy-safe logging');
+}
+
+export function actorFingerprint(id: string | number): string {
+	return createHmac('sha256', key as string).update(String(id)).digest('hex').slice(0, 16);
+}

--- a/src/lib/authNotifier/ConsoleAuthNotifier.ts
+++ b/src/lib/authNotifier/ConsoleAuthNotifier.ts
@@ -10,26 +10,26 @@ export class ConsoleAuthNotifier implements AuthNotifier {
 	}
 
 	async sendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending activation email');
+		this.logger.info({ email: maskEmail(email), key, origin }, 'Sending activation email');
 	}
 
 	async sendPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending password reset email');
+		this.logger.info({ email: maskEmail(email), key, origin }, 'Sending password reset email');
 	}
 
 	async sendPasswordChanged(email: string, login: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending password changed email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending password changed email');
 	}
 
 	async sendAdminActivation(email: string, login: string, key: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin-created activation email');
+		this.logger.info({ email: maskEmail(email), key, origin }, 'Sending admin-created activation email');
 	}
 
 	async sendAdminPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin password reset email');
+		this.logger.info({ email: maskEmail(email), key, origin }, 'Sending admin password reset email');
 	}
 
 	async sendAdminResendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
-		this.logger.info({ login, email: maskEmail(email), key, origin }, 'Sending admin resend activation email');
+		this.logger.info({ email: maskEmail(email), key, origin }, 'Sending admin resend activation email');
 	}
 }

--- a/src/lib/authNotifier/EmailAuthNotifier.ts
+++ b/src/lib/authNotifier/EmailAuthNotifier.ts
@@ -20,37 +20,37 @@ export class EmailAuthNotifier implements AuthNotifier {
 
 	async sendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
 		const href = `${origin}/activate/?key=${key}`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending activation email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending activation email');
 		await sendEmail(email, activationEmail(origin, login, href));
 	}
 
 	async sendPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
 		const href = `${origin}/reset-password/?key=${key}`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending password reset email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending password reset email');
 		await sendEmail(email, resetPasswordEmail(origin, login, href));
 	}
 
 	async sendPasswordChanged(email: string, login: string, origin: string): Promise<void> {
 		const resetHref = `${origin}/reset-password/`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending password changed email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending password changed email');
 		await sendEmail(email, passwordChangedEmail(origin, login, resetHref));
 	}
 
 	async sendAdminActivation(email: string, login: string, key: string, origin: string): Promise<void> {
 		const href = `${origin}/activate/?key=${key}`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin-created activation email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending admin-created activation email');
 		await sendEmail(email, adminActivationEmail(origin, login, href));
 	}
 
 	async sendAdminPasswordReset(email: string, login: string, key: string, origin: string): Promise<void> {
 		const href = `${origin}/reset-password/?key=${key}`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin password reset email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending admin password reset email');
 		await sendEmail(email, adminPasswordResetEmail(origin, login, href));
 	}
 
 	async sendAdminResendActivation(email: string, login: string, key: string, origin: string): Promise<void> {
 		const href = `${origin}/activate/?key=${key}`;
-		this.logger.info({ login, email: maskEmail(email), origin }, 'Sending admin resend activation email');
+		this.logger.info({ email: maskEmail(email), origin }, 'Sending admin resend activation email');
 		await sendEmail(email, adminResendActivationEmail(origin, login, href));
 	}
 }

--- a/src/plugins/auth/authRoutes.ts
+++ b/src/plugins/auth/authRoutes.ts
@@ -31,6 +31,7 @@ import {
 	updateUserRightsAndKey,
 } from './databaseHelpers.js';
 import { issueTokens } from './issueTokens.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import {
 	activateRequest,
 	type ActivateRequest,
@@ -74,36 +75,36 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				const user = await findUserByLogin(fastify.mysql, login);
 
 				if (!user) {
-					request.log.warn({ login }, 'Login failed: user not found');
+					request.log.warn({ reason: 'user_not_found' }, 'Login failed');
 					return reply.code(401).send({ error: 'invalid_credentials', message: 'Invalid credentials' });
 				}
 
 				const passwordValid = await checkPassword(password, user.passwordHash);
 
 				if (!passwordValid) {
-					request.log.warn({ login, userId: user.userId }, 'Login failed: invalid password');
+					request.log.warn({ actorFingerprint: actorFingerprint(user.userId), reason: 'invalid_password' }, 'Login failed');
 					return reply.code(401).send({ error: 'invalid_credentials', message: 'Invalid credentials' });
 				}
 
 				if (isBanned(user.userRights)) {
-					request.log.warn({ login, userId: user.userId }, 'Login failed: account banned');
+					request.log.warn({ actorFingerprint: actorFingerprint(user.userId), reason: 'banned' }, 'Login failed');
 					return reply.code(403).send({ error: 'account_banned', message: 'Account is banned' });
 				}
 
 				if (!isEmailActivated(user.userRights)) {
-					request.log.warn({ login, userId: user.userId }, 'Login failed: account not activated');
+					request.log.warn({ actorFingerprint: actorFingerprint(user.userId), reason: 'not_activated' }, 'Login failed');
 					return reply.code(403).send({ error: 'account_not_activated', message: 'Account requires email activation' });
 				}
 
 				if (needsRehash(user.passwordHash)) {
 					const newHash = await hashPassword(password);
 					await rehashPassword(fastify.mysql, user.userId, newHash);
-					request.log.info({ login, userId: user.userId }, 'Password rehashed from MD5 to bcrypt');
+					request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Password rehashed from MD5 to bcrypt');
 				}
 
 				await updateLastLogin(fastify.mysql, user.userId);
 
-				request.log.info({ login, userId: user.userId }, 'Login successful');
+				request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Login successful');
 				return await issueTokens(fastify, user.userId, user.login, user.userRights, user.groupRights, user.groupId, user.tokenVersion);
 			} catch (error) {
 				request.log.error(error);
@@ -135,7 +136,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				}
 
 				if (isBanned(user.userRights)) {
-					request.log.warn({ userId: user.userId }, 'Token refresh failed: account banned');
+					request.log.warn({ actorFingerprint: actorFingerprint(user.userId) }, 'Token refresh failed: account banned');
 					return reply.code(403).send({ error: 'account_banned', message: 'Account is banned' });
 				}
 
@@ -197,12 +198,12 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				const key = generateVerificationKey();
 
 				await createUser(fastify.mysql, login, passwordHash, email, key);
-				request.log.info({ login, email: maskEmail(email) }, 'User registered');
+				request.log.info({ email: maskEmail(email) }, 'User registered');
 
 				try {
 					await fastify.authNotifier.sendActivation(email, login, key, fastify.resolveOrigin(request));
 				} catch (notifierError) {
-					fastify.log.error({ login, email: maskEmail(email), err: notifierError }, 'Failed to send activation email');
+					fastify.log.error({ email: maskEmail(email), err: notifierError }, 'Failed to send activation email');
 				}
 
 				const adminEmail = process.env.ADMIN_NOTIFY_EMAIL;
@@ -253,7 +254,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				const newRights = setEmailActivated(user.userRights);
 				await updateUserRightsAndKey(fastify.mysql, user.userId, newRights, null);
 
-				request.log.info({ login: user.login, userId: user.userId }, 'Account activated');
+				request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Account activated');
 				return { message: 'Account activated successfully' };
 			} catch (error) {
 				request.log.error(error);
@@ -284,7 +285,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 					try {
 						await fastify.authNotifier.sendActivation(user.email, user.login, key, fastify.resolveOrigin(request));
 					} catch (notifierError) {
-						fastify.log.error({ login, email: maskEmail(user.email), err: notifierError }, 'Failed to send activation email');
+						fastify.log.error({ email: maskEmail(user.email), err: notifierError }, 'Failed to send activation email');
 					}
 				}
 
@@ -316,7 +317,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 					const newRights = setPasswordResetRequested(user.userRights);
 
 					await updateUserRightsAndKey(fastify.mysql, user.userId, newRights, key);
-					request.log.info({ login: user.login, userId: user.userId }, 'Password reset requested');
+					request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Password reset requested');
 
 					await fastify.authNotifier.sendPasswordReset(user.email, user.login, key, fastify.resolveOrigin(request));
 				}
@@ -360,7 +361,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 				await resetPassword(fastify.mysql, user.userId, passwordHash, newRights);
 				await deleteAllUserRefreshTokens(fastify.mysql, user.userId);
 
-				request.log.info({ login: user.login, userId: user.userId }, 'Password reset completed');
+				request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Password reset completed');
 				return { message: 'Password reset successfully' };
 			} catch (error) {
 				request.log.error(error);

--- a/src/plugins/auth/passkey/passkeyRoutes.ts
+++ b/src/plugins/auth/passkey/passkeyRoutes.ts
@@ -9,6 +9,7 @@ import {
 import type { AuthenticatorTransportFuture, RegistrationResponseJSON, AuthenticationResponseJSON } from '@simplewebauthn/server';
 import { z } from 'zod';
 import { errorResponse } from '../../../lib/schemas.js';
+import { actorFingerprint } from '../../../lib/actorFingerprint.js';
 import { isBanned, isEmailActivated } from '../rights.js';
 import { findUserByLogin, updateLastLogin } from '../databaseHelpers.js';
 import { issueTokens } from '../issueTokens.js';
@@ -141,7 +142,7 @@ export async function passkeyRoutesPlugin(fastify: FastifyInstance) {
 					request.body.name,
 				);
 
-				request.log.info({ userId }, 'Passkey registered');
+				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Passkey registered');
 				return reply.code(201).send({ message: 'Passkey registered successfully' });
 			} catch (error) {
 				request.log.error(error);
@@ -227,12 +228,12 @@ export async function passkeyRoutesPlugin(fastify: FastifyInstance) {
 				}
 
 				if (isBanned(passkey.userRights)) {
-					request.log.warn({ userId: passkey.userId, login: passkey.login }, 'Passkey login failed: account banned');
+					request.log.warn({ actorFingerprint: actorFingerprint(passkey.userId), reason: 'banned' }, 'Passkey login failed');
 					return reply.code(403).send({ error: 'account_banned', message: 'Account is banned' });
 				}
 
 				if (!isEmailActivated(passkey.userRights)) {
-					request.log.warn({ userId: passkey.userId, login: passkey.login }, 'Passkey login failed: account not activated');
+					request.log.warn({ actorFingerprint: actorFingerprint(passkey.userId), reason: 'not_activated' }, 'Passkey login failed');
 					return reply.code(403).send({ error: 'account_not_activated', message: 'Account requires email activation' });
 				}
 
@@ -250,14 +251,14 @@ export async function passkeyRoutesPlugin(fastify: FastifyInstance) {
 				});
 
 				if (!verification.verified) {
-					request.log.warn({ userId: passkey.userId, login: passkey.login }, 'Passkey login failed: verification failed');
+					request.log.warn({ actorFingerprint: actorFingerprint(passkey.userId), reason: 'verification_failed' }, 'Passkey login failed');
 					return reply.code(401).send({ error: 'invalid_credentials', message: 'Invalid credentials' });
 				}
 
 				await updatePasskeyCounter(fastify.mysql, passkey.id, verification.authenticationInfo.newCounter);
 				await updateLastLogin(fastify.mysql, passkey.userId);
 
-				request.log.info({ login: passkey.login, userId: passkey.userId }, 'Passkey login successful');
+				request.log.info({ actorFingerprint: actorFingerprint(passkey.userId) }, 'Passkey login successful');
 				return await issueTokens(
 					fastify, passkey.userId, passkey.login, passkey.userRights, passkey.groupRights, passkey.groupId, passkey.tokenVersion,
 				);
@@ -321,7 +322,7 @@ export async function passkeyRoutesPlugin(fastify: FastifyInstance) {
 					return reply.code(404).send({ error: 'not_found', message: 'Passkey not found' });
 				}
 
-				request.log.info({ userId: request.user!.sub, passkeyId: request.params.passkeyId }, 'Passkey deleted');
+				request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), passkeyId: request.params.passkeyId }, 'Passkey deleted');
 				return reply.code(204).send();
 			} catch (error) {
 				request.log.error(error);

--- a/src/plugins/bookmarks/bookmarks.ts
+++ b/src/plugins/bookmarks/bookmarks.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { errorResponse } from '../../lib/schemas.js';
 import { authErrorResponse } from '../auth/schemas.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import {
 	getBookmarks,
 	resolveThingId,
@@ -77,7 +78,7 @@ export async function bookmarksPlugin(fastify: FastifyInstance) {
 			try {
 				const resolved = await resolveOrFail(fastify, sectionId, positionInSection);
 				await addBookmark(fastify.mysql, userId, resolved.thingId, resolved.sectionId);
-				request.log.info({ userId, sectionId, positionInSection }, 'Bookmark added');
+				request.log.info({ actorFingerprint: actorFingerprint(userId), sectionId, positionInSection }, 'Bookmark added');
 				return await getBookmarks(fastify.mysql, userId);
 			} catch (error) {
 				if (isNotFoundError(error)) {
@@ -109,7 +110,7 @@ export async function bookmarksPlugin(fastify: FastifyInstance) {
 			try {
 				const resolved = await resolveOrFail(fastify, sectionId, positionInSection);
 				await removeBookmark(fastify.mysql, userId, resolved.thingId, resolved.sectionId);
-				request.log.info({ userId, sectionId, positionInSection }, 'Bookmark removed');
+				request.log.info({ actorFingerprint: actorFingerprint(userId), sectionId, positionInSection }, 'Bookmark removed');
 				return await getBookmarks(fastify.mysql, userId);
 			} catch (error) {
 				if (isNotFoundError(error)) {
@@ -145,7 +146,7 @@ export async function bookmarksPlugin(fastify: FastifyInstance) {
 				}
 
 				await reorderBookmarks(fastify.mysql, userId, items);
-				request.log.info({ userId, count: items.length }, 'Bookmarks reordered');
+				request.log.info({ actorFingerprint: actorFingerprint(userId), count: items.length }, 'Bookmarks reordered');
 				return await getBookmarks(fastify.mysql, userId);
 			} catch (error) {
 				if (isNotFoundError(error)) {
@@ -181,13 +182,13 @@ export async function bookmarksPlugin(fastify: FastifyInstance) {
 					if (resolved !== null) {
 						items.push(resolved);
 					} else {
-						request.log.warn({ userId, sectionId: bookmark.sectionId, positionInSection: bookmark.positionInSection }, 'Bookmark skipped: thing not found');
+						request.log.warn({ actorFingerprint: actorFingerprint(userId), sectionId: bookmark.sectionId, positionInSection: bookmark.positionInSection }, 'Bookmark skipped: thing not found');
 					}
 				}
 
 				if (items.length > 0) {
 					await bulkAddBookmarks(fastify.mysql, userId, items);
-					request.log.info({ userId, count: items.length }, 'Bookmarks bulk-added');
+					request.log.info({ actorFingerprint: actorFingerprint(userId), count: items.length }, 'Bookmarks bulk-added');
 				}
 
 				return await getBookmarks(fastify.mysql, userId);

--- a/src/plugins/cms/commentsCmsRoutes.ts
+++ b/src/plugins/cms/commentsCmsRoutes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { errorResponse } from '../../lib/schemas.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import { requireCanEditContent } from './hooks.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import {
 	getCommentMeta,
 	setCommentStatus,
@@ -85,7 +86,7 @@ export async function commentsCmsRoutes(fastify: FastifyInstance) {
 			if (!meta) return reply.code(404).send(errorBody('not_found'));
 
 			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.hidden, userId);
-			request.log.info({ commentId, modUserId: userId }, 'Comment hidden by mod');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment hidden by mod');
 			return { ok: true as const };
 		},
 	});
@@ -111,7 +112,7 @@ export async function commentsCmsRoutes(fastify: FastifyInstance) {
 			if (!meta) return reply.code(404).send(errorBody('not_found'));
 
 			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.deleted, userId);
-			request.log.info({ commentId, modUserId: userId }, 'Comment soft-deleted by mod');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment soft-deleted by mod');
 			return { ok: true as const };
 		},
 	});
@@ -137,7 +138,7 @@ export async function commentsCmsRoutes(fastify: FastifyInstance) {
 			if (!meta) return reply.code(404).send(errorBody('not_found'));
 
 			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.visible, userId);
-			request.log.info({ commentId, modUserId: userId }, 'Comment restored by mod');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment restored by mod');
 			return { ok: true as const };
 		},
 	});
@@ -163,7 +164,7 @@ export async function commentsCmsRoutes(fastify: FastifyInstance) {
 			if (!meta) return reply.code(404).send(errorBody('not_found'));
 
 			await hardDeleteComment(fastify.mysql, commentId);
-			request.log.warn({ commentId, modUserId: userId }, 'Comment hard-deleted by mod');
+			request.log.warn({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment hard-deleted by mod');
 			return { ok: true as const };
 		},
 	});

--- a/src/plugins/cms/userRoutes.ts
+++ b/src/plugins/cms/userRoutes.ts
@@ -26,6 +26,7 @@ import { createUser, loginOrEmailExists, generateVerificationKey, updateUserRigh
 import { hashPassword } from '../auth/password.js';
 import { setPasswordResetRequested } from '../auth/rights.js';
 import { maskEmail } from '../../lib/maskEmail.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 
 const adminHooks = [requireAdmin, requireCanEditUsers];
 
@@ -141,7 +142,7 @@ export async function userRoutes(fastify: FastifyInstance) {
 
 				const userId = await createUser(fastify.mysql, login, passwordHash, email, key, groupId);
 
-				request.log.info({ userId, login, email: maskEmail(email), createdBy: request.user!.sub }, 'Admin created user');
+				request.log.info({ subjectFingerprint: actorFingerprint(userId), email: maskEmail(email), actorFingerprint: actorFingerprint(request.user!.sub) }, 'Admin created user');
 
 				await fastify.authNotifier.sendAdminActivation(email, login, key, fastify.resolveOrigin(request));
 
@@ -222,7 +223,7 @@ export async function userRoutes(fastify: FastifyInstance) {
 				await updateCmsUser(fastify.mysql, userId, newGroupId, newRights);
 				await invalidateUserSessions(fastify.mysql, userId);
 
-				request.log.info({ userId, login: currentUser.login, updatedBy: request.user!.sub }, 'Admin updated user');
+				request.log.info({ subjectFingerprint: actorFingerprint(userId), actorFingerprint: actorFingerprint(request.user!.sub) }, 'Admin updated user');
 
 				return await getUserById(fastify.mysql, userId);
 			} catch (error) {
@@ -268,7 +269,7 @@ export async function userRoutes(fastify: FastifyInstance) {
 
 				await deleteCmsUser(fastify.mysql, userId);
 
-				request.log.info({ userId, login: user.login, deletedBy: request.user!.sub }, 'Admin deleted user');
+				request.log.info({ subjectFingerprint: actorFingerprint(userId), actorFingerprint: actorFingerprint(request.user!.sub) }, 'Admin deleted user');
 
 				return reply.code(204).send();
 			} catch (error) {
@@ -314,7 +315,7 @@ export async function userRoutes(fastify: FastifyInstance) {
 				const key = generateVerificationKey();
 				await updateUserRightsAndKey(fastify.mysql, user.id, user.rights, key);
 
-				request.log.info({ userId: user.id, login: user.login, triggeredBy: request.user!.sub }, 'Admin resent activation');
+				request.log.info({ subjectFingerprint: actorFingerprint(user.id), actorFingerprint: actorFingerprint(request.user!.sub) }, 'Admin resent activation');
 
 				await fastify.authNotifier.sendAdminResendActivation(user.email!, user.login!, key, fastify.resolveOrigin(request));
 
@@ -359,7 +360,7 @@ export async function userRoutes(fastify: FastifyInstance) {
 				const newRights = setPasswordResetRequested(user.rights);
 				await updateUserRightsAndKey(fastify.mysql, user.id, newRights, key);
 
-				request.log.info({ userId: user.id, login: user.login, triggeredBy: request.user!.sub }, 'Admin triggered password reset');
+				request.log.info({ subjectFingerprint: actorFingerprint(user.id), actorFingerprint: actorFingerprint(request.user!.sub) }, 'Admin triggered password reset');
 
 				await fastify.authNotifier.sendAdminPasswordReset(user.email!, user.login!, key, fastify.resolveOrigin(request));
 

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -5,6 +5,7 @@ import { sendEmail } from '../../lib/email.js';
 import { commentReportedEmail, commentReplyEmail, commentVoteEmail } from '../../lib/emailTemplates.js';
 import { voteValueToDb } from '../../lib/voteValue.js';
 import { sanitizeCommentText } from './sanitizeCommentText.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import {
 	listComments,
 	getCommentById,
@@ -176,7 +177,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				parentId,
 				text: sanitized.text,
 			});
-			request.log.info({ commentId, userId, thingId: resolvedThingId, parentId }, 'Comment created');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId), thingId: resolvedThingId, parentId }, 'Comment created');
 
 			// Reply notification: fire-and-forget. The thread deep link points to
 			// the parent (top-level), since pagination is on top-level — opening
@@ -241,7 +242,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			if (!sanitized.ok) return reply.code(400).send(errorBody(sanitized.error));
 
 			await updateCommentText(fastify.mysql, commentId, sanitized.text);
-			request.log.info({ commentId, userId }, 'Comment edited');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment edited');
 
 			return await getCommentById(fastify.mysql, commentId, userId);
 		},
@@ -272,7 +273,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('already_removed'));
 
 			await setCommentStatus(fastify.mysql, commentId, COMMENT_STATUS.deleted, userId);
-			request.log.info({ commentId, userId }, 'Comment self-deleted');
+			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment self-deleted');
 			return { ok: true as const };
 		},
 	});
@@ -306,10 +307,10 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			const dbVote = voteValueToDb(vote);
 			if (dbVote === 0) {
 				await deleteCommentVote(fastify.mysql, commentId, userId);
-				request.log.info({ commentId, userId }, 'Comment vote removed');
+				request.log.info({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment vote removed');
 			} else {
 				await upsertCommentVote(fastify.mysql, commentId, userId, dbVote);
-				request.log.info({ commentId, userId, vote }, 'Comment vote recorded');
+				request.log.info({ commentId, actorFingerprint: actorFingerprint(userId), vote }, 'Comment vote recorded');
 
 				// Vote notification: fire-and-forget. Skip self-votes (meta.userId is
 				// the comment author) and votes on comments by deleted users.
@@ -322,7 +323,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 							ctx.author.email,
 							commentVoteEmail(siteOrigin, ctx.author.login, dbVote, ctx.commentText, threadHref),
 						).catch((err) => request.log.warn(err, 'Comment-vote notification email failed'));
-						request.log.info({ commentId, recipientUserId: meta.userId }, 'Comment-vote notification email sent');
+						request.log.info({ commentId, recipientFingerprint: actorFingerprint(meta.userId) }, 'Comment-vote notification email sent');
 					}
 				}
 			}
@@ -358,7 +359,7 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			if (meta.statusId !== COMMENT_STATUS.visible) return reply.code(409).send(errorBody('not_reportable'));
 
 			await reportComment(fastify.mysql, commentId, userId, reason ?? null);
-			request.log.warn({ commentId, userId }, 'Comment reported');
+			request.log.warn({ commentId, actorFingerprint: actorFingerprint(userId) }, 'Comment reported');
 
 			if (ADMIN_NOTIFY_EMAIL) {
 				sendEmail(ADMIN_NOTIFY_EMAIL, commentReportedEmail(login, commentId, reason ?? null))

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -7,6 +7,7 @@ import { checkPassword, hashPassword } from '../auth/password.js';
 import { deleteAllUserRefreshTokens } from '../auth/databaseHelpers.js';
 import { getUserCredentials, updatePassword, deleteUser, getNotificationSettings, updateNotificationSettings } from './databaseHelpers.js';
 import { authErrorResponse } from '../auth/schemas.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import {
 	userIdParam,
 	changePasswordRequest,
@@ -59,7 +60,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				const passwordValid = await checkPassword(currentPassword, credentials.passwordHash);
 
 				if (!passwordValid) {
-					request.log.warn({ login: user.login, userId }, 'Password change failed: invalid current password');
+					request.log.warn({ actorFingerprint: actorFingerprint(userId) }, 'Password change failed: invalid current password');
 					return reply.code(401).send({ error: 'invalid_credentials', message: 'Invalid credentials' });
 				}
 
@@ -68,7 +69,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				await deleteAllUserRefreshTokens(fastify.mysql, userId);
 				await fastify.authNotifier.sendPasswordChanged(credentials.email, user.login, fastify.resolveOrigin(request));
 
-				request.log.info({ login: user.login, userId }, 'Password changed');
+				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Password changed');
 				return { message: 'Password changed successfully' };
 			} catch (error) {
 				request.log.error(error);
@@ -112,14 +113,14 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				const passwordValid = await checkPassword(password, credentials.passwordHash);
 
 				if (!passwordValid) {
-					request.log.warn({ login: user.login, userId }, 'Account deletion failed: invalid password');
+					request.log.warn({ actorFingerprint: actorFingerprint(userId) }, 'Account deletion failed: invalid password');
 					return reply.code(401).send({ error: 'invalid_credentials', message: 'Invalid credentials' });
 				}
 
 				await deleteAllUserRefreshTokens(fastify.mysql, userId);
 				await deleteUser(fastify.mysql, userId);
 
-				request.log.info({ login: user.login, userId }, 'Account deleted');
+				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Account deleted');
 
 				const adminEmail = process.env.ADMIN_NOTIFY_EMAIL;
 
@@ -205,7 +206,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 
 				const { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote } = request.body;
 				await updateNotificationSettings(fastify.mysql, userId, { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote });
-				request.log.info({ userId }, 'Notification settings updated');
+				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Notification settings updated');
 
 				return { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote };
 			} catch (error) {

--- a/src/plugins/votes/votes.ts
+++ b/src/plugins/votes/votes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { errorResponse } from '../../lib/schemas.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import { sendEmail } from '../../lib/email.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import { thingVotedEmail } from '../../lib/emailTemplates.js';
 import { voteValueToDb } from '../../lib/voteValue.js';
 import {
@@ -82,10 +83,10 @@ export async function votesPlugin(fastify: FastifyInstance) {
 
 				if (dbVote === 0) {
 					await deleteVote(fastify.mysql, thingId, userId);
-					request.log.info({ thingId, userId }, 'Vote removed');
+					request.log.info({ thingId, actorFingerprint: actorFingerprint(userId) }, 'Vote removed');
 				} else {
 					await upsertVote(fastify.mysql, thingId, userId, dbVote);
-					request.log.info({ thingId, userId, vote }, 'Vote recorded');
+					request.log.info({ thingId, actorFingerprint: actorFingerprint(userId), vote }, 'Vote recorded');
 				}
 
 				if (ADMIN_NOTIFY_EMAIL) {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,5 @@
+// Global test setup — runs before any module is loaded in test files.
+// Provides a stable HMAC key so actorFingerprint.ts does not throw at module load.
+// Individual tests that need to exercise the "throws when key is missing" path
+// must call vi.resetModules() and use dynamic imports (see actorFingerprint.test.ts).
+process.env.LOG_HMAC_KEY_CURRENT ??= 'test-key-do-not-use-in-prod-test-key-do-not-use-in-prod-padding';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		setupFiles: ['./src/test-setup.ts'],
+	},
+});


### PR DESCRIPTION
## Summary

Migrates `poetry-api` to privacy-safe logging. Every log call site that emitted raw user identifiers now emits `actorFingerprint` (HMAC-SHA256 of the user id, truncated to 16 hex chars, keyed by `LOG_HMAC_KEY_CURRENT` from the VPS rotation cron). `login` is removed from logs; differentiated `'Login failed: …'` messages are flattened to `'Login failed'` with structured `reason`. A CI guard (`src/lib/__tests__/no-raw-identifiers.test.ts`) blocks regressions.

- New: `src/lib/actorFingerprint.ts` + 5 unit tests.
- 47 call sites migrated across 8 plugin files (auth, comments, bookmarks, votes, users, cms admin user, cms comments, passkey).
- 12 additional sites in `EmailAuthNotifier`/`ConsoleAuthNotifier` (`this.logger.info(…)` form) also dropped `login` from log objects. CI guard regex broadened to cover `*.logger.*` patterns alongside `request.log.*`/`fastify.log.*`.
- 7 message texts flattened to remove user-existence leakage (4 `'Login failed: …'` + 3 `'Passkey login failed: …'`).
- New: CI guard test with positive + negative fixtures; the regex catches both `{ userId }` shorthand and `{ userId: x }` explicit forms.
- New: vitest setupFile (`src/test-setup.ts` + `vitest.config.ts`) seeds `LOG_HMAC_KEY_CURRENT` for tests, since the helper validates at module load.
- `.env.example` and `CLAUDE.md` updated.

## Spec

`mellonis/poetry`: `docs/superpowers/specs/2026-05-05-privacy-safe-logging-design.md`. Tracks issue [`mellonis/poetry#10`](https://github.com/mellonis/poetry/issues/10). Prerequisite: `mellonis/vps#1` shipped + bootstrap done; `LOG_HMAC_KEY_CURRENT` already live in the running container.

## Out of scope (deferred)

- Per-call-site integration tests asserting log shape (e.g., `expect(logLine.actorFingerprint).toMatch(...)`). The current `buildApp` test helper uses `logger: false`; adding log capture would require refactoring the test infra in a way disproportionate to this PR. Coverage is provided by helper unit tests + CI guard + manual post-deploy Dozzle smoke.
- Stack traces / error-object content (e.g., `request.log.error(err, '...')`) — known limitation per the spec; out of scope.
- Pre-existing `credentialId` in the passkey credential-not-found log line — pseudonym that could correlate logins; flagged for a future privacy pass. The `'Passkey login failed: credential not found'` message also retains its colon suffix (other 3 passkey-login-failed paths were flattened); kept consistent with the deferred fix above.
- `ConsoleAuthNotifier` (dev-only) still logs the raw activation/reset `key` for local debugging. The production `EmailAuthNotifier` does not. Not a prod risk; intentionally kept for dev ergonomics.

## Test plan

- [x] `npm test` — 231/231 green (helper unit tests, CI guard with broadened regex, all pre-existing tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [ ] After deploy:
  - [ ] `docker exec poetry-api env | grep LOG_HMAC_KEY` — both `CURRENT` and `PREVIOUS` present.
  - [ ] Tail Dozzle (`logs.poetry.mellonis.ru`); trigger a login via curl. Expected log line includes `"actorFingerprint":"<16-hex>"` and does NOT contain `userId`, raw `login`, or unmasked email.
  - [ ] Trigger a registration. Same — masked email present, no login/userId raw.
  - [ ] Trigger a wrong-password login. Log shows `"Login failed"` (not "Login failed: invalid password") with `reason: 'invalid_password'` in the structured fields.

