### PR TITLE
feat: add displayName endpoints, reserved-name CMS, comment snapshot

### DIFF
--- a/src/lib/__tests__/displayName.test.ts
+++ b/src/lib/__tests__/displayName.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDisplayName, reservedCheckKey, validateDisplayName } from '../displayName.js';
+
+describe('normalizeDisplayName', () => {
+  it('trims whitespace', () => {
+    expect(normalizeDisplayName('  hello  ')).toBe('hello');
+  });
+  it('collapses consecutive spaces', () => {
+    expect(normalizeDisplayName('a  b')).toBe('a b');
+  });
+  it('NFC-normalizes', () => {
+    // café decomposed (e + combining acute) → café composed
+    const decomposed = 'café';
+    expect(normalizeDisplayName(decomposed)).toBe('café');
+  });
+});
+
+describe('reservedCheckKey', () => {
+  it('lowercases', () => {
+    expect(reservedCheckKey('Admin')).toBe('admin');
+  });
+  it('folds Cyrillic homoglyphs to Latin', () => {
+    // Cyrillic а (U+0430) → Latin a, so 'аdmin' (Cyrillic а + Latin dmin) → 'admin'
+    expect(reservedCheckKey('аdmin')).toBe('admin');
+  });
+  it('is idempotent on Latin-only input', () => {
+    expect(reservedCheckKey('mellonis')).toBe('mellonis');
+  });
+});
+
+describe('validateDisplayName', () => {
+  it('accepts valid Cyrillic+Latin+digit+space', () => {
+    expect(validateDisplayName('Иван Petrov 42')).toEqual({ ok: true, value: 'Иван Petrov 42' });
+  });
+  it('accepts max-length 64 chars', () => {
+    expect(validateDisplayName('a'.repeat(64))).toEqual({ ok: true, value: 'a'.repeat(64) });
+  });
+  it('rejects empty string', () => {
+    expect(validateDisplayName('')).toMatchObject({ ok: false });
+  });
+  it('rejects string longer than 64 chars', () => {
+    expect(validateDisplayName('a'.repeat(65))).toMatchObject({ ok: false });
+  });
+  it('rejects special characters', () => {
+    expect(validateDisplayName('user@example')).toMatchObject({ ok: false });
+  });
+  it('rejects consecutive spaces after normalize', () => {
+    expect(validateDisplayName('a  b')).toMatchObject({ ok: false });
+  });
+  it('trims before validating', () => {
+    expect(validateDisplayName('  hello  ')).toEqual({ ok: true, value: 'hello' });
+  });
+  it('rejects blank-after-trim', () => {
+    expect(validateDisplayName('   ')).toMatchObject({ ok: false });
+  });
+});

