### PR TITLE
fix(deps): clear runtime security advisories (nodemailer, @fastify/static, fast-uri)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@fastify/mysql": "^5.0.2",
 				"@fastify/rate-limit": "^10.3.0",
 				"@fastify/swagger": "^9.7.0",
-				"@fastify/swagger-ui": "^5.2.5",
+				"@fastify/swagger-ui": "^6.0.0",
 				"@simplewebauthn/server": "^13.3.0",
 				"bcryptjs": "^3.0.3",
 				"fastify": "^5.8.4",
@@ -21,7 +21,7 @@
 				"fastify-type-provider-zod": "^6.1.0",
 				"jose": "^6.2.2",
 				"meilisearch": "^0.57.0",
-				"nodemailer": "^8.0.5",
+				"nodemailer": "^9.0.3",
 				"pino-pretty": "^13.1.3",
 				"zod": "^4.3.6"
 			},
@@ -896,9 +896,9 @@
 			}
 		},
 		"node_modules/@fastify/static": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.0.tgz",
-			"integrity": "sha512-EPRNQYqEYEYTK8yyGbcM0iHpyJaupb94bey5O6iCQfLTADr02kaZU+qeHSdd9H9TiMwTBVkrMa59V8CMbn3avQ==",
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+			"integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -943,9 +943,9 @@
 			}
 		},
 		"node_modules/@fastify/swagger-ui": {
-			"version": "5.2.6",
-			"resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-5.2.6.tgz",
-			"integrity": "sha512-OMnms0O5s9wb6wis/K5nlrAMLsgUbr1GA8uphM41IasWe3AFdgxz6r/3bA9HTxlDNUYc2FGGKeqMp3ntxmSiNA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-6.0.0.tgz",
+			"integrity": "sha512-L9c4CbXj3FnquqpCmn0IfbEeIqDUNi6QwXd23VhQj/bHEjNzDFIAy2W9I3prvSqM+mJWOElIa6uXROmcMDnfUA==",
 			"funding": [
 				{
 					"type": "github",
@@ -2948,9 +2948,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -4115,9 +4115,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
 			"funding": [
 				{
 					"type": "github",
@@ -5501,9 +5501,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -5807,9 +5807,9 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-			"integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+			"integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@fastify/mysql": "^5.0.2",
 		"@fastify/rate-limit": "^10.3.0",
 		"@fastify/swagger": "^9.7.0",
-		"@fastify/swagger-ui": "^5.2.5",
+		"@fastify/swagger-ui": "^6.0.0",
 		"@simplewebauthn/server": "^13.3.0",
 		"bcryptjs": "^3.0.3",
 		"fastify": "^5.8.4",
@@ -26,14 +26,9 @@
 		"fastify-type-provider-zod": "^6.1.0",
 		"jose": "^6.2.2",
 		"meilisearch": "^0.57.0",
-		"nodemailer": "^8.0.5",
+		"nodemailer": "^9.0.3",
 		"pino-pretty": "^13.1.3",
 		"zod": "^4.3.6"
-	},
-	"overrides": {
-		"@fastify/swagger-ui": {
-			"@fastify/static": "9.1.0"
-		}
 	},
 	"devDependencies": {
 		"@semantic-release/commit-analyzer": "^13.0.1",


### PR DESCRIPTION
Clears every **production-dependency** security advisory. `npm audit --omit=dev` goes from several highs/moderates to **0 vulnerabilities**.

## Changes
| Dep | Change | Advisory |
|---|---|---|
| `nodemailer` | 8 → **9.0.3** | HIGH — CRLF header injection (recipients are user-controlled addresses) + jsonTransport file-access bypass, OAuth2 TLS validation, raw-option file-read/SSRF |
| `@fastify/swagger-ui` | 5 → **6.0.0** | moderate — the `overrides` block pinned a vulnerable `@fastify/static` 9.1.0 (path traversal + route-guard bypass); v6 pulls a patched `@fastify/static`, so the override is removed |
| `fast-uri` | → **3.1.3** (transitive) | HIGH — path traversal / host confusion |
| `brace-expansion` | → **5.0.7** (transitive) | moderate — DoS |

## Verification
- `tsc` + `eslint` clean; **290 tests pass**.
- `/docs` verified serving under swagger-ui 6 (isolated harness: 200 on the UI page, `/docs/json`, and `/docs/static/*` assets).
- nodemailer usage is basic `createTransport` / `sendMail` (`src/lib/email.ts`) — unaffected by the v9 major.
- **`npm audit --omit=dev` → 0 vulnerabilities.**

## Out of scope (follow-ups)
Remaining audit findings are all **dev/CI/test-only** and not runtime-exploitable: the semantic-release chain (CI, needs a major bump), vitest→vite/esbuild (Windows-only, dev), and npm’s own bundled picomatch. The non-security majors (`@fastify/rate-limit` 11, `fastify-type-provider-zod` 7) are deferred — they touch rate-limit config and route validation and warrant their own PR.