### PR TITLE
fix(thingsOfTheDay): order fallback by stable hash, not RAND(seed)

### DIFF
--- a/src/plugins/thingsOfTheDay/queries.ts
+++ b/src/plugins/thingsOfTheDay/queries.ts
@@ -38,7 +38,8 @@ export const thingsOfTheDayFallbackQuery = `
 		FROM thing
 		WHERE exclude_from_daily = FALSE
 			AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(CURDATE(), '%m')
-		ORDER BY RAND(TO_DAYS(CURDATE()))
+		-- Row-dependent hash, not RAND(constant): the optimizer collapses the latter to scan order.
+		ORDER BY MD5(CONCAT(id, ':', TO_DAYS(CURDATE())))
 		LIMIT 1
 	) AS chosen ON v_things_info.thing_id = chosen.id;
 `;
@@ -52,7 +53,8 @@ export const thingsOfTheDayFallbackWithUserVoteQuery = `
 		FROM thing
 		WHERE exclude_from_daily = FALSE
 			AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(CURDATE(), '%m')
-		ORDER BY RAND(TO_DAYS(CURDATE()))
+		-- See thingsOfTheDayFallbackQuery for why the ordering is hash-based, not RAND(seed).
+		ORDER BY MD5(CONCAT(id, ':', TO_DAYS(CURDATE())))
 		LIMIT 1
 	) AS chosen ON v_things_info.thing_id = chosen.id;
 `;


### PR DESCRIPTION
## Summary

- MySQL's optimizer collapses `ORDER BY RAND(constant) LIMIT 1` to a scan-order pick, ignoring the seed. The "date-stable random fallback" has returned thing #1 (or #2 when #1 was excluded by the same-month rule) for years.
- Replace with `ORDER BY MD5(CONCAT(id, ':', TO_DAYS(CURDATE())))` in both `thingsOfTheDayFallbackQuery` and `thingsOfTheDayFallbackWithUserVoteQuery`. The hash is row-dependent so the optimizer can't collapse it.

Fixes #130. See the issue for the diagnostic queries and evidence.

## Verification

Tested on the prod DB:

```sql
SELECT seed, (
    SELECT id FROM thing
    WHERE exclude_from_daily = FALSE
    ORDER BY MD5(CONCAT(id, ':', seed)) LIMIT 1
) AS picked
FROM (SELECT 1 AS seed UNION SELECT 100 UNION SELECT 1000 UNION SELECT 10000
      UNION SELECT 100000 UNION SELECT 500000 UNION SELECT 700000
      UNION SELECT 739000 UNION SELECT 739100 UNION SELECT 739500
      UNION SELECT 800000 UNION SELECT 1000000) s;
```

Old behavior (with `RAND(seed)`): all 12 seeds return `picked = 1`.
New behavior (with `MD5`): 12 distinct IDs (438, 445, 430, 63, 522, 126, 33, 338, 200, 27, 52, 28).

Distribution check across 1000 sequential seeds (no month filter) — pool size 524, 451 distinct picks, max count 8 — matches uniform Poisson(1.91) within sample variance. Across 366 real day-of-year seeds with the same-month exclusion, max pick count is 4 across the year — also matches uniform.

## Behavior change visible to end users

On any day with no `MM-DD`-matched curated thing (~200 days/year given the current dataset), visitors will now see a different fallback rather than the same single thing every time. No DB migration, no API contract change.

## Test plan

- [ ] CI: lint + tests (passing locally — `npm run lint` clean, `npm test` 257/257)
- [ ] Verify in dev: `GET /things-of-the-day` on a date with no curated bucket returns a non-trivial pick (and that the same date still returns the same pick on repeat calls — date-stability is preserved)
- [ ] Verify in prod after deploy: spot-check a known-empty day; pick should differ from "Темно" / "Уснувшая Мечта"