### PR TITLE
feat: /health + /setup endpoints for first-run wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,4 @@ SITE_AUTHOR_USER_ID=1
 MEILI_URL=http://poetry-meilisearch:7700
 MEILI_MASTER_KEY=
 LOG_HMAC_KEY_CURRENT=dev-placeholder-do-not-use-in-prod-this-is-only-for-local-tests
+INITIAL_ADMIN_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ MEILI_URL=http://poetry-meilisearch:7700  # optional, Meilisearch host (default:
 MEILI_MASTER_KEY=<key>               # optional (required for search to work), shared with Meilisearch container
 LOG_HMAC_KEY_CURRENT=<32-byte hex>      # required, HMAC key for actorFingerprint() log helper. In prod, written by the VPS rotation script (see mellonis/poetry docs/superpowers/specs/2026-05-05-privacy-safe-logging-design.md). In dev, any non-empty string works.
 LOG_HMAC_KEY_PREVIOUS=<32-byte hex>     # optional, prior HMAC key during rotation overlap; not read by emitters but kept in env for log analysts.
+INITIAL_ADMIN_PASSWORD=<gate-secret>    # optional, gates POST /setup/admin for the first-run wizard. When set + no active admins exist, the wizard frontends collect this secret from the operator (separate from the chosen admin password) and forward it as a one-shot authorization. Unset in normal operation; set on first deploy and unset after the initial admin is created. See `docs/superpowers/specs/2026-05-11-first-run-setup-design.md`.
 ```
 
 See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port overridable via `PORT` env var). `CONNECTION_STRING`, `JWT_SECRET`, and `ALLOWED_ORIGINS` are validated on startup. SMTP vars are required only in production (`NODE_ENV=production`); in dev mode, notifications are logged to the console instead. If `MEILI_MASTER_KEY` is not set, search is disabled (sync calls become no-ops, `GET /search` returns 503).
@@ -60,6 +61,8 @@ See `.env.example` for a template. The server listens on `0.0.0.0:3000` (port ov
 Fastify app using a plugin-based structure under `src/plugins/`:
 
 - **`database/`** — registers the MySQL connection pool on the Fastify instance via `@fastify/mysql`
+- **`health/`** — `GET /health` (public, no auth, no rate-limit). Always returns 200 with `{status: 'ok', db: 'ok' | 'error'}`. Probes the DB with `SELECT 1`; `db: 'error'` signals api-alive-but-db-broken. Consumed by the first-run wizard's Page-1 status check and by external monitoring
+- **`setup/`** — first-run setup endpoints (public, rate-limited). `GET /setup/status` returns `{schema: {db_reachable, auth_user_table, display_name_col}, has_active_admins, setup_secret_configured, needs_setup}`. `POST /setup/admin` (body `{secret, email, password}`) is gated by `INITIAL_ADMIN_PASSWORD` env, one-shot (refuses when an active admin exists), and on success INSERTs the root admin row (`id=1, login='admin', r_group_id=1, rights=1`) using `bcryptjs`. Plugin-scoped `setErrorHandler` reformats Zod validation errors to `{error: 'validation', issues: [...]}`. Response codes: 201 / 400 / 401 / 409 / 500 / 503. See `docs/superpowers/specs/2026-05-11-first-run-setup-design.md`. `has_active_admins` excludes banned users via JOIN on `auth_group` checking `(u.rights & 4) = 0 AND (g.rights & 4) = 0`
 - **`auth/`** — `auth.ts` is a `fastify-plugin` decorator (`verifyJwt`, `optionalVerifyJwt`, `requireRight`) visible to all plugins
   - `authRoutes.ts` — routes prefixed `/auth` (register, activate, login, refresh, logout, password reset). Sends `ADMIN_NOTIFY_EMAIL` on new registration
   - Pure utilities: `password.ts`, `jwt.ts`, `rights.ts`, `issueTokens.ts`

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { cmsPlugin } from './plugins/cms/cms.js';
 import { commentsPlugin } from './plugins/comments/comments.js';
 import searchPlugin from './plugins/search/search.js';
 import { searchRoutes } from './plugins/search/searchRoutes.js';
+import { healthPlugin } from './plugins/health/health.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -85,6 +86,7 @@ fastify.register(rateLimit, {
 	},
 });
 fastify.register(databasePlugin);
+fastify.register(healthPlugin);
 fastify.register(searchPlugin);
 fastify.register(authPlugin);
 fastify.register(authNotifierPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { commentsPlugin } from './plugins/comments/comments.js';
 import searchPlugin from './plugins/search/search.js';
 import { searchRoutes } from './plugins/search/searchRoutes.js';
 import { healthPlugin } from './plugins/health/health.js';
+import { setupPlugin } from './plugins/setup/setup.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
 
@@ -87,6 +88,7 @@ fastify.register(rateLimit, {
 });
 fastify.register(databasePlugin);
 fastify.register(healthPlugin);
+fastify.register(setupPlugin);
 fastify.register(searchPlugin);
 fastify.register(authPlugin);
 fastify.register(authNotifierPlugin);

--- a/src/plugins/health/health.test.ts
+++ b/src/plugins/health/health.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { healthPlugin } from './health.js';
+
+function mockMysql(queryImpl: () => Promise<unknown>): MySQLPromisePool {
+  return {
+    getConnection: vi.fn().mockImplementation(() => Promise.resolve({
+      query: queryImpl,
+      release: vi.fn(),
+    })),
+  } as unknown as MySQLPromisePool;
+}
+
+function buildApp(mysql: MySQLPromisePool) {
+  const app = Fastify({ logger: false });
+  app.decorate('mysql', mysql);
+  app.register(healthPlugin);
+  return app;
+}
+
+describe('GET /health', () => {
+  it('returns 200 with db=ok when SELECT 1 succeeds', async () => {
+    const mysql = mockMysql(() => Promise.resolve([[{ '1': 1 }], []]));
+    const app = buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/health' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: 'ok', db: 'ok' });
+
+    await app.close();
+  });
+
+  it('returns 200 with db=error when SELECT 1 throws', async () => {
+    const mysql = mockMysql(() => Promise.reject(new Error('db unreachable')));
+    const app = buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/health' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: 'ok', db: 'error' });
+
+    await app.close();
+  });
+});

--- a/src/plugins/health/health.ts
+++ b/src/plugins/health/health.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from 'fastify';
+
+export async function healthPlugin(fastify: FastifyInstance) {
+  fastify.get(
+    '/health',
+    { config: { rateLimit: false } },
+    async (request, reply) => {
+      let db: 'ok' | 'error' = 'ok';
+      try {
+        const conn = await fastify.mysql.getConnection();
+        try {
+          await conn.query('SELECT 1');
+        } finally {
+          conn.release();
+        }
+      } catch (err) {
+        db = 'error';
+        request.log.warn({ err }, 'health: db probe failed');
+      }
+      return reply.code(200).send({ status: 'ok', db });
+    }
+  );
+}

--- a/src/plugins/setup/queries.ts
+++ b/src/plugins/setup/queries.ts
@@ -1,0 +1,73 @@
+import type { MySQLPromisePool } from '@fastify/mysql';
+import type { RowDataPacket } from 'mysql2';
+import { withConnection } from '../../lib/databaseHelpers.js';
+
+export type SchemaProbe = {
+  db_reachable: boolean;
+  auth_user_table: boolean;
+  display_name_col: boolean;
+};
+
+export async function probeSchema(mysql: MySQLPromisePool): Promise<SchemaProbe> {
+  const result: SchemaProbe = {
+    db_reachable: false,
+    auth_user_table: false,
+    display_name_col: false,
+  };
+
+  let conn;
+  try {
+    conn = await mysql.getConnection();
+    result.db_reachable = true;
+  } catch {
+    return result;
+  }
+
+  try {
+    await conn.query('SELECT 1 FROM auth_user LIMIT 1');
+    result.auth_user_table = true;
+  } catch {
+    // 42S02 = table missing. Other errors leave auth_user_table false.
+  }
+
+  if (result.auth_user_table) {
+    try {
+      await conn.query('SELECT display_name FROM auth_user LIMIT 0');
+      result.display_name_col = true;
+    } catch {
+      // 42S22 = column missing
+    }
+  }
+
+  conn.release();
+  return result;
+}
+
+export async function hasActiveAdmins(mysql: MySQLPromisePool): Promise<boolean> {
+  return withConnection(mysql, async (conn) => {
+    const [rows] = await conn.query<RowDataPacket[]>(
+      `SELECT EXISTS (
+         SELECT 1 FROM auth_user u
+         JOIN auth_group g ON u.r_group_id = g.id
+         WHERE u.r_group_id = 1
+           AND (u.rights & 4) = 0
+           AND (g.rights & 4) = 0
+       ) AS has_active_admins`
+    );
+    return Boolean(rows[0]?.has_active_admins);
+  });
+}
+
+export async function insertInitialAdmin(
+  mysql: MySQLPromisePool,
+  email: string,
+  passwordHash: string
+): Promise<void> {
+  return withConnection(mysql, async (conn) => {
+    await conn.query(
+      `INSERT INTO auth_user (id, login, password_hash, email, rights, r_group_id)
+       VALUES (1, 'admin', ?, ?, 1, 1)`,
+      [passwordHash, email]
+    );
+  });
+}

--- a/src/plugins/setup/schemas.ts
+++ b/src/plugins/setup/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const setupStatusResponseSchema = z.object({
+  schema: z.object({
+    db_reachable: z.boolean(),
+    auth_user_table: z.boolean(),
+    display_name_col: z.boolean(),
+  }),
+  has_active_admins: z.boolean(),
+  setup_secret_configured: z.boolean(),
+  needs_setup: z.boolean(),
+});
+
+export const setupAdminBodySchema = z.object({
+  secret: z.string().min(1),
+  email: z.string().email().max(50),
+  password: z.string().min(6),
+});
+
+export type SetupAdminBody = z.infer<typeof setupAdminBodySchema>;
+
+export const setupAdminSuccessSchema = z.object({
+  id: z.literal(1),
+});
+
+export const setupAdminErrorSchema = z.object({
+  error: z.enum([
+    'wrong_secret',
+    'already_initialized',
+    'setup_disabled',
+    'insert_failed',
+    'validation',
+  ]),
+  issues: z.array(z.unknown()).optional(),
+});

--- a/src/plugins/setup/setup.test.ts
+++ b/src/plugins/setup/setup.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import rateLimit from '@fastify/rate-limit';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { setupPlugin } from './setup.js';
+
+type QueryImpl = (sql: string, params?: unknown[]) => Promise<unknown>;
+
+function mockMysql(queryImpl: QueryImpl): MySQLPromisePool {
+  return {
+    getConnection: vi.fn().mockImplementation(() => Promise.resolve({
+      query: vi.fn().mockImplementation(queryImpl),
+      release: vi.fn(),
+    })),
+  } as unknown as MySQLPromisePool;
+}
+
+function unreachableMysql(): MySQLPromisePool {
+  return {
+    getConnection: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')),
+  } as unknown as MySQLPromisePool;
+}
+
+async function buildApp(mysql: MySQLPromisePool) {
+  const app = Fastify({ logger: false });
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.decorate('mysql', mysql);
+  await app.register(rateLimit, { global: false });
+  await app.register(setupPlugin);
+  return app;
+}
+
+describe('GET /setup/status', () => {
+  beforeEach(() => { delete process.env.INITIAL_ADMIN_PASSWORD; });
+  afterEach(() => { delete process.env.INITIAL_ADMIN_PASSWORD; });
+
+  it('fresh DB, no admins, secret unset → needs_setup:true', async () => {
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('FROM auth_user LIMIT 1')) return [[{}], []];
+      if (sql.includes('SELECT display_name')) return [[], []];
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 0 }], []];
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/setup/status' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      schema: { db_reachable: true, auth_user_table: true, display_name_col: true },
+      has_active_admins: false,
+      setup_secret_configured: false,
+      needs_setup: true,
+    });
+    await app.close();
+  });
+
+  it('active admin exists → has_active_admins:true, needs_setup:false', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('FROM auth_user LIMIT 1')) return [[{}], []];
+      if (sql.includes('SELECT display_name')) return [[], []];
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 1 }], []];
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/setup/status' });
+
+    expect(res.json()).toMatchObject({
+      has_active_admins: true,
+      setup_secret_configured: true,
+      needs_setup: false,
+    });
+    await app.close();
+  });
+
+  it('schema missing (42S02 on auth_user) → schema flags false, needs_setup:true', async () => {
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('FROM auth_user LIMIT 1')) {
+        const err: NodeJS.ErrnoException & { code: string } = Object.assign(
+          new Error("Table 'poetry.auth_user' doesn't exist"),
+          { code: 'ER_NO_SUCH_TABLE' }
+        );
+        throw err;
+      }
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/setup/status' });
+
+    expect(res.json()).toMatchObject({
+      schema: { db_reachable: true, auth_user_table: false, display_name_col: false },
+      has_active_admins: false,
+      needs_setup: true,
+    });
+    await app.close();
+  });
+
+  it('schema partial: auth_user exists but display_name column missing → display_name_col:false', async () => {
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('FROM auth_user LIMIT 1')) return [[{}], []];
+      if (sql.includes('SELECT display_name')) {
+        const err = Object.assign(
+          new Error("Unknown column 'display_name'"),
+          { code: 'ER_BAD_FIELD_ERROR' }
+        );
+        throw err;
+      }
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 0 }], []];
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/setup/status' });
+
+    expect(res.json()).toMatchObject({
+      schema: { db_reachable: true, auth_user_table: true, display_name_col: false },
+      has_active_admins: false,
+      needs_setup: true,
+    });
+    await app.close();
+  });
+
+  it('db unreachable → db_reachable:false', async () => {
+    const mysql = unreachableMysql();
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'GET', url: '/setup/status' });
+
+    expect(res.json()).toMatchObject({
+      schema: { db_reachable: false, auth_user_table: false, display_name_col: false },
+      needs_setup: true,
+    });
+    await app.close();
+  });
+});
+
+describe('POST /setup/admin', () => {
+  beforeEach(() => { delete process.env.INITIAL_ADMIN_PASSWORD; });
+  afterEach(() => { delete process.env.INITIAL_ADMIN_PASSWORD; });
+
+  const validBody = { secret: 'test-secret', email: 'a@b.test', password: 'pass1234' };
+
+  it('returns 503 when INITIAL_ADMIN_PASSWORD is not set', async () => {
+    const mysql = mockMysql(async () => [[], []]);
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'POST', url: '/setup/admin', payload: validBody });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({ error: 'setup_disabled' });
+    await app.close();
+  });
+
+  it('returns 409 when active admin already exists', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 1 }], []];
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'POST', url: '/setup/admin', payload: validBody });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: 'already_initialized' });
+    await app.close();
+  });
+
+  it('returns 401 on secret mismatch', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'real-secret';
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 0 }], []];
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/setup/admin',
+      payload: { ...validBody, secret: 'wrong' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({ error: 'wrong_secret' });
+    await app.close();
+  });
+
+  it('returns 400 on bad email format', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async () => [[], []]);
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/setup/admin',
+      payload: { ...validBody, email: 'not-an-email' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'validation' });
+    expect(res.json().issues).toBeInstanceOf(Array);
+    await app.close();
+  });
+
+  it('returns 400 on short password (< 6)', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async () => [[], []]);
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/setup/admin',
+      payload: { ...validBody, password: '12345' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'validation' });
+    expect(res.json().issues).toBeInstanceOf(Array);
+    await app.close();
+  });
+
+  it('returns 400 on missing secret', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async () => [[], []]);
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/setup/admin',
+      payload: { email: 'a@b.test', password: 'pass1234' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'validation' });
+    expect(res.json().issues).toBeInstanceOf(Array);
+    await app.close();
+  });
+
+  it('returns 201 + creates row on valid request', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    let insertCalled = false;
+    let insertEmail = '';
+    let insertHash = '';
+    const mysql = mockMysql(async (sql, params) => {
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 0 }], []];
+      if (sql.includes('INSERT INTO auth_user')) {
+        insertCalled = true;
+        insertHash = (params as unknown[])[0] as string;
+        insertEmail = (params as unknown[])[1] as string;
+        return [{ affectedRows: 1 }, []];
+      }
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'POST', url: '/setup/admin', payload: validBody });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ id: 1 });
+    expect(insertCalled).toBe(true);
+    expect(insertEmail).toBe('a@b.test');
+    expect(insertHash).toMatch(/^\$2[ab]\$10\$/);
+    await app.close();
+  });
+
+  it('returns 500 if INSERT throws', async () => {
+    process.env.INITIAL_ADMIN_PASSWORD = 'test-secret';
+    const mysql = mockMysql(async (sql) => {
+      if (sql.includes('SELECT EXISTS')) return [[{ has_active_admins: 0 }], []];
+      if (sql.includes('INSERT INTO auth_user')) throw new Error('integrity violation');
+      throw new Error(`unmocked: ${sql}`);
+    });
+    const app = await buildApp(mysql);
+
+    const res = await app.inject({ method: 'POST', url: '/setup/admin', payload: validBody });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'insert_failed' });
+    await app.close();
+  });
+});

--- a/src/plugins/setup/setup.ts
+++ b/src/plugins/setup/setup.ts
@@ -1,0 +1,97 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import bcrypt from 'bcryptjs';
+import { hasZodFastifySchemaValidationErrors } from 'fastify-type-provider-zod';
+import { maskEmail } from '../../lib/maskEmail.js';
+import {
+  setupStatusResponseSchema,
+  setupAdminBodySchema,
+  setupAdminSuccessSchema,
+  setupAdminErrorSchema,
+  type SetupAdminBody,
+} from './schemas.js';
+import {
+  probeSchema,
+  hasActiveAdmins,
+  insertInitialAdmin,
+} from './queries.js';
+
+const BCRYPT_COST = 10;
+
+export async function setupPlugin(fastify: FastifyInstance) {
+  fastify.setErrorHandler((err, _request, reply) => {
+    if (hasZodFastifySchemaValidationErrors(err)) {
+      return reply.code(400).send({ error: 'validation' as const, issues: err.validation });
+    }
+    return reply.send(err);
+  });
+
+  fastify.get(
+    '/setup/status',
+    {
+      config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+      schema: { response: { 200: setupStatusResponseSchema } },
+    },
+    async () => {
+      const schema = await probeSchema(fastify.mysql);
+      const hasAdmins = schema.auth_user_table
+        ? await hasActiveAdmins(fastify.mysql)
+        : false;
+      const secretConfigured = Boolean(process.env.INITIAL_ADMIN_PASSWORD);
+      const needsSetup = !schema.auth_user_table || !hasAdmins;
+
+      return {
+        schema,
+        has_active_admins: hasAdmins,
+        setup_secret_configured: secretConfigured,
+        needs_setup: needsSetup,
+      };
+    }
+  );
+
+  fastify.post(
+    '/setup/admin',
+    {
+      config: { rateLimit: { max: 5, timeWindow: '1 minute' } },
+      schema: {
+        body: setupAdminBodySchema,
+        response: {
+          201: setupAdminSuccessSchema,
+          400: setupAdminErrorSchema,
+          401: setupAdminErrorSchema,
+          409: setupAdminErrorSchema,
+          500: setupAdminErrorSchema,
+          503: setupAdminErrorSchema,
+        },
+      },
+    },
+    async (request: FastifyRequest<{ Body: SetupAdminBody }>, reply) => {
+      const expected = process.env.INITIAL_ADMIN_PASSWORD;
+      if (!expected) {
+        return reply.code(503).send({ error: 'setup_disabled' as const });
+      }
+
+      if (await hasActiveAdmins(fastify.mysql)) {
+        return reply.code(409).send({ error: 'already_initialized' as const });
+      }
+
+      if (request.body.secret !== expected) {
+        request.log.warn('setup: secret mismatch');
+        return reply.code(401).send({ error: 'wrong_secret' as const });
+      }
+
+      const passwordHash = await bcrypt.hash(request.body.password, BCRYPT_COST);
+      try {
+        await insertInitialAdmin(fastify.mysql, request.body.email, passwordHash);
+      } catch (err) {
+        request.log.error({ err }, 'setup: insert failed');
+        return reply.code(500).send({ error: 'insert_failed' as const });
+      }
+
+      request.log.info(
+        { email: maskEmail(request.body.email) },
+        'setup: initial admin created'
+      );
+      return reply.code(201).send({ id: 1 as const });
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds three new public endpoints to poetry-api in support of the
first-run setup wizard (spec: `docs/superpowers/specs/2026-05-11-first-run-setup-design.md`):

- `GET /health` — liveness + db probe (always 200; `db: ok|error`)
- `GET /setup/status` — schema probe, `has_active_admins` bool, `setup_secret_configured` bool, `needs_setup` bool
- `POST /setup/admin` — `INITIAL_ADMIN_PASSWORD`-gated, one-shot, creates `auth_user` row `id=1` with `r_group_id=1`, `rights=1` (R_EMAIL_ACTIVATED)

PR 1 of 3 in the first-run wizard rollout. Must merge before `poetry-old2#feat/first-run-setup` and `poetry-nextjs#feat/first-run-setup`.

