### PR TITLE
feat: in-app notifications — Phase 1 (#117)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Fastify app using a plugin-based structure under `src/plugins/`:
 - **`swagger/`** — mounts OpenAPI docs at `/docs` via `@fastify/swagger` + `@fastify/swagger-ui`
 - **`sections/`** — routes prefixed `/sections`
 - **`thingsOfTheDay/`** — routes prefixed `/things-of-the-day`
-- **`users/`** — routes prefixed `/users` (change password, delete account, get/update notification settings). Sends `ADMIN_NOTIFY_EMAIL` on account deletion. `GET/PUT /:userId/notification-settings` — self-only (403 otherwise); returns/updates `{ notifyAuthorOnCommentReply, notifyAuthorOnCommentVote }` booleans
+- **`users/`** — routes prefixed `/users` (change password, delete account, get/update notification settings). Sends `ADMIN_NOTIFY_EMAIL` on account deletion. `GET/PUT /:userId/notification-settings` — self-only (403 otherwise); returns/updates `{ notifyAuthorOnCommentReply, notifyAuthorOnCommentVote }` booleans. `GET/PUT /:userId/notification-settings` is **deprecated**: each call logs `'Deprecated endpoint hit'`. Use `/notifications/settings` instead.
 - **`votes/`** — routes prefixed `/things` for voting
   - `PUT /:thingId/vote` — `verifyJwt` + `canVote`. Body `{ vote: 'like' | 'dislike' | null }` — `null` removes the vote. Returns the updated `{ likes, dislikes, userVote }` summary (same shape as the batch GET and comment-vote endpoints). Sends `ADMIN_NOTIFY_EMAIL` on every vote action including removal (fire-and-forget, includes thing title).
   - `GET /votes?thingIds=…` or `?sectionId=…` — `optionalVerifyJwt`. Batch summaries keyed by thingId-as-string: `{ "1": { likes, dislikes, userVote }, ... }`. Anonymous → `userVote: null`. Schema enforces *exactly one* of `thingIds` (1..100 unique positive int ids, comma-separated) or `sectionId` (`section.identifier`, max 64 chars, `[A-Za-z0-9_-]`). `thingIds` mode pre-fills zero summaries for ids with no vote rows so callers get a stable shape. `sectionId` mode joins `v_things_info` to cover every thing in the section (zero-filled for unvoted) and avoids client-side chunking on big `/sections/[id]/all` pages. Vote totals are global (a thing's votes don't change by section).
@@ -94,6 +94,12 @@ Fastify app using a plugin-based structure under `src/plugins/`:
   - Sanitization: `sanitizeCommentText.ts` (NFC normalize → CRLF→LF → strip control chars → collapse blank-line runs → trim → length 2–4000 → flood reject). Plain-text only; renderers must escape on output
   - Reply notification: deep-link URL points to the parent (top-level), since pagination is on top-level. Shape: `<origin>/sections/<sectionIdentifier>/<positionInSection>?thread=<parentId>` for thing comments, `<origin>/guestbook?thread=<parentId>` for guestbook (no trailing slash before `?` — nextjs convention). Single-thread mode is drift-proof — the link still works regardless of how many comments accumulate later. Frontend reads `?thread=…` and renders only that top-level + its replies via `GET /comments/:commentId`
   - Moderation routes live in `cms/commentsCmsRoutes.ts` (registered by `cmsPlugin`, gated by editor + `canEditContent`): `GET /cms/comments`, `POST /cms/comments/:commentId/{hide,delete,restore}`, `DELETE /cms/comments/:commentId` (hard delete). Hide/delete on a comment auto-resolves any open `comment_report` rows for it
+- **`notifications/`** — routes prefixed `/notifications`. All endpoints require `verifyJwt`; recipient is implicit (`r_user_id = request.user.sub`) so users only ever see and mutate their own inbox. Endpoints:
+  - `GET /summary` — `{ unreadCount: number }`, used by the FE polling badge.
+  - `GET /` — paginated list with `?cursor&limit&unreadOnly`. Cursor is a base64url `<updatedAtMs>_<id>` token (see `lib/cursor.ts`). Visibility-filtered: notifications referring to non-Visible (Hidden/Deleted) comments are omitted from both list and summary; restoring a comment makes its notifications reappear.
+  - `POST /:id/read`, `POST /read-all`, `DELETE /:id` — state mutations. 404 (not 403) if the id isn't the caller's, to avoid existence disclosure.
+  - `GET/PUT /settings` — canonical replacement for `/users/:userId/notification-settings`. Returns/updates `{ notifyAuthorOnCommentReply, notifyAuthorOnCommentVote }`.
+  - Issuance lives in `lib/notifications.ts` (called from `comments.ts` on reply/vote): writes the in-app row unconditionally, then sends email iff the per-event toggle is true. Vote events use a per-(comment, unread) bucket — successive votes increment `event_count` until the recipient marks the bucket read.
 - **`@fastify/rate-limit`** — registered globally with `global: false`; routes opt in via `config: { rateLimit: { max, timeWindow } }`. In-memory store (no Redis), keyed by IP (the rate-limit hook runs before `verifyJwt`)
 - **`search/`** — Meilisearch integration. `search.ts` is a `fastify-plugin` that decorates `fastify.meiliClient` (nullable — `null` when `MEILI_MASTER_KEY` is not set). `searchRoutes.ts` provides public `GET /search?q=&limit=&offset=` (always filters `statusId=2`). `searchSync.ts` has `syncThingToSearch` / `deleteThingFromSearch` / `reindexAll`. `textStripping.ts` strips BBCode tags and `{note}` markers for indexing. CMS thing mutations fire-and-forget sync to Meilisearch after DB write. **Index versioning:** `INDEX_VERSION` constant in `search.ts` tracks the indexing schema version. On startup, the plugin compares it against the version stored in a `_meta` Meilisearch index. If they differ, a full reindex runs automatically. Bump `INDEX_VERSION` when changing stripping logic, indexed fields, or document shape.
 - **`cms/`** — routes prefixed `/cms`. Two-layer auth: all routes require `verifyJwt` + editor role (`isEditor`); mutations require `canEditContent` right (bit 12). Shared hook in `hooks.ts`. Sub-plugins:
@@ -115,10 +121,12 @@ Each route plugin is split into: `*.ts` (handler), `schemas.ts`, `queries.ts`, `
 Shared utilities in `src/lib/`:
 - `schemas.ts` — Zod schemas (shared `thingSchema`, `errorResponse`)
 - `queries.ts` — SQL fragments (thing fields, user vote field)
+- `cursor.ts` — keyset-pagination cursor codec (`encodeCursor`/`decodeCursor`). Used by `/notifications` list.
 - `mappers.ts` — row mappers (`mapThingBaseRow`, `splitLines`, `parseJSON`, `thingDisplayTitle`)
 - `isoDate.ts` — date format conversion at the wire boundary (`dbDateToIso`, `isoDateToDb`, `isValidIsoDate`)
 - `databaseHelpers.ts` — `withConnection` (pool acquire/release)
 - `email.ts` — SMTP transport via nodemailer
+- `notifications.ts` — `notifyCommentReply` / `notifyCommentVote` fire-and-forget orchestrators; in-app row insert + gated email send. Vote bucket upsert with `SELECT … FOR UPDATE` inside a transaction.
 - `emailTemplates.ts` — email templates:
 
   | Template | Recipient | Trigger |
@@ -135,6 +143,8 @@ Shared utilities in `src/lib/`:
   | `commentReportedEmail` | `ADMIN_NOTIFY_EMAIL` | user reported a comment |
   | `commentReplyEmail` | parent comment author | someone replied to their comment (skipped on self-reply, deleted author, banned) |
   | `commentVoteEmail` | comment author | someone liked/disliked their comment (skipped on self-vote, vote removal, deleted author, banned) |
+
+  The `commentReplyEmail` and `commentVoteEmail` recipients are gated by `auth_user.notify_author_on_comment_reply` / `notify_author_on_comment_vote`. As of in-app notifications (Phase 1), those toggles control **only the email** — the in-app feed row is always inserted (subject to the unchanged skip rules: self-action, banned recipient, deleted-author origin).
 - `maskEmail.ts` — masks emails for logging
 - `authNotifier/` — `AuthNotifier` interface, `EmailAuthNotifier` (production), `ConsoleAuthNotifier` (dev)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { bookmarksPlugin } from './plugins/bookmarks/bookmarks.js';
 import { authorPlugin } from './plugins/author/author.js';
 import { cmsPlugin } from './plugins/cms/cms.js';
 import { commentsPlugin } from './plugins/comments/comments.js';
+import { notificationsPlugin } from './plugins/notifications/notifications.js';
 import searchPlugin from './plugins/search/search.js';
 import { searchRoutes } from './plugins/search/searchRoutes.js';
 import { healthPlugin } from './plugins/health/health.js';
@@ -103,6 +104,7 @@ fastify.register(bookmarksPlugin, { prefix: '/bookmarks' });
 fastify.register(authorPlugin, { prefix: '/author' });
 fastify.register(cmsPlugin, { prefix: '/cms' });
 fastify.register(commentsPlugin, { prefix: '/comments' });
+fastify.register(notificationsPlugin, { prefix: '/notifications' });
 fastify.register(searchRoutes, { prefix: '/search' });
 
 async function main() {

--- a/src/lib/cursor.test.ts
+++ b/src/lib/cursor.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { encodeCursor, decodeCursor } from './cursor.js';
+
+describe('cursor codec', () => {
+	it('round-trips a (Date, id) pair', () => {
+		const d = new Date('2026-05-18T12:34:56.789Z');
+		const encoded = encodeCursor(d, 42);
+		const decoded = decodeCursor(encoded);
+		expect(decoded).toEqual({ updatedAtMs: d.getTime(), id: 42 });
+	});
+
+	it('produces a base64url-safe string (no +/= chars)', () => {
+		const encoded = encodeCursor(new Date(), 1);
+		expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+	});
+
+	it('returns null on a malformed input', () => {
+		expect(decodeCursor('not-a-valid-cursor!')).toBeNull();
+	});
+
+	it('returns null when the decoded payload is missing parts', () => {
+		// "abc" without the underscore separator
+		const broken = Buffer.from('abc', 'utf8').toString('base64url');
+		expect(decodeCursor(broken)).toBeNull();
+	});
+
+	it('returns null when the id portion is not a positive integer', () => {
+		const payload = '1234567890_abc';
+		const broken = Buffer.from(payload, 'utf8').toString('base64url');
+		expect(decodeCursor(broken)).toBeNull();
+	});
+
+	it('rejects negative timestamps', () => {
+		const payload = '-1_5';
+		const broken = Buffer.from(payload, 'utf8').toString('base64url');
+		expect(decodeCursor(broken)).toBeNull();
+	});
+});

--- a/src/lib/cursor.ts
+++ b/src/lib/cursor.ts
@@ -1,0 +1,28 @@
+// Keyset-pagination cursor for the notifications list endpoint.
+// Encodes (updatedAtMs, id) as "<ms>_<id>" then base64url. Opaque to
+// clients — the server decodes and applies (updated_at, id) < cursor.
+
+export const encodeCursor = (updatedAt: Date, id: number): string => {
+	const payload = `${updatedAt.getTime()}_${id}`;
+	return Buffer.from(payload, 'utf8').toString('base64url');
+};
+
+export const decodeCursor = (cursor: string): { updatedAtMs: number; id: number } | null => {
+	let decoded: string;
+	try {
+		decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+	} catch {
+		return null;
+	}
+
+	const parts = decoded.split('_');
+	if (parts.length !== 2) return null;
+
+	const updatedAtMs = Number(parts[0]);
+	const id = Number(parts[1]);
+
+	if (!Number.isInteger(updatedAtMs) || updatedAtMs < 0) return null;
+	if (!Number.isInteger(id) || id <= 0) return null;
+
+	return { updatedAtMs, id };
+};

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { upsertVoteNotification, insertReplyNotification } from './notifications.js';
+
+interface MockConnection {
+	query: ReturnType<typeof vi.fn>;
+	release: ReturnType<typeof vi.fn>;
+	beginTransaction: ReturnType<typeof vi.fn>;
+	commit: ReturnType<typeof vi.fn>;
+	rollback: ReturnType<typeof vi.fn>;
+}
+
+const buildMysql = (queryResponses: unknown[][]): { mysql: MySQLPromisePool; conn: MockConnection } => {
+	let queryIndex = 0;
+	const conn: MockConnection = {
+		query: vi.fn().mockImplementation(() => {
+			const response = queryResponses[queryIndex++] ?? [];
+			return Promise.resolve([response]);
+		}),
+		release: vi.fn(),
+		beginTransaction: vi.fn().mockResolvedValue(undefined),
+		commit: vi.fn().mockResolvedValue(undefined),
+		rollback: vi.fn().mockResolvedValue(undefined),
+	};
+	const mysql = {
+		getConnection: vi.fn().mockResolvedValue(conn),
+	} as unknown as MySQLPromisePool;
+	return { mysql, conn };
+};
+
+describe('upsertVoteNotification', () => {
+	it('increments event_count when an unread bucket already exists', async () => {
+		const { mysql, conn } = buildMysql([
+			[{ id: 42 }],          // findUnreadVoteBucket — hit
+			{ affectedRows: 1 },    // incrementVoteBucket
+		]);
+
+		const id = await upsertVoteNotification(mysql, { recipientUserId: 7, subjectCommentId: 99 });
+
+		expect(id).toBe(42);
+		expect(conn.beginTransaction).toHaveBeenCalled();
+		expect(conn.commit).toHaveBeenCalled();
+		expect(conn.rollback).not.toHaveBeenCalled();
+		expect(conn.release).toHaveBeenCalled();
+		expect(conn.query).toHaveBeenCalledTimes(2);
+	});
+
+	it('inserts a new row when no unread bucket exists', async () => {
+		const { mysql, conn } = buildMysql([
+			[],                            // findUnreadVoteBucket — miss
+			{ insertId: 100, affectedRows: 1 }, // insertNotification
+		]);
+
+		const id = await upsertVoteNotification(mysql, { recipientUserId: 7, subjectCommentId: 99 });
+
+		expect(id).toBe(100);
+		expect(conn.commit).toHaveBeenCalled();
+		expect(conn.rollback).not.toHaveBeenCalled();
+	});
+
+	it('rolls back the transaction on SQL error', async () => {
+		const { mysql, conn } = buildMysql([]);
+		conn.query.mockRejectedValueOnce(new Error('boom'));
+
+		await expect(
+			upsertVoteNotification(mysql, { recipientUserId: 7, subjectCommentId: 99 }),
+		).rejects.toThrow('boom');
+		expect(conn.rollback).toHaveBeenCalled();
+		expect(conn.commit).not.toHaveBeenCalled();
+		expect(conn.release).toHaveBeenCalled();
+	});
+});
+
+describe('insertReplyNotification', () => {
+	it('inserts a row with the object comment id and returns the inserted id', async () => {
+		const { mysql, conn } = buildMysql([
+			{ insertId: 55, affectedRows: 1 },
+		]);
+
+		const id = await insertReplyNotification(mysql, {
+			recipientUserId: 3,
+			subjectCommentId: 10,
+			objectCommentId: 20,
+		});
+
+		expect(id).toBe(55);
+		expect(conn.query).toHaveBeenCalledTimes(1);
+		expect(conn.release).toHaveBeenCalled();
+	});
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,194 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { MySQLPromisePool, MySQLRowDataPacket, MySQLResultSetHeader } from '@fastify/mysql';
+import { sendEmail } from './email.js';
+import { commentReplyEmail, commentVoteEmail } from './emailTemplates.js';
+import { actorFingerprint } from './actorFingerprint.js';
+import {
+	findUnreadVoteBucketQuery,
+	incrementVoteBucketQuery,
+	insertNotificationQuery,
+} from '../plugins/notifications/queries.js';
+import { NOTIFICATION_TYPE } from '../plugins/notifications/schemas.js';
+
+interface ReplyRecipient {
+	userId: number;
+	login: string;
+	email: string;
+	isBanned: boolean;
+	notifyAuthorOnCommentReply: boolean;
+}
+
+interface VoteRecipient {
+	userId: number;
+	login: string;
+	email: string;
+	isBanned: boolean;
+	notifyAuthorOnCommentVote: boolean;
+}
+
+interface ReplyPayload {
+	recipient: ReplyRecipient;
+	parentCommentId: number;
+	replyCommentId: number;
+	replierDisplayName: string;
+	replierIsAuthor: boolean;
+	replyText: string;
+	siteOrigin: string;
+	threadHref: string;
+}
+
+interface VotePayload {
+	recipient: VoteRecipient;
+	commentId: number;
+	voteDirection: 1 | -1;
+	commentText: string;
+	siteOrigin: string;
+	threadHref: string;
+}
+
+interface InsertReplyArgs {
+	recipientUserId: number;
+	subjectCommentId: number;
+	objectCommentId: number;
+}
+
+interface UpsertVoteArgs {
+	recipientUserId: number;
+	subjectCommentId: number;
+}
+
+// Inserts one notification row for a reply event. Returns the new id.
+export const insertReplyNotification = async (
+	mysql: MySQLPromisePool,
+	args: InsertReplyArgs,
+): Promise<number> => {
+	const connection = await mysql.getConnection();
+	try {
+		const [result] = await connection.query<MySQLResultSetHeader>(
+			insertNotificationQuery,
+			[args.recipientUserId, NOTIFICATION_TYPE.commentReply, args.subjectCommentId, args.objectCommentId],
+		);
+		return result.insertId;
+	} finally {
+		connection.release();
+	}
+};
+
+// Vote-bucket upsert: find the recipient's unread bucket for this comment
+// and increment, else insert a new row. Runs in a transaction with FOR UPDATE
+// on the SELECT so concurrent votes serialize on the bucket row.
+export const upsertVoteNotification = async (
+	mysql: MySQLPromisePool,
+	args: UpsertVoteArgs,
+): Promise<number> => {
+	const connection = await mysql.getConnection();
+	try {
+		await connection.beginTransaction();
+		try {
+			const [rows] = await connection.query<MySQLRowDataPacket[]>(
+				findUnreadVoteBucketQuery,
+				[args.recipientUserId, args.subjectCommentId],
+			);
+
+			let id: number;
+			if (rows.length > 0) {
+				id = rows[0].id as number;
+				await connection.query<MySQLResultSetHeader>(incrementVoteBucketQuery, [id]);
+			} else {
+				const [result] = await connection.query<MySQLResultSetHeader>(
+					insertNotificationQuery,
+					[args.recipientUserId, NOTIFICATION_TYPE.commentVote, args.subjectCommentId, null],
+				);
+				id = result.insertId;
+			}
+
+			await connection.commit();
+			return id;
+		} catch (err) {
+			await connection.rollback();
+			throw err;
+		}
+	} finally {
+		connection.release();
+	}
+};
+
+// Fire-and-forget orchestration. The caller has already applied skip rules
+// (self-reply, banned recipient, deleted-author). Helpers MUST NOT throw —
+// any insert / email failure is logged and swallowed so the underlying
+// comment / vote mutation isn't rolled back.
+export const notifyCommentReply = (
+	fastify: FastifyInstance,
+	request: FastifyRequest,
+	payload: ReplyPayload,
+): void => {
+	const { recipient, parentCommentId, replyCommentId } = payload;
+
+	insertReplyNotification(fastify.mysql, {
+		recipientUserId: recipient.userId,
+		subjectCommentId: parentCommentId,
+		objectCommentId: replyCommentId,
+	})
+		.then((notificationId) => {
+			request.log.info(
+				{ notificationId, recipientFingerprint: actorFingerprint(recipient.userId), type: 'comment_reply' },
+				'Notification created',
+			);
+		})
+		.catch((err) => {
+			request.log.warn(err, 'Notification insert failed (comment_reply)');
+		});
+
+	if (recipient.notifyAuthorOnCommentReply) {
+		sendEmail(
+			recipient.email,
+			commentReplyEmail(
+				payload.siteOrigin,
+				recipient.login,
+				payload.replierDisplayName,
+				payload.replyText,
+				payload.threadHref,
+				payload.replierIsAuthor,
+			),
+		).catch((err) => request.log.warn(err, 'Comment-reply notification email failed'));
+	}
+};
+
+export const notifyCommentVote = (
+	fastify: FastifyInstance,
+	request: FastifyRequest,
+	payload: VotePayload,
+): void => {
+	const { recipient, commentId, voteDirection } = payload;
+
+	upsertVoteNotification(fastify.mysql, {
+		recipientUserId: recipient.userId,
+		subjectCommentId: commentId,
+	})
+		.then((notificationId) => {
+			request.log.info(
+				{ notificationId, recipientFingerprint: actorFingerprint(recipient.userId), type: 'comment_vote' },
+				'Notification upserted',
+			);
+		})
+		.catch((err) => {
+			request.log.warn(err, 'Notification upsert failed (comment_vote)');
+		});
+
+	if (recipient.notifyAuthorOnCommentVote) {
+		sendEmail(
+			recipient.email,
+			commentVoteEmail(
+				payload.siteOrigin,
+				recipient.login,
+				voteDirection,
+				payload.commentText,
+				payload.threadHref,
+			),
+		).catch((err) => request.log.warn(err, 'Comment-vote notification email failed'));
+		request.log.info(
+			{ commentId, recipientFingerprint: actorFingerprint(recipient.userId) },
+			'Comment-vote notification email sent',
+		);
+	}
+};

--- a/src/plugins/comments/comments.test.ts
+++ b/src/plugins/comments/comments.test.ts
@@ -26,19 +26,34 @@ beforeEach(() => {
 // listComments runs multiple queries on one connection, so the mock advances
 // per query call rather than per getConnection (which is the simpler pattern
 // used by votes.test.ts where each route call does a single query).
-function createMockMysql(...responses: Record<string, unknown>[][]): MySQLPromisePool {
-	let queryIndex = 0;
+// beginTransaction/commit/rollback stubs are needed for the notifications
+// helper (upsertVoteNotification) which runs inside a transaction.
+// `sqlLog` is attached to the returned pool so tests can assert the cumulative
+// stream of executed SQL across all acquired connections (handy for the
+// fire-and-forget notification helpers, which run on their own connection).
+type MockMysqlPool = MySQLPromisePool & { __sqlLog: string[] };
 
-	return {
+function createMockMysql(...responses: (Record<string, unknown>[] | Record<string, unknown>)[]): MockMysqlPool {
+	let queryIndex = 0;
+	const sqlLog: string[] = [];
+
+	const pool = {
 		getConnection: vi.fn().mockImplementation(() =>
 			Promise.resolve({
-				query: vi.fn().mockImplementation(() =>
-					Promise.resolve([responses[queryIndex++] ?? []])
-				),
+				query: vi.fn().mockImplementation((sql: string) => {
+					sqlLog.push(sql);
+					return Promise.resolve([responses[queryIndex++] ?? []]);
+				}),
+				beginTransaction: vi.fn().mockResolvedValue(undefined),
+				commit: vi.fn().mockResolvedValue(undefined),
+				rollback: vi.fn().mockResolvedValue(undefined),
 				release: vi.fn(),
 			})
 		),
-	} as unknown as MySQLPromisePool;
+		__sqlLog: sqlLog,
+	} as unknown as MockMysqlPool;
+
+	return pool;
 }
 
 async function buildApp(mysql: MySQLPromisePool) {
@@ -251,6 +266,59 @@ describe('POST /comments', () => {
 		expect(response.statusCode).toBe(400);
 		expect(response.json().error).toBe('TEXT_FLOOD');
 	});
+
+	it('writes an in-app reply notification when the parent author is not the replier', async () => {
+		const parentMeta = {
+			id: 50,
+			parentId: null,
+			thingId: 7,
+			userId: 2,
+			statusId: 1,
+			createdAt: new Date(),
+		};
+		const replyContextRow = {
+			thingId: 7,
+			sectionIdentifier: 'sec',
+			positionInSection: 3,
+			authorUserId: 2,
+			authorLogin: 'parentauthor',
+			authorEmail: 'parent@example.com',
+			authorUserRights: 0,
+			authorGroupRights: 0,
+			authorNotifyOnReply: 1,
+		};
+
+		// Reply path query order:
+		// 1) getCommentMeta(parentId)
+		// 2) createComment (INSERT)
+		// 3) getCommentById (returned to client)
+		// 4) getCommentReplyContext
+		// 5) insertReplyNotification (INSERT INTO notification) — fire-and-forget
+		const mysql = createMockMysql(
+			[parentMeta],
+			{ insertId: 999, affectedRows: 1 },
+			[{ ...visibleRow, id: 999, parentId: 50, userId: 1 }],
+			[replyContextRow],
+			{ insertId: 123, affectedRows: 1 },
+		);
+		const app = await buildApp(mysql);
+		const token = await buildToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/comments',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { parentId: 50, text: 'A reply' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		// Allow the fire-and-forget notification promise to settle.
+		await new Promise((r) => setImmediate(r));
+
+		// Assert the notification INSERT was hit (cumulative SQL across all connections).
+		const allSql = mysql.__sqlLog.join('\n');
+		expect(allSql).toContain('INSERT INTO notification');
+	});
 });
 
 describe('PUT /comments/:commentId/vote', () => {
@@ -340,6 +408,56 @@ describe('PUT /comments/:commentId/vote', () => {
 		// Allow the fire-and-forget promise to settle
 		await new Promise((r) => setImmediate(r));
 		expect(sendEmail).toHaveBeenCalledOnce();
+	});
+
+	it('writes an in-app vote notification (bucket insert) even when the email toggle is off', async () => {
+		const { sendEmail } = await import('../../lib/email.js');
+		vi.mocked(sendEmail).mockClear();
+
+		// meta (authorId=2, not the voter sub=1), upsert, voteContext (toggle OFF),
+		// findUnreadVoteBucket (miss → empty), insertNotification, voteCounts, userVote
+		const mysql = createMockMysql(
+			[{ id: 10, userId: 2, thingId: 5, parentId: null, statusId: 1, createdAt: new Date() }],
+			[],
+			[{
+				authorUserId: 2,
+				thingId: 5,
+				parentId: null,
+				commentText: 'text',
+				authorDisplayName: 'author',
+				authorLogin: 'author',
+				authorEmail: 'author@example.com',
+				authorUserRights: 0,
+				authorGroupRights: 0,
+				authorNotifyOnVote: 0,
+				sectionIdentifier: 'sec',
+				positionInSection: 3,
+			}],
+			[],
+			{ insertId: 77, affectedRows: 1 },
+			[{ likes: 1, dislikes: 0 }],
+			[{ vote: 1 }],
+		);
+		const app = await buildApp(mysql);
+		const token = await buildToken({ sub: 1 });
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/comments/10/vote',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { vote: 'like' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		// Allow the fire-and-forget notification promise to settle.
+		await new Promise((r) => setImmediate(r));
+
+		// Email toggle is off → no email sent.
+		expect(sendEmail).not.toHaveBeenCalled();
+
+		// But the notification insert HAS happened.
+		const allSql = mysql.__sqlLog.join('\n');
+		expect(allSql).toContain('INSERT INTO notification');
 	});
 
 	it('does not send a notification email on self-vote', async () => {

--- a/src/plugins/comments/comments.ts
+++ b/src/plugins/comments/comments.ts
@@ -2,7 +2,8 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { errorResponse } from '../../lib/schemas.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import { sendEmail } from '../../lib/email.js';
-import { commentReportedEmail, commentReplyEmail, commentVoteEmail } from '../../lib/emailTemplates.js';
+import { commentReportedEmail } from '../../lib/emailTemplates.js';
+import { notifyCommentReply, notifyCommentVote } from '../../lib/notifications.js';
 import { voteValueToDb } from '../../lib/voteValue.js';
 import { sanitizeCommentText } from './sanitizeCommentText.js';
 import { actorFingerprint } from '../../lib/actorFingerprint.js';
@@ -197,18 +198,24 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				if (
 					ctx?.parentAuthor &&
 					ctx.parentAuthor.userId !== userId &&
-					!ctx.parentAuthor.isBanned &&
-					ctx.parentAuthor.notifyAuthorOnCommentReply
+					!ctx.parentAuthor.isBanned
 				) {
 					const recipient = ctx.parentAuthor;
 					const replierDisplayName = created?.authorDisplayName ?? '—';
 					const replierIsAuthor = created?.isAuthor ?? false;
 					const siteOrigin = fastify.resolveOrigin(request);
 					const threadHref = buildThreadHref(siteOrigin, ctx, parentId);
-					sendEmail(
-						recipient.email,
-						commentReplyEmail(siteOrigin, recipient.login, replierDisplayName, sanitized.text, threadHref, replierIsAuthor),
-					).catch((err) => request.log.warn(err, 'Comment-reply notification email failed'));
+
+					notifyCommentReply(fastify, request, {
+						recipient,
+						parentCommentId: parentId,
+						replyCommentId: commentId,
+						replierDisplayName,
+						replierIsAuthor,
+						replyText: sanitized.text,
+						siteOrigin,
+						threadHref,
+					});
 				}
 			}
 
@@ -326,14 +333,18 @@ export async function commentsPlugin(fastify: FastifyInstance) {
 				// the comment author) and votes on comments by deleted users.
 				if (meta.userId !== null && meta.userId !== userId) {
 					const ctx = await getCommentVoteContext(fastify.mysql, commentId);
-					if (ctx?.author && !ctx.author.isBanned && ctx.author.notifyAuthorOnCommentVote) {
+					if (ctx?.author && !ctx.author.isBanned) {
 						const siteOrigin = fastify.resolveOrigin(request);
 						const threadHref = buildThreadHref(siteOrigin, ctx, ctx.threadCommentId);
-						sendEmail(
-							ctx.author.email,
-							commentVoteEmail(siteOrigin, ctx.author.login, dbVote, ctx.commentText, threadHref),
-						).catch((err) => request.log.warn(err, 'Comment-vote notification email failed'));
-						request.log.info({ commentId, recipientFingerprint: actorFingerprint(meta.userId) }, 'Comment-vote notification email sent');
+
+						notifyCommentVote(fastify, request, {
+							recipient: ctx.author,
+							commentId,
+							voteDirection: dbVote as 1 | -1,
+							commentText: ctx.commentText,
+							siteOrigin,
+							threadHref,
+						});
 					}
 				}
 			}

--- a/src/plugins/notifications/databaseHelpers.ts
+++ b/src/plugins/notifications/databaseHelpers.ts
@@ -1,0 +1,143 @@
+import type { MySQLPromisePool, MySQLRowDataPacket, MySQLResultSetHeader } from '@fastify/mysql';
+import { withConnection } from '../../lib/databaseHelpers.js';
+import { encodeCursor, decodeCursor } from '../../lib/cursor.js';
+import {
+	countUnreadQuery,
+	listNotificationsBaseQuery,
+	markReadQuery,
+	markAllReadQuery,
+	deleteNotificationQuery,
+} from './queries.js';
+import {
+	DEFAULT_LIMIT,
+	MAX_LIMIT,
+	type NotificationItem,
+} from './schemas.js';
+
+interface ListParams {
+	cursor?: string;
+	limit?: number;
+	unreadOnly?: boolean;
+}
+
+interface ListResult {
+	items: NotificationItem[];
+	nextCursor: string | null;
+}
+
+interface RawNotificationRow {
+	id: number;
+	typeId: number;
+	typeCode: 'comment_reply' | 'comment_vote';
+	eventCount: number | string;
+	isRead: number;
+	createdAt: Date;
+	updatedAt: Date;
+	subjectId: number;
+	subjectText: string;
+	threadCommentId: number;
+	subjectThingId: number | null;
+	objectId: number | null;
+	objectText: string | null;
+	objectAuthorUserId: number | null;
+	objectAuthorDisplayName: string | null;
+	sectionIdentifier: string | null;
+	positionInSection: number | null;
+}
+
+const SITE_AUTHOR_USER_ID = Number(process.env.SITE_AUTHOR_USER_ID) || 1;
+
+const toIso = (d: Date | string): string =>
+	d instanceof Date ? d.toISOString() : new Date(d).toISOString();
+
+const projectRow = (row: RawNotificationRow): NotificationItem => ({
+	id: row.id,
+	type: row.typeCode,
+	eventCount: Number(row.eventCount),
+	isRead: row.isRead === 1,
+	createdAt: toIso(row.createdAt),
+	updatedAt: toIso(row.updatedAt),
+	subjectComment: {
+		id: row.subjectId,
+		text: row.subjectText,
+		threadCommentId: row.threadCommentId,
+		thingId: row.subjectThingId,
+		sectionIdentifier: row.sectionIdentifier,
+		positionInSection: row.positionInSection,
+	},
+	objectComment: row.typeCode === 'comment_reply' && row.objectId !== null
+		? {
+			id: row.objectId,
+			text: row.objectText ?? '',
+			authorDisplayName: row.objectAuthorDisplayName,
+			authorIsAuthor: row.objectAuthorUserId === SITE_AUTHOR_USER_ID,
+		}
+		: null,
+});
+
+export const countUnread = async (mysql: MySQLPromisePool, userId: number): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(countUnreadQuery, [userId]);
+		return Number(rows[0]?.cnt ?? 0);
+	});
+
+export const listNotifications = async (
+	mysql: MySQLPromisePool,
+	userId: number,
+	params: ListParams,
+): Promise<ListResult> => {
+	const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const unreadFilter = params.unreadOnly ? 'AND n.is_read = 0' : '';
+
+	const decoded = params.cursor ? decodeCursor(params.cursor) : null;
+	const cursorFilter = decoded
+		? 'AND (n.updated_at < FROM_UNIXTIME(? / 1000) OR (n.updated_at = FROM_UNIXTIME(? / 1000) AND n.id < ?))'
+		: '';
+	const cursorBindings = decoded ? [decoded.updatedAtMs, decoded.updatedAtMs, decoded.id] : [];
+
+	const sql = listNotificationsBaseQuery
+		.replace('{{UNREAD_FILTER}}', unreadFilter)
+		.replace('{{CURSOR_FILTER}}', cursorFilter);
+
+	const bindings = [userId, ...cursorBindings, limit + 1];
+
+	return withConnection(mysql, async (connection) => {
+		const [rows] = await connection.query<MySQLRowDataPacket[]>(sql, bindings);
+		const projected = (rows as unknown as RawNotificationRow[]).map(projectRow);
+
+		const hasMore = projected.length > limit;
+		const items = hasMore ? projected.slice(0, limit) : projected;
+		const last = items[items.length - 1];
+		const nextCursor = hasMore && last
+			? encodeCursor(new Date(last.updatedAt), last.id)
+			: null;
+
+		return { items, nextCursor };
+	});
+};
+
+export const markRead = async (
+	mysql: MySQLPromisePool,
+	notificationId: number,
+	userId: number,
+): Promise<boolean> =>
+	withConnection(mysql, async (connection) => {
+		const [result] = await connection.query<MySQLResultSetHeader>(markReadQuery, [notificationId, userId]);
+		return result.affectedRows > 0;
+	});
+
+export const markAllRead = async (mysql: MySQLPromisePool, userId: number): Promise<number> =>
+	withConnection(mysql, async (connection) => {
+		const [result] = await connection.query<MySQLResultSetHeader>(markAllReadQuery, [userId]);
+		return result.affectedRows;
+	});
+
+export const deleteNotification = async (
+	mysql: MySQLPromisePool,
+	notificationId: number,
+	userId: number,
+): Promise<boolean> =>
+	withConnection(mysql, async (connection) => {
+		const [result] = await connection.query<MySQLResultSetHeader>(deleteNotificationQuery, [notificationId, userId]);
+		return result.affectedRows > 0;
+	});

--- a/src/plugins/notifications/notifications.test.ts
+++ b/src/plugins/notifications/notifications.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import type { MySQLPromisePool } from '@fastify/mysql';
+import { authPlugin } from '../auth/auth.js';
+import { notificationsPlugin } from './notifications.js';
+import { signAccessToken } from '../auth/jwt.js';
+
+const JWT_SECRET = 'test-jwt-secret-that-is-at-least-32-characters-long';
+const secret = new TextEncoder().encode(JWT_SECRET);
+
+beforeEach(() => {
+	vi.stubEnv('JWT_SECRET', JWT_SECRET);
+	vi.stubEnv('JWT_ACCESS_TOKEN_TTL', '900');
+	vi.stubEnv('JWT_REFRESH_TOKEN_TTL', '2592000');
+	vi.stubEnv('ACTIVATION_KEY_TTL', '86400');
+	vi.stubEnv('RESET_KEY_TTL', '3600');
+	vi.stubEnv('ALLOWED_ORIGINS', 'https://poetry.mellonis.ru');
+});
+
+// Each rest arg is the "first element of one query result tuple": a row array
+// for SELECT (e.g. `[{cnt: 5}]`) or a result-set header object for UPDATE/
+// DELETE (e.g. `{affectedRows: 1}`). The mock wraps it in `[…]` so the helper's
+// `const [x] = await query(...)` destructure strips one level back to the arg.
+function createMockMysql(...responses: unknown[]): MySQLPromisePool {
+	let queryIndex = 0;
+	return {
+		getConnection: vi.fn().mockImplementation(() =>
+			Promise.resolve({
+				query: vi.fn().mockImplementation(() =>
+					Promise.resolve([responses[queryIndex++] ?? []]),
+				),
+				release: vi.fn(),
+			}),
+		),
+	} as unknown as MySQLPromisePool;
+}
+
+async function buildApp(mysql: MySQLPromisePool) {
+	const app = Fastify({ logger: false });
+	app.setValidatorCompiler(validatorCompiler);
+	app.setSerializerCompiler(serializerCompiler);
+	app.decorate('mysql', mysql);
+	app.register(authPlugin);
+	app.register(notificationsPlugin, { prefix: '/notifications' });
+	await app.ready();
+	return app;
+}
+
+const buildToken = (sub: number = 1) =>
+	signAccessToken({
+		sub,
+		login: 'testuser',
+		isAdmin: false,
+		isEditor: false,
+		tokenVersion: 0,
+		rights: {
+			canVote: true,
+			canComment: true,
+			canEditContent: false,
+			canEditUsers: false,
+		},
+	}, secret);
+
+describe('GET /notifications/summary', () => {
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({ method: 'GET', url: '/notifications/summary' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns the unread count for the authenticated user', async () => {
+		const app = await buildApp(createMockMysql([{ cnt: 5 }]));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications/summary',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ unreadCount: 5 });
+	});
+
+	it('returns 0 when the recipient has nothing', async () => {
+		const app = await buildApp(createMockMysql([]));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications/summary',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ unreadCount: 0 });
+	});
+});
+
+describe('GET /notifications', () => {
+	const baseRow = {
+		id: 100,
+		typeId: 2,
+		typeCode: 'comment_vote' as const,
+		eventCount: 3,
+		isRead: 0,
+		createdAt: new Date('2026-05-15T10:00:00Z'),
+		updatedAt: new Date('2026-05-16T10:00:00Z'),
+		subjectId: 50,
+		subjectText: 'My comment',
+		threadCommentId: 50,
+		subjectThingId: 7,
+		objectId: null,
+		objectText: null,
+		objectAuthorUserId: null,
+		objectAuthorDisplayName: null,
+		sectionIdentifier: 'sec',
+		positionInSection: 3,
+	};
+
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({ method: 'GET', url: '/notifications' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns items with nextCursor null when fewer than limit+1 rows', async () => {
+		const app = await buildApp(createMockMysql([baseRow]));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications?limit=20',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.nextCursor).toBeNull();
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0].type).toBe('comment_vote');
+		expect(body.items[0].objectComment).toBeNull();
+	});
+
+	it('emits a nextCursor when there are limit+1 rows', async () => {
+		const second = { ...baseRow, id: 99, updatedAt: new Date('2026-05-14T10:00:00Z') };
+		const app = await buildApp(createMockMysql([baseRow, second]));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications?limit=1',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.items).toHaveLength(1);
+		expect(body.nextCursor).not.toBeNull();
+	});
+
+	it('projects an objectComment for a reply row', async () => {
+		const reply = {
+			...baseRow,
+			typeId: 1,
+			typeCode: 'comment_reply' as const,
+			eventCount: 1,
+			objectId: 200,
+			objectText: 'Reply text',
+			objectAuthorUserId: 2,
+			objectAuthorDisplayName: 'replier',
+		};
+		const app = await buildApp(createMockMysql([reply]));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.items[0].type).toBe('comment_reply');
+		expect(body.items[0].objectComment).toEqual({
+			id: 200,
+			text: 'Reply text',
+			authorDisplayName: 'replier',
+			authorIsAuthor: false,
+		});
+	});
+});
+
+describe('POST /notifications/:id/read', () => {
+	it('returns 401 without auth', async () => {
+		const app = await buildApp(createMockMysql());
+		const response = await app.inject({ method: 'POST', url: '/notifications/1/read' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('marks the row read', async () => {
+		const app = await buildApp(createMockMysql({ affectedRows: 1 }));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/notifications/1/read',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true });
+	});
+
+	it("returns 404 when the row is not the caller's (or does not exist)", async () => {
+		const app = await buildApp(createMockMysql({ affectedRows: 0 }));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/notifications/999/read',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(404);
+	});
+});
+
+describe('POST /notifications/read-all', () => {
+	it('returns the count marked', async () => {
+		const app = await buildApp(createMockMysql({ affectedRows: 4 }));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/notifications/read-all',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true, marked: 4 });
+	});
+});
+
+describe('DELETE /notifications/:id', () => {
+	it('deletes the row', async () => {
+		const app = await buildApp(createMockMysql({ affectedRows: 1 }));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/notifications/1',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true });
+	});
+
+	it("returns 404 when the row is not the caller's", async () => {
+		const app = await buildApp(createMockMysql({ affectedRows: 0 }));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/notifications/999',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(404);
+	});
+});
+
+describe('GET /notifications/settings', () => {
+	it('returns the current settings', async () => {
+		const app = await buildApp(createMockMysql(
+			[{ notify_author_on_comment_reply: 1, notify_author_on_comment_vote: 0 }],
+		));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'GET',
+			url: '/notifications/settings',
+			headers: { authorization: `Bearer ${token}` },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			notifyAuthorOnCommentReply: true,
+			notifyAuthorOnCommentVote: false,
+		});
+	});
+});
+
+describe('PUT /notifications/settings', () => {
+	it('updates and returns the new settings', async () => {
+		const app = await buildApp(createMockMysql(
+			{ affectedRows: 1 },
+			[{ notify_author_on_comment_reply: 0, notify_author_on_comment_vote: 1 }],
+		));
+		const token = await buildToken();
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/notifications/settings',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { notifyAuthorOnCommentReply: false, notifyAuthorOnCommentVote: true },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			notifyAuthorOnCommentReply: false,
+			notifyAuthorOnCommentVote: true,
+		});
+	});
+});

--- a/src/plugins/notifications/notifications.ts
+++ b/src/plugins/notifications/notifications.ts
@@ -1,0 +1,163 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
+import { errorResponse } from '../../lib/schemas.js';
+import { authErrorResponse } from '../auth/schemas.js';
+import {
+	getNotificationSettings,
+	updateNotificationSettings,
+} from '../users/databaseHelpers.js';
+import {
+	countUnread,
+	listNotifications,
+	markRead,
+	markAllRead,
+	deleteNotification,
+} from './databaseHelpers.js';
+import {
+	notificationParams,
+	notificationListQuery,
+	notificationListResponse,
+	summaryResponse,
+	okResponse,
+	markAllReadResponse,
+	settingsResponse,
+	updateSettingsRequest,
+	errorBody,
+	type NotificationParams,
+	type NotificationListQuery,
+	type UpdateSettingsRequest,
+} from './schemas.js';
+
+export async function notificationsPlugin(fastify: FastifyInstance) {
+	fastify.log.info('[PLUGIN] Registering: notifications...');
+
+	fastify.get('/summary', {
+		schema: {
+			description: 'Lightweight unread-count for the header badge poll.',
+			tags: ['Notifications'],
+			response: { 200: summaryResponse, 401: authErrorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request) => {
+			const userId = request.user!.sub;
+			const unreadCount = await countUnread(fastify.mysql, userId);
+			return { unreadCount };
+		},
+	});
+
+	fastify.get('/', {
+		schema: {
+			description: "Paginated list of the caller's notifications. Keyset cursor on (updated_at, id).",
+			tags: ['Notifications'],
+			querystring: notificationListQuery,
+			response: { 200: notificationListResponse, 401: authErrorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Querystring: NotificationListQuery }>) => {
+			const userId = request.user!.sub;
+			return listNotifications(fastify.mysql, userId, {
+				cursor: request.query.cursor,
+				limit: request.query.limit,
+				unreadOnly: request.query.unreadOnly,
+			});
+		},
+	});
+
+	fastify.post('/:notificationId/read', {
+		schema: {
+			description: 'Mark a single notification as read. Idempotent.',
+			tags: ['Notifications'],
+			params: notificationParams,
+			response: { 200: okResponse, 401: authErrorResponse, 404: errorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Params: NotificationParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { notificationId } = request.params;
+			const affected = await markRead(fastify.mysql, notificationId, userId);
+			if (!affected) return reply.code(404).send(errorBody('not_found'));
+			request.log.info(
+				{ notificationId, actorFingerprint: actorFingerprint(userId) },
+				'Notification marked read',
+			);
+			return { ok: true as const };
+		},
+	});
+
+	fastify.post('/read-all', {
+		schema: {
+			description: 'Mark every unread notification for the caller as read.',
+			tags: ['Notifications'],
+			response: { 200: markAllReadResponse, 401: authErrorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request) => {
+			const userId = request.user!.sub;
+			const marked = await markAllRead(fastify.mysql, userId);
+			request.log.info(
+				{ actorFingerprint: actorFingerprint(userId), marked },
+				'Notifications mark-all-read',
+			);
+			return { ok: true as const, marked };
+		},
+	});
+
+	fastify.delete('/:notificationId', {
+		schema: {
+			description: 'Delete a single notification permanently.',
+			tags: ['Notifications'],
+			params: notificationParams,
+			response: { 200: okResponse, 401: authErrorResponse, 404: errorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Params: NotificationParams }>, reply) => {
+			const userId = request.user!.sub;
+			const { notificationId } = request.params;
+			const affected = await deleteNotification(fastify.mysql, notificationId, userId);
+			if (!affected) return reply.code(404).send(errorBody('not_found'));
+			request.log.info(
+				{ notificationId, actorFingerprint: actorFingerprint(userId) },
+				'Notification deleted',
+			);
+			return { ok: true as const };
+		},
+	});
+
+	fastify.get('/settings', {
+		schema: {
+			description: 'Get notification preferences for the authenticated user.',
+			tags: ['Notifications'],
+			response: { 200: settingsResponse, 401: authErrorResponse, 404: errorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request, reply) => {
+			const userId = request.user!.sub;
+			const settings = await getNotificationSettings(fastify.mysql, userId);
+			if (!settings) return reply.code(404).send(errorBody('not_found'));
+			return settings;
+		},
+	});
+
+	fastify.put('/settings', {
+		schema: {
+			description: 'Update notification preferences for the authenticated user.',
+			tags: ['Notifications'],
+			body: updateSettingsRequest,
+			response: { 200: settingsResponse, 401: authErrorResponse, 404: errorResponse, 500: errorResponse },
+		},
+		preHandler: fastify.verifyJwt,
+		handler: async (request: FastifyRequest<{ Body: UpdateSettingsRequest }>, reply) => {
+			const userId = request.user!.sub;
+			await updateNotificationSettings(fastify.mysql, userId, request.body);
+			const settings = await getNotificationSettings(fastify.mysql, userId);
+			if (!settings) return reply.code(404).send(errorBody('not_found'));
+			request.log.info(
+				{ actorFingerprint: actorFingerprint(userId), settings: request.body },
+				'Notification settings updated',
+			);
+			return settings;
+		},
+	});
+
+	fastify.log.info('[PLUGIN] Registered: notifications');
+}

--- a/src/plugins/notifications/queries.ts
+++ b/src/plugins/notifications/queries.ts
@@ -1,0 +1,112 @@
+// SQL constants for the notifications plugin. All read queries apply the
+// visibility filter (subject Visible; object NULL or Visible) so moderated
+// comments fall out of both the badge count and the feed.
+
+const visibilityJoin = `
+  JOIN comment cs ON cs.id = n.r_subject_comment_id AND cs.r_comment_status_id = 1
+  LEFT JOIN comment co ON co.id = n.r_object_comment_id
+`;
+
+const visibilityWhere = `
+  AND (n.r_object_comment_id IS NULL OR co.r_comment_status_id = 1)
+`;
+
+// SUMMARY -----------------------------------------------------------------
+
+export const countUnreadQuery = `
+  SELECT COUNT(*) AS cnt
+  FROM notification n
+  ${visibilityJoin}
+  WHERE n.r_user_id = ?
+    AND n.is_read = 0
+    ${visibilityWhere}
+`;
+
+// LIST --------------------------------------------------------------------
+// Note: caller fetches LIMIT+1 rows so it can detect "more pages exist"
+// and emit a nextCursor. The keyset compares (updated_at, id) strictly less
+// than the cursor — equal-timestamp rows are tie-broken by id DESC.
+
+export const listNotificationsBaseQuery = `
+  SELECT
+    n.id,
+    n.r_notification_type_id AS typeId,
+    nt.code AS typeCode,
+    n.event_count AS eventCount,
+    n.is_read AS isRead,
+    n.created_at AS createdAt,
+    n.updated_at AS updatedAt,
+    cs.id AS subjectId,
+    cs.text AS subjectText,
+    COALESCE(cs.parent_id, cs.id) AS threadCommentId,
+    cs.r_thing_id AS subjectThingId,
+    co.id AS objectId,
+    co.text AS objectText,
+    co.r_user_id AS objectAuthorUserId,
+    co.display_name_snapshot AS objectAuthorDisplayName,
+    sec.identifier AS sectionIdentifier,
+    ti.thing_position_in_section AS positionInSection
+  FROM notification n
+  JOIN notification_type nt ON nt.id = n.r_notification_type_id
+  ${visibilityJoin}
+  LEFT JOIN thing_identifier ti
+    ON ti.r_thing_id = cs.r_thing_id
+   AND ti.r_redirect_thing_identifier_id IS NULL
+  LEFT JOIN section sec
+    ON sec.id = ti.r_section_id
+   AND sec.r_section_status_id IN (2, 3)
+  WHERE n.r_user_id = ?
+    {{UNREAD_FILTER}}
+    {{CURSOR_FILTER}}
+    ${visibilityWhere}
+  ORDER BY n.updated_at DESC, n.id DESC
+  LIMIT ?
+`;
+
+// MARK READ ---------------------------------------------------------------
+
+export const markReadQuery = `
+  UPDATE notification
+  SET is_read = 1, read_at = NOW()
+  WHERE id = ? AND r_user_id = ? AND is_read = 0
+`;
+
+export const markAllReadQuery = `
+  UPDATE notification
+  SET is_read = 1, read_at = NOW()
+  WHERE r_user_id = ? AND is_read = 0
+`;
+
+// DELETE ------------------------------------------------------------------
+
+export const deleteNotificationQuery = `
+  DELETE FROM notification
+  WHERE id = ? AND r_user_id = ?
+`;
+
+// VOTE BUCKET UPSERT ------------------------------------------------------
+// These two statements run in a single transaction with FOR UPDATE on the
+// SELECT. The helper in lib/notifications.ts owns the BEGIN/COMMIT.
+
+export const findUnreadVoteBucketQuery = `
+  SELECT id FROM notification
+  WHERE r_user_id = ?
+    AND r_subject_comment_id = ?
+    AND r_notification_type_id = 2
+    AND is_read = 0
+  ORDER BY id DESC
+  LIMIT 1
+  FOR UPDATE
+`;
+
+export const incrementVoteBucketQuery = `
+  UPDATE notification
+  SET event_count = event_count + 1
+  WHERE id = ?
+`;
+
+export const insertNotificationQuery = `
+  INSERT INTO notification
+    (r_user_id, r_notification_type_id, r_subject_comment_id, r_object_comment_id)
+  VALUES (?, ?, ?, ?)
+`;

--- a/src/plugins/notifications/schemas.ts
+++ b/src/plugins/notifications/schemas.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+export const NOTIFICATION_TYPE = {
+	commentReply: 1,
+	commentVote: 2,
+} as const;
+
+export const notificationTypeCode = z.enum(['comment_reply', 'comment_vote']);
+
+export const errorBody = (code: string, message?: string) =>
+	({ error: code, ...(message ? { message } : {}) });
+
+const subjectCommentSchema = z.object({
+	id: z.number().int().positive(),
+	text: z.string(),
+	threadCommentId: z.number().int().positive(),
+	thingId: z.number().int().positive().nullable(),
+	sectionIdentifier: z.string().nullable(),
+	positionInSection: z.number().int().positive().nullable(),
+});
+
+const objectCommentSchema = z.object({
+	id: z.number().int().positive(),
+	text: z.string(),
+	authorDisplayName: z.string().nullable(),
+	authorIsAuthor: z.boolean(),
+});
+
+export const notificationItemSchema = z.object({
+	id: z.number().int().positive(),
+	type: notificationTypeCode,
+	eventCount: z.number().int().min(1),
+	isRead: z.boolean(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	subjectComment: subjectCommentSchema,
+	objectComment: objectCommentSchema.nullable(),
+});
+
+export const notificationParams = z.object({
+	notificationId: z.coerce.number().int().positive(),
+});
+
+export const notificationListQuery = z.object({
+	cursor: z.optional(z.string().min(1).max(256)),
+	limit: z.optional(z.coerce.number().int().min(1).max(MAX_LIMIT)),
+	unreadOnly: z.optional(z.coerce.boolean()),
+});
+
+export const notificationListResponse = z.object({
+	items: z.array(notificationItemSchema),
+	nextCursor: z.string().nullable(),
+});
+
+export const summaryResponse = z.object({
+	unreadCount: z.number().int().min(0),
+});
+
+export const okResponse = z.object({
+	ok: z.literal(true),
+});
+
+export const markAllReadResponse = z.object({
+	ok: z.literal(true),
+	marked: z.number().int().min(0),
+});
+
+export const settingsResponse = z.object({
+	notifyAuthorOnCommentReply: z.boolean(),
+	notifyAuthorOnCommentVote: z.boolean(),
+});
+
+export const updateSettingsRequest = settingsResponse;
+
+export type NotificationItem = z.infer<typeof notificationItemSchema>;
+export type NotificationListQuery = z.infer<typeof notificationListQuery>;
+export type NotificationParams = z.infer<typeof notificationParams>;
+export type UpdateSettingsRequest = z.infer<typeof updateSettingsRequest>;
+export type SettingsResponse = z.infer<typeof settingsResponse>;

--- a/src/plugins/users/users.ts
+++ b/src/plugins/users/users.ts
@@ -163,6 +163,14 @@ export async function usersPlugin(fastify: FastifyInstance) {
 				const { userId } = request.params;
 				const user = request.user!;
 
+				request.log.info(
+					{
+						actorFingerprint: actorFingerprint(request.user!.sub),
+						path: '/users/:userId/notification-settings',
+					},
+					'Deprecated endpoint hit',
+				);
+
 				if (user.sub !== userId) {
 					return reply.code(403).send({ error: 'forbidden', message: 'Cannot read another user\'s notification settings' });
 				}
@@ -201,6 +209,14 @@ export async function usersPlugin(fastify: FastifyInstance) {
 			try {
 				const { userId } = request.params;
 				const user = request.user!;
+
+				request.log.info(
+					{
+						actorFingerprint: actorFingerprint(request.user!.sub),
+						path: '/users/:userId/notification-settings',
+					},
+					'Deprecated endpoint hit',
+				);
 
 				if (user.sub !== userId) {
 					return reply.code(403).send({ error: 'forbidden', message: 'Cannot update another user\'s notification settings' });


### PR DESCRIPTION
## Summary

- New `notifications/` plugin at `/notifications` with 7 routes: summary, paginated list (keyset cursor on `updated_at, id`), mark-read, read-all, delete, get/put settings.
- New `lib/notifications.ts` issuance helpers (`notifyCommentReply`, `notifyCommentVote`) replace the inline `sendEmail` in `comments.ts`. In-app row insertion is unconditional; email is sent only when the per-event toggle is on. Skip rules unchanged.
- `/users/:userId/notification-settings` survives as a deprecated alias; each call logs `'Deprecated endpoint hit'`.
- Vote bucket aggregation: `SELECT … FOR UPDATE` inside a transaction increments `event_count` on the unread bucket or inserts a fresh row.

Depends on: mellonis/poetry-old2#84 (migration must merge first so the production deploy doesn't outpace the schema). Closes #117.

Spec: `docs/superpowers/specs/2026-05-18-in-app-notifications-design.md` (umbrella poetry repo).

## Test plan

- [x] `npm test` — 310 tests pass.
- [x] `npm run lint`, `npx tsc --noEmit` clean.
- [x] Local DDEV smoke: api restart shows \`[PLUGIN] Registered: notifications\`; unauthenticated GET /notifications/summary returns 401.
- [ ] After merge: confirm \`[PLUGIN] Registered: notifications\` in prod logs.

## Follow-ups

- Phase 1.5 (List-Unsubscribe headers in emails) — separate plan.
- Phase 2 (Web Push) — separate plan.
- Frontend integration in \`poetry-nextjs\` — separate issue.