### PR TITLE
fix(search): keep api alive when meilisearch is unreachable at boot

### DIFF
--- a/src/plugins/search/search.test.ts
+++ b/src/plugins/search/search.test.ts
@@ -1,0 +1,91 @@
+import { vi, beforeEach, afterEach, describe, expect, it } from 'vitest';
+import Fastify from 'fastify';
+
+const { mockMeilisearchCtor } = vi.hoisted(() => ({
+	mockMeilisearchCtor: vi.fn(),
+}));
+
+vi.mock('meilisearch', () => ({
+	Meilisearch: mockMeilisearchCtor,
+}));
+
+vi.mock('./searchSync.js', () => ({
+	reindexAll: vi.fn().mockResolvedValue(0),
+}));
+
+// Static import is safe: vi.mock above is hoisted, so the plugin module
+// resolves `Meilisearch` to the spy at parse time.
+import searchPlugin from './search.js';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('search plugin', () => {
+	it('boots with meiliClient = null when meilisearch is unreachable', async () => {
+		vi.stubEnv('MEILI_MASTER_KEY', 'test-key');
+		mockMeilisearchCtor.mockImplementation(function () {
+			return {
+				createIndex: vi.fn().mockResolvedValue({}),
+				index: () => ({
+					updateSettings: vi.fn().mockRejectedValue(new Error('ENOTFOUND poetry-meilisearch')),
+					getDocument: vi.fn().mockResolvedValue({ version: 5 }),
+					addDocuments: vi.fn().mockResolvedValue({}),
+				}),
+			};
+		});
+
+		const app = Fastify({ logger: false });
+		await app.register(searchPlugin);
+		await app.ready();
+
+		expect(app.meiliClient).toBeNull();
+
+		await app.close();
+	});
+
+	it('boots with meiliClient = null when MEILI_MASTER_KEY is unset', async () => {
+		// Stub to empty string — falsy, hits the !masterKey branch.
+		// More robust than relying on the env var being absent in the controller's shell.
+		vi.stubEnv('MEILI_MASTER_KEY', '');
+
+		const app = Fastify({ logger: false });
+		await app.register(searchPlugin);
+		await app.ready();
+
+		expect(app.meiliClient).toBeNull();
+		expect(mockMeilisearchCtor).not.toHaveBeenCalled();
+
+		await app.close();
+	});
+
+	it('boots with a real meiliClient when meilisearch is reachable', async () => {
+		vi.stubEnv('MEILI_MASTER_KEY', 'test-key');
+		mockMeilisearchCtor.mockImplementation(function () {
+			return {
+				createIndex: vi.fn().mockResolvedValue({}),
+				index: () => ({
+					updateSettings: vi.fn().mockResolvedValue({}),
+					getDocument: vi.fn().mockResolvedValue({ version: 5 }),
+					addDocuments: vi.fn().mockResolvedValue({}),
+				}),
+			};
+		});
+
+		const app = Fastify({ logger: false });
+		await app.register(searchPlugin);
+		await app.ready();
+
+		expect(app.meiliClient).not.toBeNull();
+		expect(mockMeilisearchCtor).toHaveBeenCalledWith({
+			host: 'http://poetry-meilisearch:7700',
+			apiKey: 'test-key',
+		});
+
+		await app.close();
+	});
+});

