### PR TITLE
feat(cms): editingDone attestation on things — wire contract, stamping, logging

### DIFF
--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -524,6 +524,75 @@ describe('POST /cms/things — date format', () => {
 	});
 });
 
+describe('PUT /cms/things/:thingId — editingDone semantics', () => {
+	const thingRow = (editingDoneAt: string | null, lastModified: string | null) => ({
+		id: 7, title: 'T', text: 'body', categoryId: 1, statusId: 2,
+		startDate: null, finishDate: '2026-01-01', firstLines: null,
+		firstLinesAutoGenerating: 0, excludeFromDaily: 0,
+		editingDoneAt, lastModified,
+		seoDescription: null, seoKeywords: null, info: null,
+	});
+
+	function createRecordingMysql(...responses: Record<string, unknown>[][]) {
+		let callIndex = 0;
+		const calls: { sql: string; params: unknown[] }[] = [];
+		const pool = {
+			getConnection: vi.fn().mockImplementation(() =>
+				Promise.resolve({
+					query: vi.fn().mockImplementation((sql: string, params?: unknown[]) => {
+						calls.push({ sql, params: params ?? [] });
+						return Promise.resolve([responses[callIndex++] ?? []]);
+					}),
+					beginTransaction: vi.fn().mockResolvedValue(undefined),
+					commit: vi.fn().mockResolvedValue(undefined),
+					rollback: vi.fn().mockResolvedValue(undefined),
+					release: vi.fn(),
+				})
+			),
+		} as unknown as MySQLPromisePool;
+		return { pool, calls };
+	}
+
+	const putThing = async (body: Record<string, unknown>, current = thingRow(null, '2026-07-01T10:00:00'), updated = thingRow('2026-07-05T12:00:00', '2026-07-05T12:00:00')) => {
+		const { pool, calls } = createRecordingMysql(
+			[current], [],        // getCmsThing (current) + notes
+			[],                    // updateThingQuery
+			[updated], [],         // getCmsThing (refetch) + notes
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+		const res = await app.inject({
+			method: 'PUT', url: '/cms/things/7',
+			headers: { authorization: `Bearer ${token}` },
+			payload: body,
+		});
+		return { res, calls };
+	};
+
+	it('editingDone: true binds the stamp param 1 and returns the stamped thing', async () => {
+		const { res, calls } = await putThing({ editingDone: true });
+		expect(res.statusCode).toBe(200);
+		const update = calls.find((c) => c.sql.includes('UPDATE thing SET'));
+		expect(update!.params[9]).toBe(1); // tri-state param after the 9 field bindings
+		const body = res.json();
+		expect(body.editingDoneAt).toBe('2026-07-05T12:00:00');
+		expect(body.lastModified).toBe('2026-07-05T12:00:00');
+		expect(body.editingDoneAt).toBe(body.lastModified);
+	});
+
+	it('editingDone: false binds -1 (clear)', async () => {
+		const { calls } = await putThing({ editingDone: false }, thingRow('2026-07-01T10:00:00', '2026-07-01T10:00:00'), thingRow(null, '2026-07-05T12:00:00'));
+		const update = calls.find((c) => c.sql.includes('UPDATE thing SET'));
+		expect(update!.params[9]).toBe(-1);
+	});
+
+	it('editingDone omitted binds 0 (leave untouched)', async () => {
+		const { calls } = await putThing({ text: 'new body' });
+		const update = calls.find((c) => c.sql.includes('UPDATE thing SET'));
+		expect(update!.params[9]).toBe(0);
+	});
+});
+
 // --- User management ---
 
 const userRow = {

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -276,6 +276,8 @@ export interface CmsThingItem {
 	thingId: number;
 	title: string | null;
 	firstLines: string[] | null;
+	editingDoneAt: string | null;
+	lastModified: string | null;
 }
 
 export interface CmsSectionThing extends CmsThingItem {
@@ -288,6 +290,8 @@ const mapCmsThingRow = (row: MySQLRowDataPacket): CmsThingItem => ({
 	firstLines: row.firstLines
 		? splitLines(row.firstLines as string)
 		: null,
+	editingDoneAt: (row.editingDoneAt as string) ?? null,
+	lastModified: (row.lastModified as string) ?? null,
 });
 
 const mapCmsSectionThingRow = (row: MySQLRowDataPacket): CmsSectionThing => ({
@@ -424,6 +428,8 @@ export interface CmsThing {
 	firstLines: string | null;
 	firstLinesAutoGenerating: boolean;
 	excludeFromDaily: boolean;
+	editingDoneAt: string | null;
+	lastModified: string | null;
 	notes: CmsThingNote[];
 	seoDescription: string | null;
 	seoKeywords: string | null;
@@ -464,6 +470,8 @@ export const getCmsThing = async (mysql: MySQLPromisePool, thingId: number): Pro
 			firstLines: (row.firstLines as string) ?? null,
 			firstLinesAutoGenerating: Boolean(row.firstLinesAutoGenerating),
 			excludeFromDaily: Boolean(row.excludeFromDaily),
+			editingDoneAt: (row.editingDoneAt as string) ?? null,
+			lastModified: (row.lastModified as string) ?? null,
 			notes: noteRows.map((n) => ({ id: n.id as number, text: n.text as string })),
 			seoDescription: (row.seoDescription as string) ?? null,
 			seoKeywords: (row.seoKeywords as string) ?? null,
@@ -477,6 +485,7 @@ export const createThing = async (
 		title: string | null; text: string; categoryId: number; statusId: number;
 		startDate: string | null; finishDate: string;
 		firstLines: string | null; firstLinesAutoGenerating: boolean; excludeFromDaily: boolean;
+		editingDone: boolean;
 		notes: { text: string }[];
 		seoDescription: string | null; seoKeywords: string | null; info: string | null;
 	},
@@ -489,6 +498,7 @@ export const createThing = async (
 				data.startDate ? isoDateToDb(data.startDate) : null,
 				isoDateToDb(data.finishDate),
 				data.firstLines, data.firstLinesAutoGenerating ? 1 : 0, data.excludeFromDaily ? 1 : 0,
+				data.editingDone ? 1 : 0,
 			]);
 			const thingId = result.insertId;
 
@@ -519,6 +529,7 @@ export const updateThing = async (
 		title?: string | null; text?: string; categoryId?: number; statusId?: number;
 		startDate?: string | null; finishDate?: string;
 		firstLines?: string | null; firstLinesAutoGenerating?: boolean; excludeFromDaily?: boolean;
+		editingDone?: boolean;
 		notes?: { id?: number; text: string }[];
 		seoDescription?: string | null; seoKeywords?: string | null; info?: string | null;
 	},
@@ -539,6 +550,7 @@ export const updateThing = async (
 				data.firstLines !== undefined ? data.firstLines : current.firstLines,
 				(data.firstLinesAutoGenerating ?? current.firstLinesAutoGenerating) ? 1 : 0,
 				(data.excludeFromDaily ?? current.excludeFromDaily) ? 1 : 0,
+				data.editingDone === undefined ? 0 : data.editingDone ? 1 : -1,
 				thingId,
 			]);
 

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -102,7 +102,9 @@ export const cmsSectionThingsQuery = `
 		ti.r_thing_id                  AS thingId,
 		ti.thing_position_in_section   AS position,
 		t.title,
-		t.first_lines                  AS firstLines
+		t.first_lines                  AS firstLines,
+		DATE_FORMAT(t.last_modified, '%Y-%m-%dT%H:%i:%s')   AS lastModified,
+		DATE_FORMAT(t.editing_done_at, '%Y-%m-%dT%H:%i:%s') AS editingDoneAt
 	FROM thing_identifier ti
 	JOIN thing t ON ti.r_thing_id = t.id
 	WHERE ti.r_section_id = ?
@@ -143,7 +145,9 @@ export const allThingsQuery = `
 	SELECT
 		t.id          AS thingId,
 		t.title,
-		t.first_lines AS firstLines
+		t.first_lines AS firstLines,
+		DATE_FORMAT(t.last_modified, '%Y-%m-%dT%H:%i:%s')   AS lastModified,
+		DATE_FORMAT(t.editing_done_at, '%Y-%m-%dT%H:%i:%s') AS editingDoneAt
 	FROM thing t
 	ORDER BY t.id DESC;
 `;
@@ -199,6 +203,8 @@ export const cmsThingByIdQuery = `
 		t.first_lines                  AS firstLines,
 		t.first_lines_auto_generating  AS firstLinesAutoGenerating,
 		t.exclude_from_daily           AS excludeFromDaily,
+		DATE_FORMAT(t.last_modified, '%Y-%m-%dT%H:%i:%s')   AS lastModified,
+		DATE_FORMAT(t.editing_done_at, '%Y-%m-%dT%H:%i:%s') AS editingDoneAt,
 		ts.description                 AS seoDescription,
 		ts.keywords                    AS seoKeywords,
 		ti.text                        AS info
@@ -214,8 +220,8 @@ export const thingNotesQuery = `
 
 export const createThingQuery = `
 	INSERT INTO thing (title, text, r_thing_category_id, r_thing_status_id, start_date, finish_date,
-		first_lines, first_lines_auto_generating, exclude_from_daily, last_modified)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
+		first_lines, first_lines_auto_generating, exclude_from_daily, last_modified, editing_done_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), IF(?, NOW(), NULL));
 `;
 
 export const updateThingQuery = `
@@ -223,6 +229,7 @@ export const updateThingQuery = `
 		title = ?, text = ?, r_thing_category_id = ?, r_thing_status_id = ?,
 		start_date = ?, finish_date = ?,
 		first_lines = ?, first_lines_auto_generating = ?, exclude_from_daily = ?,
+		editing_done_at = CASE ? WHEN 1 THEN NOW() WHEN -1 THEN NULL ELSE editing_done_at END,
 		last_modified = NOW()
 	WHERE id = ?;
 `;

--- a/src/plugins/cms/schemas.test.ts
+++ b/src/plugins/cms/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	cmsThingResponse,
 	createSectionRequest,
 	createThingRequest,
 	updateAuthorRequest,
@@ -124,5 +125,34 @@ describe('createSectionRequest / updateSectionRequest normalization', () => {
 	it('updateSectionRequest normalizes optional fields', () => {
 		const parsed = updateSectionRequest.parse({ title: 'A -- B' });
 		expect(parsed.title).toBe('A – B');
+	});
+});
+
+describe('editingDone wire fields', () => {
+	it('createThingRequest defaults editingDone to false', () => {
+		const parsed = createThingRequest.parse({ text: 'x', categoryId: 1, finishDate: '2026-01-01' });
+		expect(parsed.editingDone).toBe(false);
+	});
+
+	it('updateThingRequest keeps editingDone undefined when omitted', () => {
+		const parsed = updateThingRequest.parse({});
+		expect(parsed.editingDone).toBeUndefined();
+	});
+
+	it('updateThingRequest accepts editingDone true/false', () => {
+		expect(updateThingRequest.parse({ editingDone: true }).editingDone).toBe(true);
+		expect(updateThingRequest.parse({ editingDone: false }).editingDone).toBe(false);
+	});
+
+	it('cmsThingResponse requires nullable editingDoneAt and lastModified', () => {
+		const base = {
+			id: 1, title: null, text: 't', categoryId: 1, statusId: 1,
+			startDate: null, finishDate: '2026-01-01', firstLines: null,
+			firstLinesAutoGenerating: false, excludeFromDaily: false,
+			notes: [], seoDescription: null, seoKeywords: null, info: null,
+		};
+		expect(() => cmsThingResponse.parse(base)).toThrow();
+		expect(cmsThingResponse.parse({ ...base, editingDoneAt: null, lastModified: null }).editingDoneAt).toBeNull();
+		expect(cmsThingResponse.parse({ ...base, editingDoneAt: '2026-07-05T10:00:00', lastModified: '2026-07-05T10:00:00' }).editingDoneAt).toBe('2026-07-05T10:00:00');
 	});
 });

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -91,6 +91,8 @@ export const cmsThingItem = z.object({
 	thingId: z.number().int(),
 	title: z.string().nullable(),
 	firstLines: z.array(z.string()).nullable(),
+	editingDoneAt: z.string().nullable(),
+	lastModified: z.string().nullable(),
 });
 
 export const cmsThingsResponse = z.array(cmsThingItem);
@@ -166,6 +168,8 @@ export const cmsThingResponse = z.object({
 	firstLines: z.string().nullable(),
 	firstLinesAutoGenerating: z.boolean(),
 	excludeFromDaily: z.boolean(),
+	editingDoneAt: z.string().nullable(),
+	lastModified: z.string().nullable(),
 	notes: z.array(z.object({ id: z.number().int(), text: z.string() })),
 	seoDescription: z.string().nullable(),
 	seoKeywords: z.string().nullable(),
@@ -186,6 +190,7 @@ export const createThingRequest = z.object({
 	firstLines: z.string().nullable().default(null).transform(norm),
 	firstLinesAutoGenerating: z.literal(false).default(false),
 	excludeFromDaily: z.boolean().default(false),
+	editingDone: z.boolean().default(false),
 	notes: z.array(thingNoteItem).default([]),
 	seoDescription: z.string().nullable().default(null),
 	seoKeywords: z.string().nullable().default(null),
@@ -202,6 +207,7 @@ export const updateThingRequest = z.object({
 	firstLines: z.string().nullable().optional().transform(norm),
 	firstLinesAutoGenerating: z.literal(false).optional(),
 	excludeFromDaily: z.boolean().optional(),
+	editingDone: z.boolean().optional(),
 	notes: z.array(thingNoteItem).optional(),
 	seoDescription: z.string().nullable().optional(),
 	seoKeywords: z.string().nullable().optional(),

--- a/src/plugins/cms/thingRoutes.ts
+++ b/src/plugins/cms/thingRoutes.ts
@@ -158,7 +158,7 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				const updated = await getCmsThing(fastify.mysql, request.params.thingId);
 
 				request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: request.params.thingId }, 'Thing updated');
-				if (request.body.editingDone !== undefined) {
+				if (request.body.editingDone !== undefined && (request.body.editingDone || current.editingDoneAt !== null)) {
 					request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: request.params.thingId, editingDone: request.body.editingDone }, 'Thing editorial-pass flag updated');
 				}
 				if (fastify.meiliClient) {
@@ -203,7 +203,7 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				}
 
 				await deleteThing(fastify.mysql, request.params.thingId);
-				request.log.info({ thingId: request.params.thingId }, 'Thing deleted');
+				request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: request.params.thingId }, 'Thing deleted');
 				if (fastify.meiliClient) {
 					deleteThingFromSearch(fastify.meiliClient, request.params.thingId, request.log)
 						.catch((err) => request.log.error(err, 'Meilisearch delete failed'));

--- a/src/plugins/cms/thingRoutes.ts
+++ b/src/plugins/cms/thingRoutes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { errorResponse } from '../../lib/schemas.js';
+import { actorFingerprint } from '../../lib/actorFingerprint.js';
 import { authErrorResponse } from '../auth/schemas.js';
 import {
 	getThingStatuses,
@@ -114,7 +115,10 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				const id = await createThing(fastify.mysql, request.body);
 				const thing = await getCmsThing(fastify.mysql, id);
 
-				request.log.info({ thingId: id }, 'Thing created');
+				request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: id }, 'Thing created');
+				if (request.body.editingDone) {
+					request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: id, editingDone: true }, 'Thing editorial-pass flag set');
+				}
 				if (fastify.meiliClient) {
 					syncThingToSearch(fastify.meiliClient, fastify.mysql, id, request.log)
 						.catch((err) => request.log.error(err, 'Meilisearch sync failed'));
@@ -153,7 +157,10 @@ export async function thingRoutes(fastify: FastifyInstance) {
 				await updateThing(fastify.mysql, request.params.thingId, request.body, current);
 				const updated = await getCmsThing(fastify.mysql, request.params.thingId);
 
-				request.log.info({ thingId: request.params.thingId }, 'Thing updated');
+				request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: request.params.thingId }, 'Thing updated');
+				if (request.body.editingDone !== undefined) {
+					request.log.info({ actorFingerprint: actorFingerprint(request.user!.sub), thingId: request.params.thingId, editingDone: request.body.editingDone }, 'Thing editorial-pass flag updated');
+				}
 				if (fastify.meiliClient) {
 					syncThingToSearch(fastify.meiliClient, fastify.mysql, request.params.thingId, request.log)
 						.catch((err) => request.log.error(err, 'Meilisearch sync failed'));


### PR DESCRIPTION
Closes #162. Tracking issue: mellonis/poetry#27. Depends on mellonis/poetry-old2#108 (column must exist in prod before deploy).

## What

CMS-only wire contract for the per-thing editorial-pass stamp (`thing.editing_done_at`):

- **Schemas**: `cmsThingResponse` + `cmsThingItem` gain `editingDoneAt`/`lastModified` (required, nullable strings); `createThingRequest` gains `editingDone` (default false); `updateThingRequest` gains optional `editingDone` — omitted means "leave the stored stamp untouched", which is what makes an unattested content edit go stale naturally.
- **Queries**: detail/all-things/section-things SELECTs expose both columns via `DATE_FORMAT('%Y-%m-%dT%H:%i:%s')` (identical format ⇒ wire string equality === DB datetime equality). INSERT stamps via `IF(?, NOW(), NULL)`; UPDATE via tri-state `CASE ? WHEN 1 THEN NOW() WHEN -1 THEN NULL ELSE editing_done_at END` in the same statement as `last_modified = NOW()` — statement-constant `NOW()` guarantees exact equality with `last_modified`. Timestamps are server-derived only; clients send a boolean.
- **Logging**: thing create/update/delete logs now carry `actorFingerprint`; a dedicated line records actual flag state changes (no-op clears don't log).
- **Tests**: new `PUT /cms/things/:thingId` block with a recording mock asserting the tri-state param binding (1 / -1 / 0) and that the response carries `editingDoneAt === lastModified` after attesting. 297/297 green, lint + tsc clean.

Public endpoints untouched (CMS schemas are isolated; verified).

## Verification

End-to-end against real DDEV MySQL with the migrated schema: attest ⇒ response and DB show `editing_done_at = last_modified` exactly; content edit without the flag ⇒ stamp preserved, `last_modified` advanced (stale); `editingDone: false` ⇒ NULL; list endpoint carries both fields.

## Note for reviewers

Wire datetime strings are zone-less server-local time (like the DB's DATETIME values themselves). The nextjs side only compares them for equality/order and renders date-only text, so no TZ conversion is involved.
