### PR TITLE
feat(cms): add things-of-the-day rolling-year calendar endpoint

### DIFF
--- a/src/plugins/cms/calendarRoutes.ts
+++ b/src/plugins/cms/calendarRoutes.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from 'fastify';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import { getThingsOfTheDayCalendar } from './databaseHelpers.js';
+import { cmsThingsOfTheDayCalendarResponse } from './schemas.js';
+
+export async function calendarRoutes(fastify: FastifyInstance) {
+	fastify.get('/things-of-the-day/calendar', {
+		schema: {
+			description: 'Rolling 365–366 day calendar of things-of-the-day, with simulated fallback picks for empty days. Spans today through the same date one year minus one day later.',
+			tags: ['CMS'],
+			response: {
+				200: cmsThingsOfTheDayCalendarResponse,
+				401: authErrorResponse,
+				403: authErrorResponse,
+				500: errorResponse,
+			},
+		},
+		handler: async (request, reply) => {
+			try {
+				return await getThingsOfTheDayCalendar(fastify.mysql);
+			} catch (error) {
+				request.log.error(error);
+				return reply.code(500).send({ error: 'Internal server error' });
+			}
+		},
+	});
+}

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -899,3 +899,120 @@ describe('reserved display names', () => {
 		expect(res.statusCode).toBe(403);
 	});
 });
+
+// --- Things-of-the-day calendar ---
+
+describe('GET /cms/things-of-the-day/calendar', () => {
+	it('returns 401 without auth token', async () => {
+		const app = await buildApp(createMockMysql());
+
+		const response = await app.inject({ method: 'GET', url: '/cms/things-of-the-day/calendar' });
+
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns 403 for non-editor user', async () => {
+		const app = await buildApp(createMockMysql());
+		const token = await getNonEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things-of-the-day/calendar',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('groups rows by bucketDate, emits both kinds, and folds multi-section rows', async () => {
+		const mysql = createMockMysql([
+			// Same thing in two sections — should fold to one entry with sections=[2]
+			{
+				kind: 'curated', bucketDate: '2026-05-06', id: 100, title: 'Today thing',
+				firstLines: null, finishDate: '2010-05-06', statusId: 2, categoryId: 1,
+				sectionId: 'love-poems', position: 5,
+			},
+			{
+				kind: 'curated', bucketDate: '2026-05-06', id: 100, title: 'Today thing',
+				firstLines: null, finishDate: '2010-05-06', statusId: 2, categoryId: 1,
+				sectionId: 'winter-2010', position: 12,
+			},
+			// Untitled thing on the same day, single section
+			{
+				kind: 'curated', bucketDate: '2026-05-06', id: 101, title: null,
+				firstLines: 'Untitled today', finishDate: '2015-05-06', statusId: 1, categoryId: 1,
+				sectionId: 'love-poems', position: 6,
+			},
+			// Fallback on next day, no section placements (sectionId = null)
+			{
+				kind: 'fallback', bucketDate: '2026-05-07', id: 200, title: null,
+				firstLines: 'Random fill', finishDate: '2010-09-25', statusId: 2, categoryId: 1,
+				sectionId: null, position: null,
+			},
+			// Month-only date round-trip
+			{
+				kind: 'curated', bucketDate: '2026-05-31', id: 102, title: 'Month-only thing',
+				firstLines: null, finishDate: '2003-05-00', statusId: 2, categoryId: 1,
+				sectionId: 'misc', position: 1,
+			},
+			// Fallback for an undated thing
+			{
+				kind: 'fallback', bucketDate: '2026-06-01', id: 300, title: null,
+				firstLines: null, finishDate: '0000-00-00', statusId: 2, categoryId: 1,
+				sectionId: 'misc', position: 99,
+			},
+		]);
+		const app = await buildApp(mysql);
+		const token = await getEditorToken(false); // GET works without canEditContent
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things-of-the-day/calendar',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+
+		expect(Object.keys(body)).toEqual(['2026-05-06', '2026-05-07', '2026-05-31', '2026-06-01']);
+
+		// Two entries on May 6 — multi-section thing folded to one entry.
+		expect(body['2026-05-06']).toHaveLength(2);
+		expect(body['2026-05-06'][0]).toEqual({
+			kind: 'curated', id: 100, title: 'Today thing',
+			firstLines: null, finishDate: '2010-05-06', statusId: 2, categoryId: 1,
+			sections: [
+				{ id: 'love-poems', position: 5 },
+				{ id: 'winter-2010', position: 12 },
+			],
+		});
+		expect(body['2026-05-06'][1].sections).toEqual([{ id: 'love-poems', position: 6 }]);
+
+		// Both curated and fallback kinds present somewhere in the response.
+		const kinds = Object.values(body).flat().map((e: { kind: string }) => e.kind);
+		expect(kinds).toContain('curated');
+		expect(kinds).toContain('fallback');
+
+		// Fallback with no placements → empty sections array, not omitted.
+		expect(body['2026-05-07'][0].sections).toEqual([]);
+
+		// Partial-date round-trip via dbDateToIso.
+		expect(body['2026-05-31'][0].finishDate).toBe('2003-05');
+		// Undated fallback surfaces as '0000'.
+		expect(body['2026-06-01'][0].finishDate).toBe('0000');
+	});
+
+	it('returns an empty object when the query returns no rows', async () => {
+		const app = await buildApp(createMockMysql([]));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things-of-the-day/calendar',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({});
+	});
+});