--- a/src/plugins/search/search.ts
+++ b/src/plugins/search/search.ts
@@ -24,34 +24,40 @@ export default fp(async (fastify: FastifyInstance) => {
 	}
 
 	const url = process.env.MEILI_URL ?? 'http://poetry-meilisearch:7700';
-	const client = new Meilisearch({ host: url, apiKey: masterKey });
+	let client: Meilisearch | null = null;
 
-	await client.createIndex(INDEX_NAME, { primaryKey: 'id' }).catch(() => {});
+	try {
+		const c = new Meilisearch({ host: url, apiKey: masterKey });
+		await c.createIndex(INDEX_NAME, { primaryKey: 'id' }).catch(() => {});
+		await c.index(INDEX_NAME).updateSettings({
+			searchableAttributes: ['title', 'text', 'notes', 'audioTitles'],
+			filterableAttributes: ['categoryId', 'statusId'],
+			typoTolerance: {
+				minWordSizeForTypos: { oneTypo: 5, twoTypos: 9 },
+			},
+			rankingRules: ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
+		});
 
-	const index = client.index(INDEX_NAME);
-	await index.updateSettings({
-		searchableAttributes: ['title', 'text', 'notes', 'audioTitles'],
-		filterableAttributes: ['categoryId', 'statusId'],
-		typoTolerance: {
-			minWordSizeForTypos: { oneTypo: 5, twoTypos: 9 },
-		},
-		rankingRules: ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
-	});
+		await c.createIndex('_meta', { primaryKey: 'key' }).catch(() => {});
+		const metaIndex = c.index('_meta');
+		const currentVersion = await metaIndex.getDocument('index_version').then((d) => (d as { version?: number }).version).catch(() => null);
+
+		if (currentVersion !== INDEX_VERSION) {
+			fastify.log.info({ currentVersion, targetVersion: INDEX_VERSION }, 'Search index version changed — reindexing');
+			reindexAll(c, fastify.mysql, fastify.log)
+				.then(async (count) => {
+					await metaIndex.addDocuments([{ key: 'index_version', version: INDEX_VERSION }]);
+					fastify.log.info({ count, version: INDEX_VERSION }, 'Reindex complete');
+				})
+				.catch((err) => fastify.log.error(err, 'Reindex failed'));
+		}
+
+		client = c;
+		fastify.log.info({ url }, 'Meilisearch connected');
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		fastify.log.warn({ err: msg, url }, 'Meilisearch unreachable at boot — search disabled until next restart');
+	}
 
 	fastify.decorate('meiliClient', client);
-	fastify.log.info({ url }, 'Meilisearch connected');
-
-	await client.createIndex('_meta', { primaryKey: 'key' }).catch(() => {});
-	const metaIndex = client.index('_meta');
-	const currentVersion = await metaIndex.getDocument('index_version').then((d) => (d as { version?: number }).version).catch(() => null);
-
-	if (currentVersion !== INDEX_VERSION) {
-		fastify.log.info({ currentVersion, targetVersion: INDEX_VERSION }, 'Search index version changed — reindexing');
-		reindexAll(client, fastify.mysql, fastify.log)
-			.then(async (count) => {
-				await metaIndex.addDocuments([{ key: 'index_version', version: INDEX_VERSION }]);
-				fastify.log.info({ count, version: INDEX_VERSION }, 'Reindex complete');
-			})
-			.catch((err) => fastify.log.error(err, 'Reindex failed'));
-	}
 }, { name: 'search' });


### PR DESCRIPTION
## Summary
- Wrap boot-time meili calls in try/catch; decorate `fastify.meiliClient = null` on failure
- Decorate exactly once on every code path (fixes a latent `undefined`-vs-`null` issue on the connect-fail path)
- Adds `src/plugins/search/search.test.ts` with 3 cases: unreachable-at-boot, no master key, happy path

A meilisearch outage no longer brings down `/health`, auth, votes,
comments, bookmarks, things-of-the-day, or the CMS. `GET /search` returns
503 `{"error":"Search is not available"}` — same UX as the no-master-key
path today.

Spec: `mellonis/poetry docs/superpowers/specs/2026-05-18-meilisearch-boot-resilience-design.md`

Closes #142

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 283/283 passed
- [x] `npm run build`
- [x] Manual DDEV: stopped `poetry-meilisearch`, restarted `poetry-api`. `/health` → 200, `/search` → 503 `{"error":"Search is not available"}`. Warn log emitted as `{err: "Request to http://poetry-meilisearch:7700/indexes/things/settings has failed", url: "http://poetry-meilisearch:7700"}` — no stack. After restoring meili + restart: `/search` → 200, info log `Meilisearch connected`.