### PR TITLE
fix(cms): align calendar with public filtering and coerce DATE→string

### DIFF
--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -937,10 +937,11 @@ describe('GET /cms/things-of-the-day/calendar', () => {
 				firstLines: null, finishDate: '2010-05-06', statusId: 2, categoryId: 1,
 				sectionId: 'winter-2010', position: 12,
 			},
-			// Untitled thing on the same day, single section
+			// Untitled thing on the same day, single section. statusId: 3 (Editing)
+			// — still surfaces under the #134 filter alignment (only Published+Editing).
 			{
 				kind: 'curated', bucketDate: '2026-05-06', id: 101, title: null,
-				firstLines: 'Untitled today', finishDate: '2015-05-06', statusId: 1, categoryId: 1,
+				firstLines: 'Untitled today', finishDate: '2015-05-06', statusId: 3, categoryId: 1,
 				sectionId: 'love-poems', position: 6,
 			},
 			// Fallback on next day, no section placements (sectionId = null)

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -279,14 +279,22 @@ export const deleteAllThingNotesQuery = `
 // finish_date = '0000-00-00' (year-only or undated) is excluded from curated;
 // undated things may still surface as fallback picks.
 //
+// Filter alignment with the public /things-of-the-day endpoint (#134): a
+// thing must (1) have r_thing_status_id IN (2, 3) — Published or Editing —
+// and (2) be placed in at least one section that is itself non-deprecated
+// (r_section_type_id > 0) and Published-or-Editing (r_section_status_id IN
+// (2, 3)). Without this, the CMS calendar would show drafts and withdrawn
+// things that won't actually appear publicly, defeating the page's purpose.
+//
 // LEFT JOINs at the outer level expand to one row per (thing, section)
 // placement so the helper can collect a sections: [{id, position}] array per
-// entry. Deprecated sections (section_type_id = 0) are filtered at the join
-// level via an AND clause so that multi-placement things still show their
-// non-deprecated sections — and things with no non-deprecated placements
-// surface once with sections: []. Section status is NOT filtered: the CMS
-// view shows placements in Preparing/Withdrawn sections too, unlike the
-// public endpoint which goes through v_things_info's status filter.
+// entry. The section join also filters non-deprecated AND
+// Published-or-Editing sections so chip rows only surface placements that
+// the public site would render.
+//
+// CAST(... AS CHAR) on finish_date is required: mysql2 returns raw DATE
+// columns as JS Date objects in CTE/LATERAL contexts, and the response Zod
+// schema validates finishDate as a string — see #134.
 export const cmsThingsOfTheDayCalendarQuery = `
 	WITH RECURSIVE days AS (
 		SELECT CURDATE() AS d
@@ -297,7 +305,8 @@ export const cmsThingsOfTheDayCalendarQuery = `
 	curated AS (
 		SELECT
 			d.d AS bucket_day,
-			t.id, t.title, t.first_lines AS firstLines, t.finish_date AS finishDate,
+			t.id, t.title, t.first_lines AS firstLines,
+			CAST(t.finish_date AS CHAR) AS finishDate,
 			t.r_thing_status_id AS statusId,
 			t.r_thing_category_id AS categoryId
 		FROM thing t
@@ -310,13 +319,23 @@ export const cmsThingsOfTheDayCalendarQuery = `
 				AND d.d = LAST_DAY(d.d))
 		)
 		WHERE t.exclude_from_daily = FALSE
+		  AND t.r_thing_status_id IN (2, 3)
+		  AND EXISTS (
+		      SELECT 1 FROM thing_identifier ti
+		      JOIN section s ON ti.r_section_id = s.id
+		      WHERE ti.r_thing_id = t.id
+		        AND s.r_section_type_id > 0
+		        AND s.r_section_status_id IN (2, 3)
+		  )
 	)
 	SELECT 'curated' AS kind, DATE_FORMAT(c.bucket_day, '%Y-%m-%d') AS bucketDate,
 	       c.id, c.title, c.firstLines, c.finishDate, c.statusId, c.categoryId,
 	       s.identifier AS sectionId, ti.thing_position_in_section AS position
 	FROM curated c
 	LEFT JOIN thing_identifier ti ON ti.r_thing_id = c.id
-	LEFT JOIN section s ON ti.r_section_id = s.id AND s.r_section_type_id > 0
+	LEFT JOIN section s ON ti.r_section_id = s.id
+	    AND s.r_section_type_id > 0
+	    AND s.r_section_status_id IN (2, 3)
 
 	UNION ALL
 
