### PR TITLE
fix: prevent unhandled rejection when vote notification email fails

### DIFF
--- a/src/plugins/votes/votes.ts
+++ b/src/plugins/votes/votes.ts
@@ -90,11 +90,11 @@ export async function votesPlugin(fastify: FastifyInstance) {
 				}
 
 				if (ADMIN_NOTIFY_EMAIL) {
-					getThingTitle(fastify.mysql, thingId).then((title) => {
-						sendEmail(ADMIN_NOTIFY_EMAIL, thingVotedEmail(login, title, dbVote));
-					}).catch((err) => {
-						request.log.warn(err, 'Vote notification email failed');
-					});
+					getThingTitle(fastify.mysql, thingId)
+						.then((title) => sendEmail(ADMIN_NOTIFY_EMAIL, thingVotedEmail(login, title, dbVote)))
+						.catch((err) => {
+							request.log.warn(err, 'Vote notification email failed');
+						});
 				}
 
 				return await getVoteSummary(fastify.mysql, thingId, userId);


### PR DESCRIPTION
## Problem

In the thing-vote handler, the admin-notification email was fired without its rejection being captured, so an SMTP error during a vote could surface as an unhandled promise rejection (Node's default is to terminate the process).

`src/plugins/votes/votes.ts` — the `sendEmail(...)` promise was created inside the `.then` callback but not **returned**, so it was not part of the chain the `.catch` guarded. `sendEmail` rejects on any transport error.

## Fix

Return the `sendEmail` call so it joins the chain and the existing `.catch` covers it. Matches the correct pattern already in `src/plugins/comments/comments.ts`. Verified this was the only fire-and-forget `sendEmail` site with the broken shape.

Build (`tsc`) and lint clean.

Closes #153