### PR TITLE
feat: configurable SITE_AUTHOR_USER_ID for the (Автор сайта) badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ SMTP_FROM_ADDRESS=notifier@mellonis.ru
 ALLOWED_ORIGINS=
 WEBAUTHN_RP_ID=localhost
 ADMIN_NOTIFY_EMAIL=
+SITE_AUTHOR_USER_ID=1
 MEILI_URL=http://poetry-meilisearch:7700
 MEILI_MASTER_KEY=
 LOG_HMAC_KEY_CURRENT=dev-placeholder-do-not-use-in-prod-this-is-only-for-local-tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ SMTP_FROM_ADDRESS=notifier@mellonis.ru   # required, email address for From head
 ALLOWED_ORIGINS=https://poetry.mellonis.ru,https://old2.poetry.mellonis.ru  # required, comma-separated whitelist of client origins (CORS + email links)
 WEBAUTHN_RP_ID=poetry.mellonis.ru       # optional, WebAuthn Relying Party ID (default: poetry.mellonis.ru, use "localhost" for local dev)
 ADMIN_NOTIFY_EMAIL=admin@mellonis.ru  # optional, receives notifications on votes, registrations, account deletions, comment reports
+SITE_AUTHOR_USER_ID=1                 # optional, auth_user.id of the human site owner. Comments by this user get isAuthor=true (rendered as the «Автор сайта» badge in the UI / reply emails). Decoupled from the workspace's "root admin id=1" convention since the site owner may post under a different account. Default 1.
 MEILI_URL=http://poetry-meilisearch:7700  # optional, Meilisearch host (default: http://poetry-meilisearch:7700)
 MEILI_MASTER_KEY=<key>               # optional (required for search to work), shared with Meilisearch container
 LOG_HMAC_KEY_CURRENT=<32-byte hex>      # required, HMAC key for actorFingerprint() log helper. In prod, written by the VPS rotation script (see mellonis/poetry docs/superpowers/specs/2026-05-05-privacy-safe-logging-design.md). In dev, any non-empty string works.

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -1,3 +1,9 @@
+// "Site author" id — the user whose comments get the (Автор сайта) badge.
+// Decoupled from the workspace's "root admin" id (1) since the actual site
+// owner may post under a different account. Default 1 keeps existing dev/test
+// behavior; prod sets SITE_AUTHOR_USER_ID in .env.
+const SITE_AUTHOR_USER_ID = Number(process.env.SITE_AUTHOR_USER_ID) || 1;
+
 // Common SELECT body for a comment row, parameterized by the caller's userId
 // (or 0 for anonymous — never matches a real auth_user.id, so userVote stays 0).
 const commentRowFields = `
@@ -6,7 +12,7 @@ const commentRowFields = `
   c.r_thing_id AS thingId,
   c.r_user_id AS userId,
   c.display_name_snapshot AS authorDisplayName,
-  (c.r_user_id = 1) AS isAuthor,
+  (c.r_user_id = ${SITE_AUTHOR_USER_ID}) AS isAuthor,
   c.text,
   c.r_comment_status_id AS statusId,
   c.created_at AS createdAt,
@@ -205,7 +211,7 @@ const cmsCommentRowFields = `
   c.r_user_id AS userId,
   u.login AS authorLogin,
   c.display_name_snapshot AS authorDisplayName,
-  (c.r_user_id = 1) AS isAuthor,
+  (c.r_user_id = ${SITE_AUTHOR_USER_ID}) AS isAuthor,
   c.text,
   c.r_comment_status_id AS statusId,
   c.created_at AS createdAt,


### PR DESCRIPTION
## Summary

The comment-row `isAuthor` flag was hardcoded to `(c.r_user_id = 1)`, mirroring the workspace's "id=1 is root admin" convention. But the actual site owner posts under a different account (e.g. `mellonis`, id=3) and still expects the (Автор сайта) badge on their own comments.

This decouples the two concepts:
- `ROOT_ADMIN_ID = 1` (in `cms/userRoutes.ts`) — kept as-is, used for delete/ban protection rules.
- `SITE_AUTHOR_USER_ID` — new env var, default `1`, read once at module load in `comments/queries.ts` and interpolated into the `isAuthor` SELECT expression.

## After merge

Set `SITE_AUTHOR_USER_ID=3` in the prod `.env` on the VPS (`/var/web-apps/poetry/poetry-api/.env`) and restart the api container so it picks up the new env var.

## Test plan

- [x] `npm test` — 255/255 pass (existing tests mock the row directly with `isAuthor: 1|0`, so they're unaffected).
- [x] `npm run build` — clean.
- [ ] After merge + env update + restart: post a comment as `mellonis` (id=3) and confirm the ✦ "Автор сайта" badge renders.