### PR TITLE
logger: unify production log shape with poetry-nextjs / poetry-old2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,17 @@ const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) =>
 
 const fastify: FastifyInstance = Fastify({
 	logger: process.env.NODE_ENV === 'production'
-		? true
+		? {
+			// Match the JSON log shape emitted by poetry-nextjs and poetry-old2 so
+			// the three services share one canonical line format for downstream
+			// tooling (dozzle, log aggregators):
+			//   {"time":"<iso>","level":"info","reqId":"…","msg":"…"}
+			// Pino's defaults emit numeric levels (30/40/…), unix-ms time, and
+			// per-line pid+hostname — none of which match the rest of the stack.
+			formatters: { level: (label) => ({ level: label }) },
+			timestamp: () => `,"time":"${new Date().toISOString()}"`,
+			base: null,
+		}
 		: { transport: { target: 'pino-pretty' } },
 	genReqId: (req) => (req.headers['x-request-id'] as string) || randomUUID(),
 });


### PR DESCRIPTION
## Summary

Three Fastify logger options align poetry-api's production JSON output with what poetry-nextjs and poetry-old2 already emit:

```json
{"time":"<iso>","level":"info","reqId":"…","msg":"…"}
```

| Option | Before (Pino default) | After |
|---|---|---|
| `formatters.level` | numeric (`30`/`40`/…) | string (`"info"`/`"warn"`/…) |
| `timestamp` | unix-ms (`1780214797085`) | ISO 8601 (`"2026-05-31T08:06:37.085Z"`) |
| `base` | per-line `pid` + `hostname` | omitted |

## Why

A cross-service log capture this morning showed poetry-api as the only outlier among the three services we own. Unified shape lets downstream tooling (dozzle, log aggregators, ad-hoc grep) treat all three the same — same field names, same level encoding, same timestamp format. Existing `request.log.info(...)` call sites are unaffected.

Dev mode (`pino-pretty` transport) is unchanged — only the production branch of the ternary.

Out of scope (third-party containers, can't change): `poetry-db` (MySQL), `poetry-meilisearch`, `poetry-dozzle`, `poetry-old` (PHP 5.6, no Logger class).

## Test plan

- [ ] `ci` job passes (lint + tests).
- [ ] Post-deploy: check `docker logs poetry-api` and confirm a log line has the new shape (`"time"` first, `"level":"info"`, no `pid`/`hostname`).
- [ ] Cross-check the same `request.log.info(...)` call site (e.g. `Vote recorded`) in dozzle alongside an old log line — fields should now match poetry-nextjs/poetry-old2's shape.

## Follow-up (separate PR, poetry umbrella repo)

Document the canonical JSON log shape in `poetry/CLAUDE.md`'s Logging section so future services (any language) target the same fields by default.