### PR TITLE
fix: harden auth endpoints (rate limiting, allowList, enumeration, setup secret)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,12 @@ import searchPlugin from './plugins/search/search.js';
 import { searchRoutes } from './plugins/search/searchRoutes.js';
 import { healthPlugin } from './plugins/health/health.js';
 import { setupPlugin } from './plugins/setup/setup.js';
+import { isRateLimitExempt } from './plugins/auth/rateLimitAllowList.js';
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean);
+
+// Same secret encoding as auth.ts (which validates JWT_SECRET at startup).
+const jwtSecret = new TextEncoder().encode(process.env.JWT_SECRET ?? '');
 
 const fastify: FastifyInstance = Fastify({
 	logger: process.env.NODE_ENV === 'production'
@@ -40,6 +44,10 @@ const fastify: FastifyInstance = Fastify({
 		}
 		: { transport: { target: 'pino-pretty' } },
 	genReqId: (req) => (req.headers['x-request-id'] as string) || randomUUID(),
+	// Trust exactly one proxy hop (nginx). Makes request.ip the real client
+	// IP from X-Forwarded-For so per-IP rate limiting works; `1` (not `true`)
+	// prevents a client from spoofing X-Forwarded-For to evade the limit.
+	trustProxy: 1,
 });
 
 fastify.addHook('onSend', async (request, reply) => {
@@ -64,37 +72,22 @@ fastify.register(cors, {
 // is not yet populated; auth-gated routes still get the auth check on top.
 // errorResponseBuilder localizes the 429 body for our (Russian) clients.
 //
-// `skip` decodes the JWT to bypass rate-limiting for editors/admins. Decode
-// only — signature is NOT verified here (verifyJwt does that later). A forged
-// "isEditor: true" token would still fail verifyJwt and never reach the
-// handler, so the skip is safe to base on the unverified payload.
+// `allowList` lets verified editors/admins bypass rate-limiting. The token
+// signature MUST be verified here, not just decoded: some rate-limited routes
+// (e.g. POST /setup/admin, gated only by a body secret) never run verifyJwt,
+// so a forged "isAdmin: true" payload would otherwise skip the limiter and
+// keep brute-forcing. Verifying the signature makes the skip trustworthy on
+// its own, independent of whether the route runs verifyJwt.
 fastify.register(rateLimit, {
 	global: false,
+	// English message + stable `error` code, matching the rest of poetry-api;
+	// clients localize from the code. `ttl` is surfaced for a countdown UI.
 	errorResponseBuilder: (_req, ctx) => ({
 		statusCode: 429,
 		error: 'rate_limited',
-		message: `Слишком часто. Попробуйте через ${Math.ceil(ctx.ttl / 1000)} с.`,
+		message: `Too many requests. Try again in ${Math.ceil(ctx.ttl / 1000)}s.`,
 	}),
-	allowList: (request) => {
-		const auth = request.headers.authorization;
-
-		if (!auth?.startsWith('Bearer ')) return false;
-
-		try {
-			const part = auth.substring(7).split('.')[1];
-
-			if (!part) return false;
-
-			const payload = JSON.parse(Buffer.from(part, 'base64url').toString('utf8')) as {
-				isEditor?: boolean;
-				isAdmin?: boolean;
-			};
-
-			return payload.isEditor === true || payload.isAdmin === true;
-		} catch {
-			return false;
-		}
-	},
+	allowList: (request) => isRateLimitExempt(request, jwtSecret),
 });
 fastify.register(databasePlugin);
 fastify.register(healthPlugin);

--- a/src/plugins/auth/authRoutes.ts
+++ b/src/plugins/auth/authRoutes.ts
@@ -55,10 +55,23 @@ import {
 	meResponse,
 } from './schemas.js';
 
+// Per-IP rate limits (in-memory store; verified editors/admins bypass via the
+// allowList in index.ts). Sized to allow legitimate retries while throttling
+// password brute-force on /login and email-send abuse on the routes that send
+// mail (register, resend-activation, request-password-reset).
+const LOGIN_RATE_LIMIT = { max: 10, timeWindow: '1 minute' };
+const REFRESH_RATE_LIMIT = { max: 30, timeWindow: '1 minute' };
+const REGISTER_RATE_LIMIT = { max: 5, timeWindow: '1 minute' };
+const ACTIVATE_RATE_LIMIT = { max: 10, timeWindow: '1 minute' };
+const RESEND_ACTIVATION_RATE_LIMIT = { max: 5, timeWindow: '1 minute' };
+const REQUEST_PASSWORD_RESET_RATE_LIMIT = { max: 5, timeWindow: '1 minute' };
+const RESET_PASSWORD_RATE_LIMIT = { max: 10, timeWindow: '1 minute' };
+
 export async function authRoutesPlugin(fastify: FastifyInstance) {
 	fastify.log.info('[PLUGIN] Registering: authRoutes...');
 
 	fastify.post('/login', {
+		config: { rateLimit: LOGIN_RATE_LIMIT },
 		schema: {
 			description: 'Authenticate with login and password. Returns JWT access and refresh tokens.',
 			tags: ['Auth'],
@@ -115,6 +128,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/refresh', {
+		config: { rateLimit: REFRESH_RATE_LIMIT },
 		schema: {
 			description: 'Exchange a valid refresh token for a new access/refresh token pair.',
 			tags: ['Auth'],
@@ -177,6 +191,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/register', {
+		config: { rateLimit: REGISTER_RATE_LIMIT },
 		schema: {
 			description: 'Create a new user account and send an activation email.',
 			tags: ['Auth'],
@@ -224,6 +239,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/activate', {
+		config: { rateLimit: ACTIVATE_RATE_LIMIT },
 		schema: {
 			description: 'Activate a user account using the key from the activation email.',
 			tags: ['Auth'],
@@ -265,6 +281,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/resend-activation', {
+		config: { rateLimit: RESEND_ACTIVATION_RATE_LIMIT },
 		schema: {
 			description: 'Resend the activation email for an unactivated account.',
 			tags: ['Auth'],
@@ -300,6 +317,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/request-password-reset', {
+		config: { rateLimit: REQUEST_PASSWORD_RESET_RATE_LIMIT },
 		schema: {
 			description: 'Request a password reset email for the given email address.',
 			tags: ['Auth'],
@@ -320,7 +338,13 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 					await updateUserRightsAndKey(fastify.mysql, user.userId, newRights, key);
 					request.log.info({ actorFingerprint: actorFingerprint(user.userId) }, 'Password reset requested');
 
-					await fastify.authNotifier.sendPasswordReset(user.email, user.login, key, fastify.resolveOrigin(request));
+					// Swallow notifier errors so a failed send can't turn into a 500
+					// for existing accounts only — that would leak which emails exist.
+					try {
+						await fastify.authNotifier.sendPasswordReset(user.email, user.login, key, fastify.resolveOrigin(request));
+					} catch (notifierError) {
+						fastify.log.error({ email: maskEmail(user.email), err: notifierError }, 'Failed to send password reset email');
+					}
 				}
 
 				return { message: 'If an account exists, a password reset link has been sent' };
@@ -332,6 +356,7 @@ export async function authRoutesPlugin(fastify: FastifyInstance) {
 	});
 
 	fastify.post('/reset-password', {
+		config: { rateLimit: RESET_PASSWORD_RATE_LIMIT },
 		schema: {
 			description: 'Set a new password using the key from the reset email.',
 			tags: ['Auth'],

--- a/src/plugins/auth/rateLimitAllowList.test.ts
+++ b/src/plugins/auth/rateLimitAllowList.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { signAccessToken, type AccessTokenPayload } from './jwt.js';
+import { isRateLimitExempt } from './rateLimitAllowList.js';
+
+const secret = new TextEncoder().encode('test-secret-at-least-32-characters-long!');
+const wrongSecret = new TextEncoder().encode('a-different-secret-also-32-chars-long!!!');
+
+const payload = (over: Partial<AccessTokenPayload> = {}): AccessTokenPayload => ({
+	sub: 1,
+	login: 'someone',
+	isAdmin: false,
+	isEditor: false,
+	tokenVersion: 0,
+	rights: { canVote: true, canComment: true, canEditContent: false, canEditUsers: false },
+	...over,
+});
+
+const req = (authorization?: string) => ({ headers: authorization ? { authorization } : {} });
+
+beforeAll(() => {
+	process.env.JWT_ACCESS_TOKEN_TTL = '900';
+});
+
+describe('isRateLimitExempt', () => {
+	it('is false with no Authorization header', async () => {
+		expect(await isRateLimitExempt(req(), secret)).toBe(false);
+	});
+
+	it('is false for a non-Bearer scheme', async () => {
+		expect(await isRateLimitExempt(req('Basic abc'), secret)).toBe(false);
+	});
+
+	it('exempts a validly-signed editor token', async () => {
+		const token = await signAccessToken(payload({ isEditor: true }), secret);
+		expect(await isRateLimitExempt(req(`Bearer ${token}`), secret)).toBe(true);
+	});
+
+	it('exempts a validly-signed admin token', async () => {
+		const token = await signAccessToken(payload({ isAdmin: true }), secret);
+		expect(await isRateLimitExempt(req(`Bearer ${token}`), secret)).toBe(true);
+	});
+
+	it('does not exempt a validly-signed non-staff token', async () => {
+		const token = await signAccessToken(payload(), secret);
+		expect(await isRateLimitExempt(req(`Bearer ${token}`), secret)).toBe(false);
+	});
+
+	it('does not exempt a forged admin token signed with the wrong secret', async () => {
+		// The bypass this guards against: a payload claiming isAdmin whose
+		// signature the server cannot validate. Verifying (not decoding) rejects it.
+		const forged = await signAccessToken(payload({ isAdmin: true }), wrongSecret);
+		expect(await isRateLimitExempt(req(`Bearer ${forged}`), secret)).toBe(false);
+	});
+
+	it('does not exempt a structurally malformed token', async () => {
+		expect(await isRateLimitExempt(req('Bearer not.a.jwt'), secret)).toBe(false);
+	});
+});

--- a/src/plugins/auth/rateLimitAllowList.ts
+++ b/src/plugins/auth/rateLimitAllowList.ts
@@ -1,0 +1,30 @@
+import type { FastifyRequest } from 'fastify';
+import { verifyAccessToken } from './jwt.js';
+
+/**
+ * Predicate for the global rate-limit `allowList`: returns true only for a
+ * request carrying a signature-verified access token belonging to an editor
+ * or admin, so trusted staff bypass throttling.
+ *
+ * The signature MUST be verified, not just decoded. Some rate-limited routes
+ * never run verifyJwt (e.g. POST /setup/admin, gated only by a body secret),
+ * so a forged "isAdmin: true" payload would otherwise skip the limiter and
+ * keep brute-forcing. Verifying here makes the exemption trustworthy on its
+ * own, regardless of whether the route later runs verifyJwt.
+ */
+export async function isRateLimitExempt(
+	request: Pick<FastifyRequest, 'headers'>,
+	secret: Uint8Array,
+): Promise<boolean> {
+	const auth = request.headers.authorization;
+
+	if (!auth?.startsWith('Bearer ')) return false;
+
+	try {
+		const payload = await verifyAccessToken(auth.substring(7), secret);
+
+		return payload.isEditor === true || payload.isAdmin === true;
+	} catch {
+		return false;
+	}
+}

--- a/src/plugins/setup/setup.ts
+++ b/src/plugins/setup/setup.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import bcrypt from 'bcryptjs';
 import { hasZodFastifySchemaValidationErrors } from 'fastify-type-provider-zod';
@@ -16,6 +17,12 @@ import {
 } from './queries.js';
 
 const BCRYPT_COST = 10;
+
+// Constant-time comparison of the setup secret. Both sides are hashed to
+// equal-length digests first so timingSafeEqual never throws on a length
+// mismatch and the comparison leaks neither the value nor its length.
+const secretsMatch = (a: string, b: string): boolean =>
+  timingSafeEqual(createHash('sha256').update(a).digest(), createHash('sha256').update(b).digest());
 
 export async function setupPlugin(fastify: FastifyInstance) {
   fastify.setErrorHandler((err, _request, reply) => {
@@ -74,7 +81,7 @@ export async function setupPlugin(fastify: FastifyInstance) {
         return reply.code(409).send({ error: 'already_initialized' as const });
       }
 
-      if (request.body.secret !== expected) {
+      if (!secretsMatch(request.body.secret, expected)) {
         request.log.warn('setup: secret mismatch');
         return reply.code(401).send({ error: 'wrong_secret' as const });
       }


### PR DESCRIPTION
Auth-surface hardening. Groups several related fixes; none change the public wire contract (error codes unchanged).

## Changes

**1. Rate-limit the auth surface.** Limits were opt-in (`global: false`) and only comments/setup opted in, leaving `login`, `refresh`, `register`, `activate`, `resend-activation`, `request-password-reset`, `reset-password` unthrottled — password brute-force on `/login` and email-send abuse on the mail-sending routes. Per-IP limits added (in-memory store; verified staff bypass via the allowList).

**2. Verify the JWT signature in the rate-limit allowList.** Previously the allowList *decoded* the token without verifying the signature; the safety argument ("a forged token fails `verifyJwt` later") only holds for routes that run `verifyJwt`. `POST /setup/admin` doesn't — it's gated by a body secret — so a forged `{"isAdmin":true}` token stripped the only throttle on brute-forcing `INITIAL_ADMIN_PASSWORD`. Now the signature is verified, so the exemption is trustworthy on its own. Extracted to `isRateLimitExempt()` (`src/plugins/auth/rateLimitAllowList.ts`) with unit tests, including the forged-token case.

**3. `trustProxy: 1`.** `@fastify/rate-limit` keys by `request.ip`, but with no `trustProxy` set and the API behind nginx (`proxy_pass` from 127.0.0.1), every request shared one bucket — the limits above would have been global, not per-IP. `1` (not `true`) so a client can't spoof `X-Forwarded-For` to evade the limit. Also corrects the pre-existing comment/setup limits.

**4. `request-password-reset` account-existence leak.** The notifier call had no inner try/catch (unlike register / resend-activation), so an SMTP failure returned 500 only for *existing* emails — an enumeration oracle. Now swallowed and logged, preserving the uniform response.

**5. Constant-time setup-secret compare.** `setup/admin` compared the secret with `!==`; now a hashed constant-time compare (`timingSafeEqual`).

**6. Normalize the 429 body** to `{ error: 'rate_limited', message: <English>, ... }`, matching poetry-api's English-message + machine-`error`-code convention. Verified the clients (nextjs `CommentForm`, nextjs `setup/actions`, old2 `initialization.php`) already localize from the `rate_limited` code, so no UX change.

## Verification

`tsc` + `eslint` clean. **290 tests pass** (7 new in `rateLimitAllowList.test.ts` covering valid editor/admin exemption, non-staff rejection, and the forged / malformed-token rejection).