--- a/src/lib/displayName.ts
+++ b/src/lib/displayName.ts
@@ -1,0 +1,33 @@
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+	'а': 'a', 'е': 'e', 'о': 'o', 'р': 'p', 'с': 'c', 'х': 'x', 'у': 'y',
+	'в': 'b', 'н': 'h', 'к': 'k', 'м': 'm', 'т': 't',
+	'А': 'A', 'Е': 'E', 'О': 'O', 'Р': 'P', 'С': 'C', 'Х': 'X', 'У': 'Y',
+	'В': 'B', 'Н': 'H', 'К': 'K', 'М': 'M', 'Т': 'T',
+};
+
+export function normalizeDisplayName(raw: string): string {
+	return raw.trim().normalize('NFC').replace(/  +/g, ' ');
+}
+
+export function reservedCheckKey(raw: string): string {
+	return normalizeDisplayName(raw)
+		.split('')
+		.map((ch) => CYRILLIC_TO_LATIN[ch] ?? ch)
+		.join('')
+		.toLowerCase();
+}
+
+const ALLOWED_RE = /^[a-zA-ZÀ-ӿ0-9 ]+$/;
+
+export type DisplayNameResult =
+	| { ok: true; value: string }
+	| { ok: false; error: string };
+
+export function validateDisplayName(raw: string): DisplayNameResult {
+	const trimmed = raw.trim().normalize('NFC');
+	if (trimmed.length === 0) return { ok: false, error: 'display_name_empty' };
+	if (trimmed.length > 64) return { ok: false, error: 'display_name_too_long' };
+	if (!ALLOWED_RE.test(trimmed)) return { ok: false, error: 'display_name_invalid_chars' };
+	if (/  /.test(trimmed)) return { ok: false, error: 'display_name_consecutive_spaces' };
+	return { ok: true, value: trimmed };
+}

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -128,9 +128,12 @@ export const commentReplyEmail = (
 	replierDisplayName: string,
 	replyText: string,
 	threadHref: string,
-): EmailMessage => ({
-	subject: `${replierDisplayName} ответил(а) на ваш комментарий`,
-	html: layout(siteOrigin, recipientLogin, `<p style="color:#333;font-size:14px;"><strong>${replierDisplayName}</strong> ответил(а) на ваш комментарий:</p>
+	replierIsAuthor = false,
+): EmailMessage => {
+	const authorLabel = replierIsAuthor ? ' (Автор сайта)' : '';
+	return {
+		subject: `${replierDisplayName}${authorLabel} ответил(а) на ваш комментарий`,
+		html: layout(siteOrigin, recipientLogin, `<p style="color:#333;font-size:14px;"><strong>${replierDisplayName}</strong>${authorLabel} ответил(а) на ваш комментарий:</p>
 <blockquote style="margin:15px 0;padding:10px 15px;background:#f7f7f7;
 border-left:3px solid #999;color:#333;font-size:14px;
 white-space:pre-wrap;">${escapeHtml(replyText)}</blockquote>
@@ -140,7 +143,8 @@ padding:12px 30px;border-radius:5px;text-decoration:none;font-size:14px;">
 Перейти к обсуждению</a></p>
 <p style="color:#999;font-size:12px;">Или скопируйте ссылку:
 <a href="${threadHref}" style="color:#666;">${threadHref}</a></p>`),
-});
+	};
+};
 
 export const commentVoteEmail = (
 	siteOrigin: string,

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -125,12 +125,12 @@ export const commentReportedEmail = (
 export const commentReplyEmail = (
 	siteOrigin: string,
 	recipientLogin: string,
-	replierLogin: string,
+	replierDisplayName: string,
 	replyText: string,
 	threadHref: string,
 ): EmailMessage => ({
-	subject: `${replierLogin} ответил(а) на ваш комментарий`,
-	html: layout(siteOrigin, recipientLogin, `<p style="color:#333;font-size:14px;"><strong>${replierLogin}</strong> ответил(а) на ваш комментарий:</p>
+	subject: `${replierDisplayName} ответил(а) на ваш комментарий`,
+	html: layout(siteOrigin, recipientLogin, `<p style="color:#333;font-size:14px;"><strong>${replierDisplayName}</strong> ответил(а) на ваш комментарий:</p>
 <blockquote style="margin:15px 0;padding:10px 15px;background:#f7f7f7;
 border-left:3px solid #999;color:#333;font-size:14px;
 white-space:pre-wrap;">${escapeHtml(replyText)}</blockquote>

--- a/src/plugins/auth/databaseHelpers.ts
+++ b/src/plugins/auth/databaseHelpers.ts
@@ -144,7 +144,7 @@ export const createUser = async (
 	withConnection(mysql, async (connection) => {
 		const [result] = await connection.query<MySQLResultSetHeader>(
 			insertUserQuery,
-			[groupId, rights, login, passwordHash, email, hashKey(key)],
+			[groupId, rights, login, passwordHash, email, hashKey(key), login],
 		);
 		return result.insertId;
 	});

--- a/src/plugins/auth/queries.ts
+++ b/src/plugins/auth/queries.ts
@@ -36,8 +36,8 @@ export const updateLastLoginQuery = `
 `;
 
 export const insertUserQuery = `
-	INSERT INTO auth_user (r_group_id, rights, login, password_hash, email, \`key\`, key_created_at)
-	VALUES (?, ?, ?, ?, ?, ?, NOW())
+	INSERT INTO auth_user (r_group_id, rights, login, password_hash, email, \`key\`, key_created_at, display_name)
+	VALUES (?, ?, ?, ?, ?, ?, NOW(), ?)
 `;
 
 export const updateUserRightsAndKeyQuery = `

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -823,3 +823,79 @@ describe('POST /cms/users/:userId/reset-password', () => {
 		expect(mockNotifier.sendAdminPasswordReset).toHaveBeenCalled();
 	});
 });
+
+describe('reserved display names', () => {
+	it('GET /cms/reserved-display-names returns list', async () => {
+		const mysql = createMockMysql(
+			[{ id: 1, value: 'admin', reason: null, createdAt: '2026-01-01T00:00:00.000Z', createdByUserId: null }],
+			[{ total: 1 }],
+		);
+		const app = await buildApp(mysql);
+		const token = await getEditorToken();
+		const res = await app.inject({
+			method: 'GET',
+			url: '/cms/reserved-display-names',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.body);
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0].value).toBe('admin');
+	});
+
+	it('POST /cms/reserved-display-names creates entry', async () => {
+		const mysql = createMockMysql(
+			[],
+			[{ insertId: 5 }],
+		);
+		const app = await buildApp(mysql);
+		const token = await getAdminToken();
+		const res = await app.inject({
+			method: 'POST',
+			url: '/cms/reserved-display-names',
+			headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+			body: JSON.stringify({ value: 'superuser', reason: 'obvious' }),
+		});
+		expect(res.statusCode).toBe(201);
+		expect(JSON.parse(res.body)).toMatchObject({ id: 5, value: 'superuser' });
+	});
+
+	it('POST /cms/reserved-display-names returns 409 for canonical duplicate', async () => {
+		const mysql = createMockMysql(
+			[{ value: 'admin' }],
+		);
+		const app = await buildApp(mysql);
+		const token = await getAdminToken();
+		const res = await app.inject({
+			method: 'POST',
+			url: '/cms/reserved-display-names',
+			headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+			body: JSON.stringify({ value: 'аdmin' }), // Cyrillic 'а' — homoglyph of Latin 'a'
+		});
+		expect(res.statusCode).toBe(409);
+	});
+
+	it('DELETE /cms/reserved-display-names/:id removes entry', async () => {
+		const mysql = createMockMysql([{ affectedRows: 1 }]);
+		const app = await buildApp(mysql);
+		const token = await getAdminToken();
+		const res = await app.inject({
+			method: 'DELETE',
+			url: '/cms/reserved-display-names/1',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(res.statusCode).toBe(204);
+	});
+
+	it('returns 403 when canEditUsers is missing', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getEditorToken();
+		const res = await app.inject({
+			method: 'POST',
+			url: '/cms/reserved-display-names',
+			headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+			body: JSON.stringify({ value: 'x' }),
+		});
+		expect(res.statusCode).toBe(403);
+	});
+});

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -6,6 +6,7 @@ import { thingRoutes } from './thingRoutes.js';
 import { searchCmsRoutes } from './searchCmsRoutes.js';
 import { userRoutes } from './userRoutes.js';
 import { commentsCmsRoutes } from './commentsCmsRoutes.js';
+import { reservedDisplayNameRoutes } from './reservedDisplayNameRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -26,6 +27,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(searchCmsRoutes);
 	fastify.register(userRoutes);
 	fastify.register(commentsCmsRoutes);
+	fastify.register(reservedDisplayNameRoutes, { prefix: '/reserved-display-names' });
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/reservedDisplayNameRoutes.ts
+++ b/src/plugins/cms/reservedDisplayNameRoutes.ts
@@ -1,0 +1,152 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { errorResponse } from '../../lib/schemas.js';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { reservedCheckKey, normalizeDisplayName } from '../../lib/displayName.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
+import { requireCanEditUsers } from './hooks.js';
+import type { MySQLRowDataPacket, MySQLResultSetHeader } from '@fastify/mysql';
+
+const reservedNameRow = z.object({
+	id: z.number().int().positive(),
+	value: z.string(),
+	reason: z.string().nullable(),
+	createdAt: z.string(),
+	createdByUserId: z.number().int().positive().nullable(),
+});
+
+const listResponse = z.object({
+	items: z.array(reservedNameRow),
+	total: z.number().int().min(0),
+});
+
+const createRequest = z.object({
+	value: z.string().min(1).max(64),
+	reason: z.string().max(255).optional(),
+});
+
+const idParam = z.object({ id: z.coerce.number().int().positive() });
+
+export async function reservedDisplayNameRoutes(fastify: FastifyInstance) {
+	fastify.get('/', {
+		schema: {
+			description: 'List all reserved display names.',
+			tags: ['CMS', 'Reserved Display Names'],
+			response: { 200: listResponse, 500: errorResponse },
+		},
+		handler: async (request, reply) => {
+			try {
+				const [rows, countRows] = await withConnection(fastify.mysql, async (conn) => {
+					const [r] = await conn.query<MySQLRowDataPacket[]>(
+						'SELECT id, value, reason, created_at AS createdAt, created_by_user_id AS createdByUserId FROM reserved_display_name ORDER BY value',
+					);
+					const [c] = await conn.query<MySQLRowDataPacket[]>('SELECT COUNT(*) AS total FROM reserved_display_name');
+					return [r, c];
+				});
+				return {
+					items: (rows as MySQLRowDataPacket[]).map((r) => ({
+						id: r.id as number,
+						value: r.value as string,
+						reason: (r.reason as string | null) ?? null,
+						createdAt: new Date(r.createdAt as string).toISOString(),
+						createdByUserId: (r.createdByUserId as number | null) ?? null,
+					})),
+					total: Number((countRows as MySQLRowDataPacket[])[0].total),
+				};
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.post('/', {
+		schema: {
+			description: 'Add a reserved display name.',
+			tags: ['CMS', 'Reserved Display Names'],
+			body: createRequest,
+			response: { 201: reservedNameRow, 409: errorResponse, 500: errorResponse },
+		},
+		preHandler: requireCanEditUsers,
+		handler: async (request: FastifyRequest<{ Body: z.infer<typeof createRequest> }>, reply) => {
+			try {
+				const stored = normalizeDisplayName(request.body.value).toLowerCase();
+				const storedCheckKey = reservedCheckKey(stored);
+				const userId = request.user!.sub;
+
+				const isDuplicate = await withConnection(fastify.mysql, async (conn) => {
+					const [existing] = await conn.query<MySQLRowDataPacket[]>('SELECT value FROM reserved_display_name');
+					return (existing as MySQLRowDataPacket[]).some(
+						(r) => reservedCheckKey(r.value as string) === storedCheckKey,
+					);
+				});
+				if (isDuplicate) {
+					return reply.code(409).send({ error: 'already_reserved', message: 'This value is already reserved' });
+				}
+
+				const rawResult = await withConnection(fastify.mysql, async (conn) => {
+					const [r] = await conn.query<MySQLResultSetHeader>(
+						'INSERT INTO reserved_display_name (value, reason, created_by_user_id) VALUES (?, ?, ?)',
+						[stored, request.body.reason ?? null, userId],
+					);
+					return r;
+				});
+				// Support both the real MySQL driver (ResultSetHeader object) and the test mock
+				// (which wraps the response in an extra array layer).
+				const insertId: number = Array.isArray(rawResult)
+					? ((rawResult as unknown as Array<{ insertId: number }>)[0]?.insertId ?? 0)
+					: (rawResult as MySQLResultSetHeader).insertId;
+
+				request.log.info({ actorFingerprint: actorFingerprint(userId), reservedValue: stored }, 'Reserved display name added');
+				return reply.code(201).send({
+					id: insertId,
+					value: stored,
+					reason: request.body.reason ?? null,
+					createdAt: new Date().toISOString(),
+					createdByUserId: userId,
+				});
+			} catch (error: unknown) {
+				if ((error as { code?: string }).code === 'ER_DUP_ENTRY') {
+					return reply.code(409).send({ error: 'already_reserved', message: 'This value is already reserved' });
+				}
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.delete('/:id', {
+		schema: {
+			description: 'Remove a reserved display name by id.',
+			tags: ['CMS', 'Reserved Display Names'],
+			params: idParam,
+			response: { 204: z.void(), 404: errorResponse, 500: errorResponse },
+		},
+		preHandler: requireCanEditUsers,
+		handler: async (request: FastifyRequest<{ Params: { id: number } }>, reply) => {
+			try {
+				const rawResult = await withConnection(fastify.mysql, async (conn) => {
+					const [r] = await conn.query<MySQLResultSetHeader>(
+						'DELETE FROM reserved_display_name WHERE id = ?',
+						[request.params.id],
+					);
+					return r;
+				});
+				// Support both the real MySQL driver and the test mock (extra array wrap).
+				const affectedRows: number = Array.isArray(rawResult)
+					? ((rawResult as unknown as Array<{ affectedRows: number }>)[0]?.affectedRows ?? 0)
+					: (rawResult as MySQLResultSetHeader).affectedRows;
+
+				if (affectedRows === 0) return reply.code(404).send({ error: 'not_found' });
+				request.log.info(
+					{ actorFingerprint: actorFingerprint(request.user!.sub), reservedId: request.params.id },
+					'Reserved display name removed',
+				);
+				return reply.code(204).send();
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}

--- a/src/plugins/comments/comments.test.ts
+++ b/src/plugins/comments/comments.test.ts
@@ -72,7 +72,8 @@ const visibleRow = {
 	parentId: null,
 	thingId: 5,
 	userId: 1,
-	authorLogin: 'testuser',
+	authorDisplayName: 'testuser',
+	isAuthor: 1,
 	text: 'Hello world',
 	statusId: 1,
 	createdAt: new Date('2026-04-27T12:00:00Z'),
@@ -124,7 +125,8 @@ describe('GET /comments', () => {
 		const body = response.json();
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0].text).toBeNull();
-		expect(body.items[0].authorLogin).toBeNull();
+		expect(body.items[0].authorDisplayName).toBe('—');
+		expect(body.items[0].isAuthor).toBe(false);
 		expect(body.items[0].replies).toHaveLength(1);
 		expect(body.items[0].replies[0].text).toBe('Hello world');
 	});
@@ -278,7 +280,7 @@ describe('PUT /comments/:commentId/vote', () => {
 				thingId: 5,
 				parentId: null,
 				commentText: 'some comment text',
-				authorLogin: 'author',
+				authorDisplayName: 'author',
 				authorEmail: 'author@example.com',
 				authorUserRights: 24,
 				authorGroupRights: 0,

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -194,11 +194,12 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				) {
 					const recipient = ctx.parentAuthor;
 					const replierDisplayName = created?.authorDisplayName ?? '—';
+					const replierIsAuthor = created?.isAuthor ?? false;
 					const siteOrigin = fastify.resolveOrigin(request);
 					const threadHref = buildThreadHref(siteOrigin, ctx, parentId);
 					sendEmail(
 						recipient.email,
-						commentReplyEmail(siteOrigin, recipient.login, replierDisplayName, sanitized.text, threadHref),
+						commentReplyEmail(siteOrigin, recipient.login, replierDisplayName, sanitized.text, threadHref, replierIsAuthor),
 					).catch((err) => request.log.warn(err, 'Comment-reply notification email failed'));
 				}
 			}

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -179,6 +179,8 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			});
 			request.log.info({ commentId, actorFingerprint: actorFingerprint(userId), thingId: resolvedThingId, parentId }, 'Comment created');
 
+			const created = await getCommentById(fastify.mysql, commentId, userId);
+
 			// Reply notification: fire-and-forget. The thread deep link points to
 			// the parent (top-level), since pagination is on top-level — opening
 			// the parent shows the new reply under it in single-thread mode.
@@ -191,17 +193,16 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 					ctx.parentAuthor.notifyAuthorOnCommentReply
 				) {
 					const recipient = ctx.parentAuthor;
-					const replierLogin = request.user!.login;
+					const replierDisplayName = created?.authorDisplayName ?? '—';
 					const siteOrigin = fastify.resolveOrigin(request);
 					const threadHref = buildThreadHref(siteOrigin, ctx, parentId);
 					sendEmail(
 						recipient.email,
-						commentReplyEmail(siteOrigin, recipient.login, replierLogin, sanitized.text, threadHref),
+						commentReplyEmail(siteOrigin, recipient.login, replierDisplayName, sanitized.text, threadHref),
 					).catch((err) => request.log.warn(err, 'Comment-reply notification email failed'));
 				}
 			}
 
-			const created = await getCommentById(fastify.mysql, commentId, userId);
 			return reply.code(201).send(created);
 		},
 	});

--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -39,7 +39,8 @@ interface RawCommentRow {
 	parentId: number | null;
 	thingId: number | null;
 	userId: number | null;
-	authorLogin: string | null;
+	authorDisplayName: string | null;
+	isAuthor: number; // 0 | 1 from MySQL
 	text: string;
 	statusId: number;
 	createdAt: Date;
@@ -62,7 +63,8 @@ const projectRow = (row: RawCommentRow): CommentBase => {
 		parentId: row.parentId,
 		thingId: row.thingId,
 		userId: isVisible ? row.userId : null,
-		authorLogin: isVisible ? row.authorLogin : null,
+		authorDisplayName: isVisible ? row.authorDisplayName : '—',
+		isAuthor: isVisible ? Boolean(row.isAuthor) : false,
 		text: isVisible ? row.text : null,
 		statusId: row.statusId,
 		createdAt: toIso(row.createdAt),
@@ -319,6 +321,7 @@ export const createComment = async (
 			thingId,
 			parentId,
 			text,
+			userId,
 			userId,
 		]);
 		return result.insertId;

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -5,7 +5,8 @@ const commentRowFields = `
   c.parent_id AS parentId,
   c.r_thing_id AS thingId,
   c.r_user_id AS userId,
-  u.login AS authorLogin,
+  c.display_name_snapshot AS authorDisplayName,
+  (c.r_user_id = 1) AS isAuthor,
   c.text,
   c.r_comment_status_id AS statusId,
   c.created_at AS createdAt,
@@ -26,7 +27,6 @@ export const topLevelCommentsQuery = `
       WHERE c2.parent_id = c.id AND c2.r_comment_status_id = 1
     ) AS hasVisibleChild
   FROM comment c
-  LEFT JOIN auth_user u ON u.id = c.r_user_id
   LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
   WHERE c.parent_id IS NULL AND c.r_thing_id <=> ?
   GROUP BY c.id
@@ -37,7 +37,6 @@ export const topLevelCommentsQuery = `
 export const repliesByParentIdsQuery = `
   SELECT ${commentRowFields}
   FROM comment c
-  LEFT JOIN auth_user u ON u.id = c.r_user_id
   LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
   WHERE c.parent_id IN (?)
   GROUP BY c.id
@@ -62,7 +61,6 @@ export const commentByIdQuery = `
       WHERE c2.parent_id = c.id AND c2.r_comment_status_id = 1
     ) AS hasVisibleChild
   FROM comment c
-  LEFT JOIN auth_user u ON u.id = c.r_user_id
   LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
   WHERE c.id = ?
   GROUP BY c.id
@@ -85,8 +83,9 @@ export const commentMetaByIdQuery = `
 export const insertCommentQuery = `
   INSERT INTO comment
     (r_user_id, r_thing_id, parent_id, text, r_comment_status_id,
-     status_changed_at, status_changed_by_user_id)
-  VALUES (?, ?, ?, ?, 1, NOW(), ?)
+     status_changed_at, status_changed_by_user_id, display_name_snapshot)
+  VALUES (?, ?, ?, ?, 1, NOW(), ?,
+    (SELECT COALESCE(display_name, login) FROM auth_user WHERE id = ?))
 `;
 
 export const updateCommentTextQuery = `
@@ -178,7 +177,6 @@ export const commentVoteContextQuery = `
 export const repliesByParentIdQuery = `
   SELECT ${commentRowFields}
   FROM comment c
-  LEFT JOIN auth_user u ON u.id = c.r_user_id
   LEFT JOIN comment_vote cv ON cv.r_comment_id = c.id
   WHERE c.parent_id = ?
   GROUP BY c.id
@@ -206,6 +204,8 @@ const cmsCommentRowFields = `
   t.first_lines AS thingFirstLines,
   c.r_user_id AS userId,
   u.login AS authorLogin,
+  c.display_name_snapshot AS authorDisplayName,
+  (c.r_user_id = 1) AS isAuthor,
   c.text,
   c.r_comment_status_id AS statusId,
   c.created_at AS createdAt,

--- a/src/plugins/comments/schemas.ts
+++ b/src/plugins/comments/schemas.ts
@@ -30,7 +30,8 @@ const commentBaseSchema = z.object({
 	parentId: z.number().int().positive().nullable(),
 	thingId: z.number().int().positive().nullable(),
 	userId: z.number().int().positive().nullable(),
-	authorLogin: z.string().nullable(),
+	authorDisplayName: z.string().nullable(),
+	isAuthor: z.boolean(),
 	text: z.string().nullable(),
 	statusId: z.number().int().min(1).max(3),
 	createdAt: z.string(),
@@ -88,6 +89,7 @@ const cmsCommentListQuery = z.object({
 });
 
 const cmsCommentRow = commentBaseSchema.extend({
+	authorLogin: z.string().nullable(),
 	reportCount: z.number().int().min(0),
 	statusChangedAt: z.string(),
 	statusChangedByUserId: z.number().int().positive().nullable(),

--- a/src/plugins/users/databaseHelpers.ts
+++ b/src/plugins/users/databaseHelpers.ts
@@ -1,11 +1,15 @@
 import type { MySQLPromisePool, MySQLRowDataPacket } from '@fastify/mysql';
 import { withConnection } from '../../lib/databaseHelpers.js';
+import { reservedCheckKey } from '../../lib/displayName.js';
 import {
 	getUserPasswordAndEmailQuery,
 	updatePasswordQuery,
 	deleteUserQuery,
 	getNotificationSettingsQuery,
 	updateNotificationSettingsQuery,
+	getDisplayNameQuery,
+	updateDisplayNameQuery,
+	getAllReservedValuesQuery,
 } from './queries.js';
 
 export interface UserCredentials {
@@ -64,3 +68,40 @@ export const updateNotificationSettings = async (
 		]);
 	});
 };
+
+export interface DisplayNameInfo {
+	displayName: string | null;
+	displayNameChangedAt: Date | null;
+}
+
+export const getDisplayName = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+): Promise<DisplayNameInfo | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(getDisplayNameQuery, [userId]);
+		if (!rows[0]) return null;
+		return {
+			displayName: rows[0].displayName ?? null,
+			displayNameChangedAt: rows[0].displayNameChangedAt ? new Date(rows[0].displayNameChangedAt) : null,
+		};
+	});
+
+export const setDisplayName = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+	displayName: string,
+): Promise<void> =>
+	withConnection(mysql, async (connection) => {
+		await connection.query(updateDisplayNameQuery, [displayName, userId]);
+	});
+
+export const isReservedDisplayName = async (
+	mysql: MySQLPromisePool,
+	displayName: string,
+): Promise<boolean> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(getAllReservedValuesQuery);
+		const checkKey = reservedCheckKey(displayName);
+		return (rows as MySQLRowDataPacket[]).some((r) => reservedCheckKey(r.value as string) === checkKey);
+	});

--- a/src/plugins/users/queries.ts
+++ b/src/plugins/users/queries.ts
@@ -27,3 +27,18 @@ export const updateNotificationSettingsQuery = `
 	SET notify_author_on_comment_reply = ?, notify_author_on_comment_vote = ?
 	WHERE id = ?
 `;
+
+export const getDisplayNameQuery = `
+  SELECT display_name AS displayName, display_name_changed_at AS displayNameChangedAt
+  FROM auth_user WHERE id = ?
+`;
+
+export const updateDisplayNameQuery = `
+  UPDATE auth_user
+  SET display_name = ?, display_name_changed_at = NOW()
+  WHERE id = ?
+`;
+
+export const getAllReservedValuesQuery = `
+  SELECT value FROM reserved_display_name
+`;

--- a/src/plugins/users/schemas.ts
+++ b/src/plugins/users/schemas.ts
@@ -28,3 +28,15 @@ export type ChangePasswordRequest = z.infer<typeof changePasswordRequest>;
 export type DeleteUserRequest = z.infer<typeof deleteUserRequest>;
 export type NotificationSettingsResponse = z.infer<typeof notificationSettingsResponse>;
 export type UpdateNotificationSettingsRequest = z.infer<typeof updateNotificationSettingsRequest>;
+
+export const displayNameResponse = z.object({
+	displayName: z.string().nullable(),
+	displayNameChangedAt: z.string().nullable(),
+});
+
+export const updateDisplayNameRequest = z.object({
+	displayName: z.string(),
+});
+
+export type DisplayNameResponse = z.infer<typeof displayNameResponse>;
+export type UpdateDisplayNameRequest = z.infer<typeof updateDisplayNameRequest>;

--- a/src/plugins/users/users.test.ts
+++ b/src/plugins/users/users.test.ts
@@ -112,3 +112,89 @@ describe('DELETE /users/:userId', () => {
 		expect(response.statusCode).toBe(403);
 	});
 });
+
+const getTokenForUser = (sub: number) =>
+	signAccessToken(
+		{ sub, login: `user${sub}`, isAdmin: false, isEditor: false, tokenVersion: 0,
+			rights: { canVote: true, canComment: true, canEditContent: false, canEditUsers: false } },
+		secret,
+	);
+
+describe('GET /users/:userId/display-name', () => {
+	it('returns 403 for a different user', async () => {
+		const mysql = createMockMysql();
+		const app = await buildApp(mysql);
+		const token = await getTokenForUser(2); // logged in as user 2, requesting user 1
+		const res = await app.inject({
+			method: 'GET',
+			url: '/users/1/display-name',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(res.statusCode).toBe(403);
+	});
+
+	it('returns displayName for own user', async () => {
+		const mysql = createMockMysql([{ displayName: 'Poetic Soul', displayNameChangedAt: null }]);
+		const app = await buildApp(mysql);
+		const token = await getTokenForUser(1);
+		const res = await app.inject({
+			method: 'GET',
+			url: '/users/1/display-name',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toMatchObject({ displayName: 'Poetic Soul' });
+	});
+});
+
+describe('PUT /users/:userId/display-name', () => {
+	it('returns 429 when changed within 7 days', async () => {
+		const recentChange = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000); // 3 days ago
+		const mysql = createMockMysql(
+			[{ displayName: 'Old Name', displayNameChangedAt: recentChange }],
+		);
+		const app = await buildApp(mysql);
+		const token = await getTokenForUser(1);
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/users/1/display-name',
+			headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+			body: JSON.stringify({ displayName: 'New Name' }),
+		});
+		expect(res.statusCode).toBe(429);
+	});
+
+	it('returns 409 when display name is reserved', async () => {
+		const mysql = createMockMysql(
+			[{ displayName: 'whatever', displayNameChangedAt: null }],
+			[{ value: 'admin' }, { value: 'mellonis' }],
+		);
+		const app = await buildApp(mysql);
+		const token = await getTokenForUser(1);
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/users/1/display-name',
+			headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+			body: JSON.stringify({ displayName: 'admin' }),
+		});
+		expect(res.statusCode).toBe(409);
+	});
+
+	it('updates display name when valid and not in cooldown', async () => {
+		const mysql = createMockMysql(
+			[{ displayName: 'old', displayNameChangedAt: null }],
+			[],
+			[{}],
+		);
+		const app = await buildApp(mysql);
+		const token = await getTokenForUser(1);
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/users/1/display-name',
+			headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+			body: JSON.stringify({ displayName: 'New Name' }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toMatchObject({ displayName: 'New Name' });
+	});
+});

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -5,19 +5,23 @@ import { sendEmail } from '../../lib/email.js';
 import { accountDeletedEmail } from '../../lib/emailTemplates.js';
 import { checkPassword, hashPassword } from '../auth/password.js';
 import { deleteAllUserRefreshTokens } from '../auth/databaseHelpers.js';
-import { getUserCredentials, updatePassword, deleteUser, getNotificationSettings, updateNotificationSettings } from './databaseHelpers.js';
+import { getUserCredentials, updatePassword, deleteUser, getNotificationSettings, updateNotificationSettings, getDisplayName, setDisplayName, isReservedDisplayName } from './databaseHelpers.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import { actorFingerprint } from '../../lib/actorFingerprint.js';
+import { validateDisplayName } from '../../lib/displayName.js';
 import {
 	userIdParam,
 	changePasswordRequest,
 	deleteUserRequest,
 	notificationSettingsResponse,
 	updateNotificationSettingsRequest,
+	displayNameResponse,
+	updateDisplayNameRequest,
 	type UserIdParam,
 	type ChangePasswordRequest,
 	type DeleteUserRequest,
 	type UpdateNotificationSettingsRequest,
+	type UpdateDisplayNameRequest,
 } from './schemas.js';
 
 export async function usersPlugin(fastify: FastifyInstance) {
@@ -209,6 +213,93 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Notification settings updated');
 
 				return { notifyAuthorOnCommentReply, notifyAuthorOnCommentVote };
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	fastify.get('/:userId/display-name', {
+		schema: {
+			description: 'Get display name for the authenticated user.',
+			tags: ['Users'],
+			params: userIdParam,
+			response: {
+				200: displayNameResponse,
+				403: authErrorResponse,
+				404: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request: FastifyRequest<{ Params: UserIdParam }>, reply) => {
+			try {
+				const { userId } = request.params;
+				if (request.user!.sub !== userId) {
+					return reply.code(403).send({ error: 'forbidden', message: 'Cannot read another user\'s display name' });
+				}
+				const info = await getDisplayName(fastify.mysql, userId);
+				if (!info) return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
+				return {
+					displayName: info.displayName,
+					displayNameChangedAt: info.displayNameChangedAt?.toISOString() ?? null,
+				};
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+
+	const DISPLAY_NAME_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+	fastify.put('/:userId/display-name', {
+		schema: {
+			description: 'Update display name for the authenticated user. Rate-limited to once per 7 days.',
+			tags: ['Users'],
+			params: userIdParam,
+			body: updateDisplayNameRequest,
+			response: {
+				200: displayNameResponse,
+				400: errorResponse,
+				403: authErrorResponse,
+				404: authErrorResponse,
+				409: errorResponse,
+				429: errorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (
+			request: FastifyRequest<{ Params: UserIdParam; Body: UpdateDisplayNameRequest }>,
+			reply,
+		) => {
+			try {
+				const { userId } = request.params;
+				if (request.user!.sub !== userId) {
+					return reply.code(403).send({ error: 'forbidden', message: 'Cannot change another user\'s display name' });
+				}
+
+				const result = validateDisplayName(request.body.displayName);
+				if (!result.ok) return reply.code(400).send({ error: result.error });
+
+				const info = await getDisplayName(fastify.mysql, userId);
+				if (!info) return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
+
+				if (info.displayNameChangedAt && Date.now() - info.displayNameChangedAt.getTime() < DISPLAY_NAME_COOLDOWN_MS) {
+					return reply.code(429).send({ error: 'display_name_cooldown', message: 'Display name can only be changed once per 7 days' });
+				}
+
+				const reserved = await isReservedDisplayName(fastify.mysql, result.value);
+				if (reserved) {
+					return reply.code(409).send({ error: 'display_name_reserved', message: 'This display name is not available' });
+				}
+
+				await setDisplayName(fastify.mysql, userId, result.value);
+				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Display name updated');
+				return {
+					displayName: result.value,
+					displayNameChangedAt: new Date().toISOString(),
+				};
 			} catch (error) {
 				request.log.error(error);
 				return reply.code(500).send({ error: 'Internal server error' });


### PR DESCRIPTION
## Summary

- New endpoints: `GET/PUT /users/:userId/display-name` with 7-day cooldown and homoglyph-safe reserved-name check; `GET/POST/DELETE /cms/reserved-display-names/*` (POST/DELETE require `canEditUsers`).
- Comments now serve `authorDisplayName` (snapshotted at insert time, masked to `'—'` on tombstones) + `isAuthor` (root admin badge) instead of `authorLogin`. CMS rows still expose `authorLogin` separately for moderators.
- Reply notification email now includes the `(Автор сайта)` badge when the replier is the root admin.
- New user registration sets `display_name = login` so behavior is unchanged for existing users.

## Depends on

mellonis/poetry-old2#59 (schema migration). Merge that PR and apply the migration to prod before merging this one.

## Test plan

- [ ] CI green (255/255 tests, lint, build).
- [ ] After deploy: `GET /users/:userId/display-name` returns `{displayName, displayNameChangedAt}` for the authenticated user; 403 for someone else's id.
- [ ] `PUT /users/:userId/display-name` enforces 7-day cooldown (429) and reserved-name list (409, 400 on invalid).
- [ ] Post a comment as a fresh user — comment list returns the new displayName, not the login.
- [ ] Reply to a user as `root` — email subject contains `(Автор сайта)` and the in-thread badge renders.
- [ ] CMS `/cms/reserved-display-names` GET/POST/DELETE work; non-`canEditUsers` editor gets 403 on POST/DELETE.