@@ -325,16 +344,27 @@ export const cmsThingsOfTheDayCalendarQuery = `
 	       s.identifier AS sectionId, ti.thing_position_in_section AS position
 	FROM days d
 	JOIN LATERAL (
-		SELECT id, title, first_lines AS firstLines, finish_date AS finishDate,
+		SELECT id, title, first_lines AS firstLines,
+		       CAST(finish_date AS CHAR) AS finishDate,
 		       r_thing_status_id AS statusId, r_thing_category_id AS categoryId
 		FROM thing
 		WHERE exclude_from_daily = FALSE
+		  AND r_thing_status_id IN (2, 3)
 		  AND SUBSTRING(finish_date, 6, 2) != DATE_FORMAT(d.d, '%m')
+		  AND EXISTS (
+		      SELECT 1 FROM thing_identifier ti
+		      JOIN section s ON ti.r_section_id = s.id
+		      WHERE ti.r_thing_id = thing.id
+		        AND s.r_section_type_id > 0
+		        AND s.r_section_status_id IN (2, 3)
+		  )
 		ORDER BY MD5(CONCAT(id, ':', TO_DAYS(d.d)))
 		LIMIT 1
 	) fb ON TRUE
 	LEFT JOIN thing_identifier ti ON ti.r_thing_id = fb.id
-	LEFT JOIN section s ON ti.r_section_id = s.id AND s.r_section_type_id > 0
+	LEFT JOIN section s ON ti.r_section_id = s.id
+	    AND s.r_section_type_id > 0
+	    AND s.r_section_status_id IN (2, 3)
 	WHERE NOT EXISTS (
 		SELECT 1 FROM curated c WHERE c.bucket_day = d.d
 	)

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -295,6 +295,18 @@ export const deleteAllThingNotesQuery = `
 // CAST(... AS CHAR) on finish_date is required: mysql2 returns raw DATE
 // columns as JS Date objects in CTE/LATERAL contexts, and the response Zod
 // schema validates finishDate as a string — see #134.
+//
+// Per-day row ordering matches the public /things-of-the-day endpoint
+// (`ORDER BY thing_finish_date DESC, thing_id`): newest curated finish_date
+// first, then thing_id ascending as deterministic tiebreaker. The CMS
+// calendar previewing what the homepage carousel will show requires both
+// endpoints to agree row-for-row on the same day — without `id` as a
+// tiebreaker, MySQL's natural order for ties is unspecified by the spec
+// even if it usually returns PK order in practice.
+// `kind DESC` and `sectionId` in the outer ORDER BY are stable secondary
+// keys; curated and fallback never mix within a single day (the fallback
+// query is gated by NOT EXISTS curated for that day), so `kind DESC`
+// affects nothing in practice but keeps the sort fully deterministic.
 export const cmsThingsOfTheDayCalendarQuery = `
 	WITH RECURSIVE days AS (
 		SELECT CURDATE() AS d

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -224,11 +224,11 @@ export const cmsThingsOfTheDayCalendarEntry = z.object({
 		'ISO partial date (YYYY | YYYY-MM | YYYY-MM-DD). Fallback rows may carry "0000" when the picked thing is undated.',
 	),
 	statusId: z.number().int().describe(
-		'Thing status (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn). The CMS calendar shows ALL statuses, including drafts and withdrawn things — unlike the public /things-of-the-day endpoint which filters via v_things_info.',
+		'Thing status (1=Preparing, 2=Published, 3=Editing, 4=Withdrawn). The CMS calendar mirrors the public /things-of-the-day endpoint: only Published (2) and Editing (3) things are returned.',
 	),
 	categoryId: z.number().int(),
 	sections: z.array(cmsThingsOfTheDayCalendarSection).describe(
-		'Section placements (id = section.identifier, position = thing_position_in_section). Empty if the thing is not yet placed in any non-deprecated section. The CMS view skips deprecated sections (section_type_id = 0) but shows placements in all section statuses, including Preparing/Withdrawn.',
+		'Section placements (id = section.identifier, position = thing_position_in_section). Only non-deprecated, Published-or-Editing section placements appear here — same filter as the public endpoint. A thing with no such placement is excluded from the response entirely.',
 	),
 });
 
@@ -236,7 +236,7 @@ export const cmsThingsOfTheDayCalendarResponse = z.record(
 	z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 	z.array(cmsThingsOfTheDayCalendarEntry),
 ).describe(
-	'Rolling 365–366 day window keyed by YYYY-MM-DD, from today through the same date one year minus one day later (e.g. 2026-05-06 → 2027-05-05). Each day has at least one entry: curated rows from things whose finish_date matches that day (full date or month-end for YYYY-MM-00), or a single fallback row deterministically picked from the eligible pool when the curated bucket is empty.',
+	'Rolling 365–366 day window keyed by YYYY-MM-DD, from today through the same date one year minus one day later (e.g. 2026-05-06 → 2027-05-05). Each day has at least one entry: curated rows from things whose finish_date matches that day (full date or month-end for YYYY-MM-00), or a single fallback row deterministically picked from the eligible pool when the curated bucket is empty. Eligibility mirrors the public /things-of-the-day rule (Published/Editing things with at least one non-deprecated, Published/Editing section placement).',
 );
 
 // --- Inferred types ---

--- a/src/plugins/thingsOfTheDay/queries.ts
+++ b/src/plugins/thingsOfTheDay/queries.ts
@@ -6,6 +6,9 @@ const extendedThingFields = `
 	thing_position_in_section AS position
 `;
 
+// Curated ordering: most recent finish_date first, with thing_id as a
+// deterministic tiebreaker. The CMS calendar (#134) uses the same ordering
+// so the homepage carousel and the editor preview agree row-for-row.
 export const thingsForDateQuery = `
 	SELECT ${extendedThingFields}
 	FROM v_things_info
