### PR TITLE
fix: drop displayNameChangedAt from API, return inCooldown boolean

### DIFF
--- a/src/plugins/users/schemas.ts
+++ b/src/plugins/users/schemas.ts
@@ -31,7 +31,7 @@ export type UpdateNotificationSettingsRequest = z.infer<typeof updateNotificatio
 
 export const displayNameResponse = z.object({
 	displayName: z.string().nullable(),
-	displayNameChangedAt: z.string().nullable(),
+	inCooldown: z.boolean(),
 });
 
 export const updateDisplayNameRequest = z.object({

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -24,6 +24,10 @@ import {
 	type UpdateDisplayNameRequest,
 } from './schemas.js';
 
+const DISPLAY_NAME_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+const isInDisplayNameCooldown = (changedAt: Date | null): boolean =>
+	changedAt !== null && Date.now() - changedAt.getTime() < DISPLAY_NAME_COOLDOWN_MS;
+
 export async function usersPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: users...');
 
@@ -242,7 +246,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				if (!info) return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
 				return {
 					displayName: info.displayName,
-					displayNameChangedAt: info.displayNameChangedAt?.toISOString() ?? null,
+					inCooldown: isInDisplayNameCooldown(info.displayNameChangedAt),
 				};
 			} catch (error) {
 				request.log.error(error);
@@ -251,7 +255,6 @@ export async function usersPlugin(fastify: FastifyInstance) {
 		},
 	});
 
-	const DISPLAY_NAME_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
 
 	fastify.put('/:userId/display-name', {
 		schema: {
@@ -285,7 +288,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				const info = await getDisplayName(fastify.mysql, userId);
 				if (!info) return reply.code(404).send({ error: 'user_not_found', message: 'User not found' });
 
-				if (info.displayNameChangedAt && Date.now() - info.displayNameChangedAt.getTime() < DISPLAY_NAME_COOLDOWN_MS) {
+				if (isInDisplayNameCooldown(info.displayNameChangedAt)) {
 					return reply.code(429).send({ error: 'display_name_cooldown', message: 'Display name can only be changed once per 7 days' });
 				}
 
@@ -298,7 +301,7 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				request.log.info({ actorFingerprint: actorFingerprint(userId) }, 'Display name updated');
 				return {
 					displayName: result.value,
-					displayNameChangedAt: new Date().toISOString(),
+					inCooldown: true,
 				};
 			} catch (error) {
 				request.log.error(error);


### PR DESCRIPTION
## Summary

Stop exposing the cooldown unlock timestamp on the wire. `GET /users/:userId/display-name` and `PUT /users/:userId/display-name` previously returned `{displayName, displayNameChangedAt}`; now they return `{displayName, inCooldown}`. The server keeps `display_name_changed_at` internally for the cooldown check and computes the boolean; clients only see yes/no.

PUT always returns `inCooldown: true` (by definition — they just changed it).

## Why

- "Next change available after <дата>" exposes a specific timestamp that invites "why exactly that date?" friction. The boolean is enough.
- The unlock date is essentially a clock-side timing channel. Dropping it from the response keeps that data server-side only.

## Companion

- nextjs PR follow-up consumes the new shape and (separately) hides the cooldown banner after a fresh save.

## Test plan

- [x] `npm test` — 255/255 pass.
- [x] `npm run build` — clean.
- [ ] After deploy: `GET /users/:userId/display-name` returns `{displayName, inCooldown}` (no `displayNameChangedAt` field).
- [ ] PUT during cooldown still returns 429.