### PR TITLE
fix(comments): include section context in GET /comments/:id

### DIFF
--- a/src/plugins/comments/comments.test.ts
+++ b/src/plugins/comments/comments.test.ts
@@ -133,10 +133,13 @@ describe('GET /comments', () => {
 });
 
 describe('GET /comments/:commentId', () => {
-	it('bundles replies for a top-level comment (single-thread shape)', async () => {
+	const sectionCtx = [{ sectionIdentifier: 'spring-cycle', positionInSection: 7 }];
+
+	it('bundles replies for a top-level comment with section context for the deep link', async () => {
 		const top = { ...visibleRow, parentId: null, hasVisibleChild: 1 };
 		const reply = { ...visibleRow, id: 11, parentId: 10, hasVisibleChild: 0 };
-		const mysql = createMockMysql([top], [reply]);
+		// Query order: commentByIdQuery → thingSectionContextQuery → repliesByParentIdQuery
+		const mysql = createMockMysql([top], sectionCtx, [reply]);
 		const app = await buildApp(mysql);
 
 		const response = await app.inject({ method: 'GET', url: '/comments/10' });
@@ -145,11 +148,14 @@ describe('GET /comments/:commentId', () => {
 		expect(body.id).toBe(10);
 		expect(body.replies).toHaveLength(1);
 		expect(body.replies[0].id).toBe(11);
+		expect(body.sectionIdentifier).toBe('spring-cycle');
+		expect(body.positionInSection).toBe(7);
 	});
 
-	it('returns a reply without bundling further replies (one-level threading)', async () => {
+	it('returns a reply with section context (same thing, same deep-link target)', async () => {
 		const reply = { ...visibleRow, id: 11, parentId: 10, hasVisibleChild: 0 };
-		const mysql = createMockMysql([reply]);
+		// Query order: commentByIdQuery → thingSectionContextQuery (no replies fetch)
+		const mysql = createMockMysql([reply], sectionCtx);
 		const app = await buildApp(mysql);
 
 		const response = await app.inject({ method: 'GET', url: '/comments/11' });
@@ -158,6 +164,35 @@ describe('GET /comments/:commentId', () => {
 		expect(body.id).toBe(11);
 		expect(body.parentId).toBe(10);
 		expect(body.replies).toBeUndefined();
+		expect(body.sectionIdentifier).toBe('spring-cycle');
+		expect(body.positionInSection).toBe(7);
+	});
+
+	it('returns null section context for a guestbook comment (thingId IS NULL)', async () => {
+		const top = { ...visibleRow, thingId: null, parentId: null, hasVisibleChild: 0 };
+		// thingId is null → thingSectionContextQuery is skipped → only repliesByParentIdQuery runs.
+		const mysql = createMockMysql([top], []);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments/10' });
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.thingId).toBeNull();
+		expect(body.sectionIdentifier).toBeNull();
+		expect(body.positionInSection).toBeNull();
+	});
+
+	it('returns null section context when the thing is in zero sections', async () => {
+		const top = { ...visibleRow, parentId: null, hasVisibleChild: 0 };
+		// thingSectionContextQuery returns no rows (LIMIT 1 query found nothing).
+		const mysql = createMockMysql([top], [], []);
+		const app = await buildApp(mysql);
+
+		const response = await app.inject({ method: 'GET', url: '/comments/10' });
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.sectionIdentifier).toBeNull();
+		expect(body.positionInSection).toBeNull();
 	});
 
 	it('returns 404 for unknown id', async () => {

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -13,6 +13,7 @@ import {
 	getRepliesForTopLevel,
 	getCommentReplyContext,
 	getCommentVoteContext,
+	getThingSectionContext,
 	createComment,
 	updateCommentText,
 	setCommentStatus,
@@ -26,6 +27,7 @@ import {
 	commentListQuery,
 	commentListResponse,
 	commentWithRepliesSchema,
+	commentSingleSchema,
 	createCommentRequest,
 	updateCommentRequest,
 	voteCommentRequest,
@@ -107,11 +109,11 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 
 	fastify.get('/:commentId', {
 		schema: {
-			description: 'Fetch a single comment by id. Top-level rows include their replies (single-thread view); reply rows are returned bare.',
+			description: 'Fetch a single comment by id. Top-level rows include their replies (single-thread view); reply rows are returned bare. Response carries one (sectionIdentifier, positionInSection) pair for thing-comments — chosen deterministically when the thing lives in multiple sections — so callers can build a /sections/<id>/<pos>?thread=N deep link without a second round-trip; both null for guestbook entries.',
 			tags: ['Comments'],
 			params: commentParams,
 			response: {
-				200: commentWithRepliesSchema,
+				200: commentSingleSchema,
 				404: errorResponse,
 				500: errorResponse,
 			},
@@ -122,12 +124,18 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 			const comment = await getCommentById(fastify.mysql, request.params.commentId, userId);
 			if (!comment) return reply.code(404).send(errorBody('not_found'));
 
+			const sectionCtx = comment.thingId !== null
+				? await getThingSectionContext(fastify.mysql, comment.thingId)
+				: null;
+			const sectionIdentifier = sectionCtx?.sectionIdentifier ?? null;
+			const positionInSection = sectionCtx?.positionInSection ?? null;
+
 			if (comment.parentId === null) {
 				const replies = await getRepliesForTopLevel(fastify.mysql, comment.id, userId);
-				return { ...comment, replies };
+				return { ...comment, replies, sectionIdentifier, positionInSection };
 			}
 
-			return comment;
+			return { ...comment, sectionIdentifier, positionInSection };
 		},
 	});
 

--- a/src/plugins/comments/databaseHelpers.ts
+++ b/src/plugins/comments/databaseHelpers.ts
@@ -10,6 +10,7 @@ import {
 	commentByIdQuery,
 	commentMetaByIdQuery,
 	commentReplyContextQuery,
+	thingSectionContextQuery,
 	commentVoteContextQuery,
 	insertCommentQuery,
 	updateCommentTextQuery,
@@ -160,6 +161,29 @@ export const getCommentById = async (
 		if (!row) return null;
 		if (row.statusId !== COMMENT_STATUS.visible && row.hasVisibleChild !== 1) return null;
 		return projectRow(row);
+	});
+
+export interface ThingSectionContext {
+	sectionIdentifier: string;
+	positionInSection: number;
+}
+
+// Returns one (sectionIdentifier, positionInSection) pair for the thing — null
+// when the thing is in zero sections (shouldn't happen for published things,
+// possible for unpublished). The Comments widget keys by thingId, so any
+// section URL renders the same thread.
+export const getThingSectionContext = async (
+	mysql: MySQLPromisePool,
+	thingId: number,
+): Promise<ThingSectionContext | null> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingSectionContextQuery, [thingId]);
+		const row = rows[0];
+		if (!row) return null;
+		return {
+			sectionIdentifier: row.sectionIdentifier as string,
+			positionInSection: row.positionInSection as number,
+		};
 	});
 
 // Fetch all visible replies for a top-level comment. Replies that are not

--- a/src/plugins/comments/queries.ts
+++ b/src/plugins/comments/queries.ts
@@ -72,6 +72,23 @@ export const commentByIdQuery = `
   GROUP BY c.id
 `;
 
+// Lookup for the single-comment response: any one (sectionIdentifier,
+// positionInSection) pair for a thing that lives in multiple sections.
+// Same convention as commentReplyContextQuery — any link lands on the same
+// comment thread (Comments widget keys by thingId, not section). ORDER BY
+// ti.id keeps the choice stable across calls so the rendered URL doesn't
+// flicker between renders.
+export const thingSectionContextQuery = `
+  SELECT
+    s.identifier               AS sectionIdentifier,
+    ti.thing_position_in_section AS positionInSection
+  FROM thing_identifier ti
+  JOIN section s ON s.id = ti.r_section_id
+  WHERE ti.r_thing_id = ?
+  ORDER BY ti.id ASC
+  LIMIT 1
+`;
+
 // Used for parent validation on insert + edit-window / ownership / status checks
 // on update / delete.
 export const commentMetaByIdQuery = `

--- a/src/plugins/comments/schemas.ts
+++ b/src/plugins/comments/schemas.ts
@@ -44,6 +44,16 @@ const commentWithRepliesSchema = commentBaseSchema.extend({
 	replies: z.optional(z.array(commentBaseSchema)),
 });
 
+// Response for GET /comments/:commentId. Adds a deterministic
+// (sectionIdentifier, positionInSection) pair for thing-comments so callers
+// (the CMS thread page) can build a /sections/<id>/<pos>?thread=N deep link
+// without a second round-trip. Both null for guestbook entries (thingId IS
+// NULL) and for things not yet attached to any section.
+const commentSingleSchema = commentWithRepliesSchema.extend({
+	sectionIdentifier: z.string().nullable(),
+	positionInSection: z.number().int().positive().nullable(),
+});
+
 const commentListQuery = z.object({
 	thingId: z.optional(z.coerce.number().int().positive()),
 	scope: z.optional(z.enum(['site', 'thing'])),
@@ -109,6 +119,7 @@ export {
 	commentParams,
 	commentBaseSchema,
 	commentWithRepliesSchema,
+	commentSingleSchema,
 	commentListQuery,
 	commentListResponse,
 	createCommentRequest,


### PR DESCRIPTION
## Summary

- Extend the `GET /comments/:commentId` response with `sectionIdentifier` and `positionInSection`, populated for thing-comments via a deterministic `LIMIT 1` lookup against `thing_identifier`. Both null for guestbook entries (thingId IS NULL) and for things attached to no section.
- Same convention as `commentReplyContextQuery` already uses for email deep links — any link lands on the same thread because the public Comments widget keys by `thingId`, not by section.
- List response (`GET /comments`) and create response (`POST /comments`) shapes are intentionally untouched — the new fields cost a query and only the CMS thread page needs them.

## Why

Issue mellonis/poetry-nextjs#104 — the CMS comment-thread page's "Открыть ↗" link for thing-comments produced `/?thread=N`, a URL the public site silently ignores. Without the section context the page had no way to build the correct `/sections/<id>/<pos>?thread=N` URL.

The frontend half of the fix lives in mellonis/poetry-nextjs (separate PR per workspace convention).

## Test plan

- [x] `npm test` — full suite (257 passing)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] After deploy: hit `GET /comments/:id` for a thing-comment, verify `sectionIdentifier` + `positionInSection` populated
- [ ] After deploy: hit `GET /comments/:id` for a guestbook comment, verify both null