### PR TITLE
fix: project authorDisplayName + isAuthor in CMS comment list mapper

### DIFF
--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -448,6 +448,8 @@ export const listCommentsForCms = async (
 				thingFirstLines: (r.thingFirstLines as string | null) ?? null,
 				userId: r.userId as number | null,
 				authorLogin: r.authorLogin as string | null,
+				authorDisplayName: r.authorDisplayName as string | null,
+				isAuthor: Boolean(r.isAuthor),
 				text: r.text as string,
 				statusId: r.statusId as number,
 				createdAt: toIso(r.createdAt as Date),


### PR DESCRIPTION
## Summary

`GET /cms/comments` is returning 500 in prod:
```
Response doesn't match the schema: authorDisplayName / isAuthor expected, received undefined
```

The SQL (`cmsCommentRowFields`) selects both fields, but `listCommentsForCms`'s row mapper didn't project them onto the response object — so the schema validator rejected the serialized rows.

## Root cause

This bug was added in PR #125 (the displayName feature). The public comment list mapper was updated with the new fields but the CMS list mapper wasn't. There's no test coverage for `listCommentsForCms` / `GET /cms/comments`, which is why the spec/quality review didn't catch it.

## Test plan

- [x] `npm test` — 255/255 pass.
- [x] `npm run build` — clean.
- [ ] After merge + deploy: `GET /cms/comments?status=visible&limit=20&offset=0` returns 200 with `authorDisplayName` + `isAuthor` populated for each item.

## Follow-up

Add a test for `listCommentsForCms` covering at least: visible comments, hidden, deleted, reported filter, and the `isAuthor`-vs-other-user cases. Tracked separately.