--- a/src/plugins/cms/cms.ts
+++ b/src/plugins/cms/cms.ts
@@ -7,6 +7,7 @@ import { searchCmsRoutes } from './searchCmsRoutes.js';
 import { userRoutes } from './userRoutes.js';
 import { commentsCmsRoutes } from './commentsCmsRoutes.js';
 import { reservedDisplayNameRoutes } from './reservedDisplayNameRoutes.js';
+import { calendarRoutes } from './calendarRoutes.js';
 
 const requireEditorRole = async (request: FastifyRequest, reply: FastifyReply) => {
 	if (!request.user?.isEditor) {
@@ -28,6 +29,7 @@ export async function cmsPlugin(fastify: FastifyInstance) {
 	fastify.register(userRoutes);
 	fastify.register(commentsCmsRoutes);
 	fastify.register(reservedDisplayNameRoutes, { prefix: '/reserved-display-names' });
+	fastify.register(calendarRoutes);
 
 	fastify.log.info('[PLUGIN] Registered: cms');
 }

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -43,6 +43,7 @@ import {
 	updateThingNoteQuery,
 	deleteThingNotesExceptQuery,
 	deleteAllThingNotesQuery,
+	cmsThingsOfTheDayCalendarQuery,
 } from './queries.js';
 
 // --- Settings mapping ---
@@ -612,4 +613,76 @@ export const getThingInSectionsCount = async (mysql: MySQLPromisePool, thingId: 
 	withConnection(mysql, async (connection) => {
 		const [rows] = await connection.query<MySQLRowDataPacket[]>(thingInSectionsCountQuery, [thingId]);
 		return rows[0].cnt as number;
+	});
+
+// --- Things-of-the-day calendar ---
+
+export interface CmsCalendarSection {
+	id: string;
+	position: number;
+}
+
+export interface CmsCalendarEntry {
+	kind: 'curated' | 'fallback';
+	id: number;
+	title: string | null;
+	firstLines: string | null;
+	finishDate: string;
+	statusId: number;
+	categoryId: number;
+	sections: CmsCalendarSection[];
+}
+
+export type CmsThingsOfTheDayCalendar = Record<string, CmsCalendarEntry[]>;
+
+// SQL produces one row per (thing, section_placement) pair via LEFT JOINs on
+// thing_identifier + section. Multiple rows for the same (kind, id) within
+// one bucket are folded into a single entry; their sectionId/position pairs
+// accumulate into `sections`. Things with no non-deprecated placements emit
+// one row with sectionId=null → entry.sections stays empty.
+export const getThingsOfTheDayCalendar = async (
+	mysql: MySQLPromisePool,
+): Promise<CmsThingsOfTheDayCalendar> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(cmsThingsOfTheDayCalendarQuery);
+
+		const buckets = new Map<string, { order: string[]; entries: Map<string, CmsCalendarEntry> }>();
+
+		for (const row of rows) {
+			const bucketDate = row.bucketDate as string;
+			let bucket = buckets.get(bucketDate);
+			if (!bucket) {
+				bucket = { order: [], entries: new Map() };
+				buckets.set(bucketDate, bucket);
+			}
+
+			const entryKey = `${row.kind as string}:${row.id as number}`;
+			let entry = bucket.entries.get(entryKey);
+			if (!entry) {
+				entry = {
+					kind: row.kind as 'curated' | 'fallback',
+					id: row.id as number,
+					title: (row.title as string) ?? null,
+					firstLines: (row.firstLines as string) ?? null,
+					finishDate: dbDateToIso(row.finishDate as string),
+					statusId: row.statusId as number,
+					categoryId: row.categoryId as number,
+					sections: [],
+				};
+				bucket.entries.set(entryKey, entry);
+				bucket.order.push(entryKey);
+			}
+
+			const sectionId = row.sectionId as string | null;
+			if (sectionId !== null && !entry.sections.some((s) => s.id === sectionId)) {
+				entry.sections.push({ id: sectionId, position: row.position as number });
+			}
+		}
+
+		const grouped: CmsThingsOfTheDayCalendar = {};
+		for (const [bucketDate, bucket] of buckets) {
+			grouped[bucketDate] = bucket.order.map((key) => bucket.entries.get(key)!);
+		}
+
+		return grouped;
 	});

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -266,3 +266,78 @@ export const deleteThingNotesExceptQuery = `
 export const deleteAllThingNotesQuery = `
 	DELETE FROM thing_note WHERE r_thing_id = ?;
 `;
+
+// --- Things-of-the-day calendar ---
+//
+// Rolling 365/366-day window starting today. For each day in the window:
+//   - "curated" rows: things whose finish_date matches the day's MM-DD (full
+//     date), or whose finish_date is YYYY-MM-00 and the day is the last day
+//     of that month within the window.
+//   - "fallback" row: when the curated bucket is empty, one thing picked
+//     deterministically by MD5 hash (matches the live endpoint's per-day
+//     stable random pick — see issue #130 for why MD5 and not RAND).
+// finish_date = '0000-00-00' (year-only or undated) is excluded from curated;
+// undated things may still surface as fallback picks.
+//
+// LEFT JOINs at the outer level expand to one row per (thing, section)
+// placement so the helper can collect a sections: [{id, position}] array per
+// entry. Deprecated sections (section_type_id = 0) are filtered at the join
+// level via an AND clause so that multi-placement things still show their
+// non-deprecated sections — and things with no non-deprecated placements
+// surface once with sections: []. Section status is NOT filtered: the CMS
+// view shows placements in Preparing/Withdrawn sections too, unlike the
+// public endpoint which goes through v_things_info's status filter.
+export const cmsThingsOfTheDayCalendarQuery = `
+	WITH RECURSIVE days AS (
+		SELECT CURDATE() AS d
+		UNION ALL
+		SELECT d + INTERVAL 1 DAY FROM days
+		WHERE d < CURDATE() + INTERVAL 1 YEAR - INTERVAL 1 DAY
+	),
+	curated AS (
+		SELECT
+			d.d AS bucket_day,
+			t.id, t.title, t.first_lines AS firstLines, t.finish_date AS finishDate,
+			t.r_thing_status_id AS statusId,
+			t.r_thing_category_id AS categoryId
+		FROM thing t
+		JOIN days d ON (
+			(SUBSTRING(t.finish_date, 9, 2) != '00'
+				AND SUBSTRING(t.finish_date, 6) = DATE_FORMAT(d.d, '%m-%d'))
+			OR
+			(SUBSTRING(t.finish_date, 9, 2) = '00' AND SUBSTRING(t.finish_date, 6, 2) != '00'
+				AND SUBSTRING(t.finish_date, 6, 2) = DATE_FORMAT(d.d, '%m')
+				AND d.d = LAST_DAY(d.d))
+		)
+		WHERE t.exclude_from_daily = FALSE
+	)
+	SELECT 'curated' AS kind, DATE_FORMAT(c.bucket_day, '%Y-%m-%d') AS bucketDate,
+	       c.id, c.title, c.firstLines, c.finishDate, c.statusId, c.categoryId,
+	       s.identifier AS sectionId, ti.thing_position_in_section AS position
+	FROM curated c
+	LEFT JOIN thing_identifier ti ON ti.r_thing_id = c.id
+	LEFT JOIN section s ON ti.r_section_id = s.id AND s.r_section_type_id > 0
+
+	UNION ALL
+
+	SELECT 'fallback' AS kind, DATE_FORMAT(d.d, '%Y-%m-%d') AS bucketDate,
+	       fb.id, fb.title, fb.firstLines, fb.finishDate, fb.statusId, fb.categoryId,
+	       s.identifier AS sectionId, ti.thing_position_in_section AS position
+	FROM days d
+	JOIN LATERAL (
+		SELECT id, title, first_lines AS firstLines, finish_date AS finishDate,
+		       r_thing_status_id AS statusId, r_thing_category_id AS categoryId
+		FROM thing
+		WHERE exclude_from_daily = FALSE
+		  AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(d.d, '%m')
+		ORDER BY MD5(CONCAT(id, ':', TO_DAYS(d.d)))
+		LIMIT 1
+	) fb ON TRUE
+	LEFT JOIN thing_identifier ti ON ti.r_thing_id = fb.id
+	LEFT JOIN section s ON ti.r_section_id = s.id AND s.r_section_type_id > 0
+	WHERE NOT EXISTS (
+		SELECT 1 FROM curated c WHERE c.bucket_day = d.d
+	)
+
+	ORDER BY bucketDate, kind DESC, finishDate DESC, id, sectionId;
+`;

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -208,6 +208,37 @@ export const updateThingRequest = z.object({
 	info: z.string().nullable().optional().transform(normInfo),
 }).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
+// --- Things-of-the-day calendar ---
+
+export const cmsThingsOfTheDayCalendarSection = z.object({
+	id: z.string(),
+	position: z.number().int(),
+});
+
+export const cmsThingsOfTheDayCalendarEntry = z.object({
+	kind: z.enum(['curated', 'fallback']),
+	id: z.number().int(),
+	title: z.string().nullable(),
+	firstLines: z.string().nullable(),
+	finishDate: z.string().describe(
+		'ISO partial date (YYYY | YYYY-MM | YYYY-MM-DD). Fallback rows may carry "0000" when the picked thing is undated.',
+	),
+	statusId: z.number().int().describe(
+		'Thing status (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn). The CMS calendar shows ALL statuses, including drafts and withdrawn things — unlike the public /things-of-the-day endpoint which filters via v_things_info.',
+	),
+	categoryId: z.number().int(),
+	sections: z.array(cmsThingsOfTheDayCalendarSection).describe(
+		'Section placements (id = section.identifier, position = thing_position_in_section). Empty if the thing is not yet placed in any non-deprecated section. The CMS view skips deprecated sections (section_type_id = 0) but shows placements in all section statuses, including Preparing/Withdrawn.',
+	),
+});
+
+export const cmsThingsOfTheDayCalendarResponse = z.record(
+	z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+	z.array(cmsThingsOfTheDayCalendarEntry),
+).describe(
+	'Rolling 365–366 day window keyed by YYYY-MM-DD, from today through the same date one year minus one day later (e.g. 2026-05-06 → 2027-05-05). Each day has at least one entry: curated rows from things whose finish_date matches that day (full date or month-end for YYYY-MM-00), or a single fallback row deterministically picked from the eligible pool when the curated bucket is empty.',
+);
+
 // --- Inferred types ---
 
 export type SectionIdParam = z.infer<typeof sectionIdParam>;


### PR DESCRIPTION
## Summary

- Adds `GET /cms/things-of-the-day/calendar` — editor-only (gated by the existing `verifyJwt` + `requireEditorRole` plugin hooks).
- Response is a `Record<YYYY-MM-DD, Entry[]>` covering a rolling **365–366 day window from today** through the same date one year minus one day later. Frontend can iterate keys in chronological order (preserved by SQL ORDER BY + JS object key insertion order).
- Each day has at least one entry: curated rows whose `finish_date` matches the day (full date, or month-end for `YYYY-MM-00`), or a single fallback pick when the curated bucket is empty.

Closes #131. Builds on #130 (the fallback's MD5 ordering).

## Why a rolling window, not calendar year

Editors care more about "what's coming up" than "what already happened this year". A rolling 12-month view from today is the more natural editorial frame — and the YYYY-MM-DD keys disambiguate the year (the same MM-DD can fall in either calendar year of the window).

## What an entry carries

```ts
{
  kind: 'curated' | 'fallback',
  id: number, title: string|null, firstLines: string|null,
  finishDate: string,  // ISO partial; can be '0000' for fallback when picked thing is undated
  statusId: number,    // 1=Preparing, 2=Published, 3=Editing, 4=Withdrawn — ALL surface
  categoryId: number,
  sections: [{id, position}]   // dedup'd; empty when not in any non-deprecated section
}
```

`sections` matters because a thing can be placed in multiple sections; the SQL LEFT JOINs `thing_identifier` + `section` (filtering deprecated `section_type_id=0` at the join) and the helper folds rows by `(kind, id)` per bucket, accumulating placements.

## CMS vs public differences (called out in schema descriptions)

| | Public `/things-of-the-day` | CMS `/cms/things-of-the-day/calendar` |
|---|---|---|
| Thing statuses | Filtered via `v_things_info` (only Published things in Published/Editing sections) | All shown — drafts, Withdrawn, Preparing |
| Section placements | Same v_things_info filter | All section statuses; only deprecated type=0 hidden |
| Bucket scope | Today only (or random fallback) | Full 365–366 day rolling window with simulated fallback |

## Test plan

- [ ] CI: lint + tests (passing locally — `npm run lint` clean, `npm test` 261/261, `npm run build` clean)
- [ ] Smoke: hit the endpoint with an editor token after deploy; confirm response is a `{YYYY-MM-DD: Array}` object spanning roughly today → today+1y-1d.
- [ ] Spot check a multi-section curated entry: e.g. on a known day with a thing placed in two sections, the response should show one entry with `sections.length === 2`.
- [ ] Spot check a fallback day: `kind === 'fallback'`, single entry, `sections` populated (or empty if the picked thing is unplaced).

## Follow-up

The CMS UI page (poetry-nextjs) is intentionally not in this PR — it's the next step on #131 and will iterate against this endpoint. UX defaults from the issue body (show all 366 days, faded styling for fallback rows + tooltip about volatility) still apply.