## Implementation notes

- Uses `bcryptjs` (consistent with `src/plugins/auth/password.ts`).
- Plugin-scoped `setErrorHandler` reformats Zod validation errors to `{ error: 'validation', issues: [...] }` per spec.
- `probeSchema` uses two probes: `SELECT 1 FROM auth_user LIMIT 1` (catches `42S02` table-missing) and `SELECT display_name FROM auth_user LIMIT 0` (catches `42S22` column-missing) — covers partially-migrated state.
- `has_active_admins` SQL excludes banned admins via JOIN on `auth_group` checking `(u.rights & 4) = 0 AND (g.rights & 4) = 0`.

## Test plan

- [x] 12 new tests (1 health + 11 setup) covering every spec'd response code
- [x] Full suite 276 tests pass; TypeScript clean; lint clean
- [ ] Manual smoke against DDEV per plan Task 9 — depends on operator unstashing DDEV setup + setting `INITIAL_ADMIN_PASSWORD` in api's env
- [x] Privacy-safe logging: success uses `maskEmail()`; secret mismatch logs no identity; INSERT failure logs `{err}` only

## Follow-up (post-merge, not blocking)

- `probeSchema` could be refactored to use `withConnection` for codebase consistency (currently uses manual acquire/release because the "connect failed → return partial result" semantics don't fit the helper cleanly).
- `rate_limited` enum entry was dropped from `setupAdminErrorSchema` because the global `@fastify/rate-limit` `errorResponseBuilder` produces a different shape; could add per-route `errorResponseBuilder` to match the schema if needed.