@@ -15,7 +18,7 @@ export const thingsForDateQuery = `
 		     OR (SUBSTRING(thing_finish_date, 6, 2) = DATE_FORMAT(CURDATE(), '%m') AND SUBSTRING(thing_finish_date, 9) = '00'
 		         AND CURDATE() = LAST_DAY(CURDATE())))
 	-- OR SUBSTRING(thing_finish_date, 6) = '00-00' (YYYY-00-00 means date unknown — excluded until a dedicated flag exists in v_things_info)
-	ORDER BY thing_finish_date DESC;
+	ORDER BY thing_finish_date DESC, thing_id;
 `;
 
 export const thingsForDateWithUserVoteQuery = `
@@ -27,7 +30,7 @@ export const thingsForDateWithUserVoteQuery = `
 		AND (SUBSTRING(thing_finish_date, 6) = DATE_FORMAT(CURDATE(), '%m-%d')
 		     OR (SUBSTRING(thing_finish_date, 6, 2) = DATE_FORMAT(CURDATE(), '%m') AND SUBSTRING(thing_finish_date, 9) = '00'
 		         AND CURDATE() = LAST_DAY(CURDATE())))
-	ORDER BY thing_finish_date DESC;
+	ORDER BY thing_finish_date DESC, thing_id;
 `;
 
 export const thingsOfTheDayFallbackQuery = `


### PR DESCRIPTION
## Summary

Closes #134. Two bugs in \`/cms/things-of-the-day/calendar\` shipped in #131. Both live in the same SQL handler, so one diff fixes both.

### Fix 1 — filtering aligned with the public \`/things-of-the-day\` rule

- Curated CTE and fallback LATERAL now require \`r_thing_status_id IN (2, 3)\` (Published or Editing) AND \`EXISTS\` a placement in a non-deprecated, Published-or-Editing section.
- Outer section join also filters \`s.r_section_status_id IN (2, 3)\` so chip rows only show placements that the public site would render.
- Things with no qualifying placement disappear entirely (previously surfaced once with \`sections: []\`).

This is what the calendar's stated purpose requires: a faithful preview of which thing-of-the-day will appear publicly each day.

### Fix 2 — \`CAST(finish_date AS CHAR)\`

mysql2 returns raw \`DATE\` columns as JS \`Date\` objects in CTE / \`LATERAL\` contexts. The response Zod schema validates \`finishDate\` as a string, so the endpoint was 500-ing on any payload that included a \`Date\`:

\`\`\`json
{ "expected": "string", "code": "invalid_type",
  "path": ["2027-02-12", 3, "finishDate"],
  "message": "Invalid input: expected string, received Date" }
\`\`\`

Casting at the SQL boundary matches the existing \`thingFields\` pattern in \`src/lib/queries.ts\` (\`cast(thing_finish_date AS char) AS finishDate\`).

### Schema docs

Descriptions on \`statusId\` / \`sections\` / response now reflect the new (filtered) behaviour. The previous wording explicitly advertised "shows ALL statuses" — wrong for the consumer's purpose.

### Test changes

The unit test mock had a \`statusId: 1\` (Preparing) row whose continued presence is the test's "two entries on the same day" assertion. Bumped to \`statusId: 3\` (Editing) — still surfaces under the new filter, scenario intact. No new tests added: existing tests pass at the JS aggregation layer; the SQL changes can only be verified end-to-end (smoke test post-deploy).

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 261/261 passing
- [ ] Smoke: hit \`GET /cms/things-of-the-day/calendar\` with an editor JWT against a real DB; expect HTTP 200 with no Preparing/Withdrawn things and no chips for deprecated/Preparing/Withdrawn sections.

## Deploy gate

[poetry-nextjs#111](https://github.com/mellonis/poetry-nextjs/issues/111) is the consuming UI and is blocked-on this PR. Merge order: this first, then the nextjs PR.