### PR TITLE
CMS: review field (raw Markdown) on /cms/things

### DIFF
--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -33,6 +33,26 @@ function createMockMysql(...responses: Record<string, unknown>[][]): MySQLPromis
 	} as unknown as MySQLPromisePool;
 }
 
+function createRecordingMysql(...responses: Record<string, unknown>[][]) {
+	let callIndex = 0;
+	const calls: { sql: string; params: unknown[] }[] = [];
+	const pool = {
+		getConnection: vi.fn().mockImplementation(() =>
+			Promise.resolve({
+				query: vi.fn().mockImplementation((sql: string, params?: unknown[]) => {
+					calls.push({ sql, params: params ?? [] });
+					return Promise.resolve([responses[callIndex++] ?? []]);
+				}),
+				beginTransaction: vi.fn().mockResolvedValue(undefined),
+				commit: vi.fn().mockResolvedValue(undefined),
+				rollback: vi.fn().mockResolvedValue(undefined),
+				release: vi.fn(),
+			})
+		),
+	} as unknown as MySQLPromisePool;
+	return { pool, calls };
+}
+
 const mockNotifier = {
 	sendActivation: vi.fn().mockResolvedValue(undefined),
 	sendPasswordReset: vi.fn().mockResolvedValue(undefined),
@@ -562,26 +582,6 @@ describe('PUT /cms/things/:thingId — editingDone semantics', () => {
 		editingDoneAt, lastModified,
 		seoDescription: null, seoKeywords: null, info: null,
 	});
-
-	function createRecordingMysql(...responses: Record<string, unknown>[][]) {
-		let callIndex = 0;
-		const calls: { sql: string; params: unknown[] }[] = [];
-		const pool = {
-			getConnection: vi.fn().mockImplementation(() =>
-				Promise.resolve({
-					query: vi.fn().mockImplementation((sql: string, params?: unknown[]) => {
-						calls.push({ sql, params: params ?? [] });
-						return Promise.resolve([responses[callIndex++] ?? []]);
-					}),
-					beginTransaction: vi.fn().mockResolvedValue(undefined),
-					commit: vi.fn().mockResolvedValue(undefined),
-					rollback: vi.fn().mockResolvedValue(undefined),
-					release: vi.fn(),
-				})
-			),
-		} as unknown as MySQLPromisePool;
-		return { pool, calls };
-	}
 
 	const putThing = async (body: Record<string, unknown>, current = thingRow(null, '2026-07-01T10:00:00'), updated = thingRow('2026-07-05T12:00:00', '2026-07-05T12:00:00')) => {
 		const { pool, calls } = createRecordingMysql(
@@ -1114,5 +1114,147 @@ describe('GET /cms/things-of-the-day/calendar', () => {
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual({});
+	});
+});
+
+describe('CMS thing review persistence', () => {
+	const reviewRow = {
+		id: 99, title: null, text: 'Body', categoryId: 1, statusId: 1,
+		startDate: null, finishDate: '1990-05-12', firstLines: null,
+		firstLinesAutoGenerating: 0, excludeFromDaily: 0,
+		editingDoneAt: null, lastModified: null,
+		seoDescription: null, seoKeywords: null, info: null, review: null,
+	};
+
+	const md = 'Черновик: `код`, --- и -- остаются как есть';
+
+	it('POST with review upserts thing_review verbatim', async () => {
+		const { pool, calls } = createRecordingMysql(
+			[{ insertId: 99 }],                    // INSERT INTO thing
+			[],                                    // INSERT INTO thing_review
+			[{ ...reviewRow, review: md }], [],    // getCmsThing refetch + notes
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { title: null, text: 'Body', categoryId: 1, notes: [], finishDate: '1990-05-12', review: md },
+		});
+
+		expect(response.statusCode).toBe(201);
+		const reviewCall = calls.find((c) => c.sql.includes('INSERT INTO thing_review'));
+		expect(reviewCall).toBeDefined();
+		expect(reviewCall!.params[1]).toBe(md);
+		expect(response.json().review).toBe(md);
+	});
+
+	it('POST without review touches no thing_review row', async () => {
+		const { pool, calls } = createRecordingMysql(
+			[{ insertId: 99 }],
+			[reviewRow], [],
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/cms/things',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { title: null, text: 'Body', categoryId: 1, notes: [], finishDate: '1990-05-12' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		// Narrowed to the write forms: cmsThingByIdQuery's LEFT JOIN thing_review
+		// (exercised by the post-create refetch) would make a bare substring match
+		// true regardless of whether a write happened — reads don't touch rows.
+		expect(calls.some((c) => c.sql.includes('INSERT INTO thing_review'))).toBe(false);
+		expect(calls.some((c) => c.sql.includes('DELETE FROM thing_review'))).toBe(false);
+	});
+
+	const putThingReview = async (reviewInBody: Record<string, unknown>) => {
+		const { pool, calls } = createRecordingMysql(
+			[reviewRow], [],                       // getCmsThing (current) + notes
+			[],                                    // UPDATE thing
+			[],                                    // thing_review upsert or delete
+			[{ ...reviewRow, review: md }], [],    // getCmsThing refetch + notes
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/things/99',
+			headers: { authorization: `Bearer ${token}` },
+			payload: reviewInBody,
+		});
+
+		return { response, calls };
+	};
+
+	it('PUT with review string upserts verbatim', async () => {
+		const { response, calls } = await putThingReview({ review: md });
+		expect(response.statusCode).toBe(200);
+		const call = calls.find((c) => c.sql.includes('INSERT INTO thing_review'));
+		expect(call).toBeDefined();
+		expect(call!.params[1]).toBe(md);
+	});
+
+	it('PUT with review: null deletes the row', async () => {
+		const { response, calls } = await putThingReview({ review: null });
+		expect(response.statusCode).toBe(200);
+		expect(calls.some((c) => c.sql.includes('DELETE FROM thing_review'))).toBe(true);
+	});
+
+	it('PUT with whitespace-only review deletes the row', async () => {
+		const { response, calls } = await putThingReview({ review: ' \n ' });
+		expect(response.statusCode).toBe(200);
+		expect(calls.some((c) => c.sql.includes('DELETE FROM thing_review'))).toBe(true);
+		expect(calls.some((c) => c.sql.includes('INSERT INTO thing_review'))).toBe(false);
+	});
+
+	it('PUT omitting review leaves the row untouched', async () => {
+		// Own mock, not the shared putThingReview helper: when review is omitted
+		// no thing_review query fires, so the helper's 6-slot response array
+		// (sized for the review-op tests) would shift and misfeed the refetch.
+		const { pool, calls } = createRecordingMysql(
+			[reviewRow], [],   // getCmsThing (current) + notes
+			[],                // UPDATE thing — omitted review fires no query
+			[reviewRow], [],   // getCmsThing refetch + notes (review still null — untouched)
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'PUT',
+			url: '/cms/things/99',
+			headers: { authorization: `Bearer ${token}` },
+			payload: { title: 'Новое название' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(calls.some((c) => c.sql.includes('INSERT INTO thing_review'))).toBe(false);
+		expect(calls.some((c) => c.sql.includes('DELETE FROM thing_review'))).toBe(false);
+	});
+
+	it('DELETE thing clears its review row', async () => {
+		const { pool, calls } = createRecordingMysql(
+			[reviewRow], [],   // getCmsThing (current) + notes
+			[{ cnt: 0 }],      // sections count
+			[], [], [], [], [], // deleteThing txn: notes, seo, info, review, thing
+		);
+		const app = await buildApp(pool);
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: '/cms/things/99',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(204);
+		expect(calls.some((c) => c.sql.includes('DELETE FROM thing_review'))).toBe(true);
 	});
 });

--- a/src/plugins/cms/cms.test.ts
+++ b/src/plugins/cms/cms.test.ts
@@ -427,6 +427,36 @@ describe('GET /cms/things/:thingId — date format', () => {
 	});
 });
 
+describe('GET /cms/things/:thingId — review field', () => {
+	it('returns stored review text verbatim', async () => {
+		const app = await buildApp(createMockMysql([{ ...thingRow, review: 'Ранний **черновик** с `кодом`' }], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().review).toBe('Ранний **черновик** с `кодом`');
+	});
+
+	it('returns null when no review row exists', async () => {
+		const app = await buildApp(createMockMysql([thingRow], []));
+		const token = await getEditorToken();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/cms/things/42',
+			headers: { authorization: `Bearer ${token}` },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().review).toBeNull();
+	});
+});
+
 describe('POST /cms/things — date format', () => {
 	const basePayload = {
 		title: null,

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -434,6 +434,7 @@ export interface CmsThing {
 	seoDescription: string | null;
 	seoKeywords: string | null;
 	info: string | null;
+	review: string | null;
 }
 
 export const getThingStatuses = async (mysql: MySQLPromisePool): Promise<SectionType[]> =>
@@ -476,6 +477,7 @@ export const getCmsThing = async (mysql: MySQLPromisePool, thingId: number): Pro
 			seoDescription: (row.seoDescription as string) ?? null,
 			seoKeywords: (row.seoKeywords as string) ?? null,
 			info: (row.info as string) ?? null,
+			review: (row.review as string) ?? null,
 		};
 	});
 

--- a/src/plugins/cms/databaseHelpers.ts
+++ b/src/plugins/cms/databaseHelpers.ts
@@ -39,6 +39,8 @@ import {
 	deleteThingSeoQuery,
 	upsertThingInfoQuery,
 	deleteThingInfoQuery,
+	upsertThingReviewQuery,
+	deleteThingReviewQuery,
 	insertThingNoteQuery,
 	updateThingNoteQuery,
 	deleteThingNotesExceptQuery,
@@ -489,7 +491,7 @@ export const createThing = async (
 		firstLines: string | null; firstLinesAutoGenerating: boolean; excludeFromDaily: boolean;
 		editingDone: boolean;
 		notes: { text: string }[];
-		seoDescription: string | null; seoKeywords: string | null; info: string | null;
+		seoDescription: string | null; seoKeywords: string | null; info: string | null; review: string | null;
 	},
 ): Promise<number> =>
 	withConnection(mysql, async (connection) => {
@@ -510,6 +512,10 @@ export const createThing = async (
 
 			if (data.info) {
 				await connection.query(upsertThingInfoQuery, [thingId, data.info]);
+			}
+
+			if (data.review) {
+				await connection.query(upsertThingReviewQuery, [thingId, data.review]);
 			}
 
 			for (let i = 0; i < data.notes.length; i++) {
@@ -533,7 +539,7 @@ export const updateThing = async (
 		firstLines?: string | null; firstLinesAutoGenerating?: boolean; excludeFromDaily?: boolean;
 		editingDone?: boolean;
 		notes?: { id?: number; text: string }[];
-		seoDescription?: string | null; seoKeywords?: string | null; info?: string | null;
+		seoDescription?: string | null; seoKeywords?: string | null; info?: string | null; review?: string | null;
 	},
 	current: CmsThing,
 ): Promise<void> =>
@@ -577,6 +583,15 @@ export const updateThing = async (
 				}
 			}
 
+			// Review upsert/delete (raw Markdown; empty = cleared)
+			if (data.review !== undefined) {
+				if (data.review) {
+					await connection.query(upsertThingReviewQuery, [thingId, data.review]);
+				} else {
+					await connection.query(deleteThingReviewQuery, [thingId]);
+				}
+			}
+
 			// Notes sync (array position = order)
 			if (data.notes !== undefined) {
 				const keepIds = data.notes.filter((n) => n.id).map((n) => n.id as number);
@@ -614,6 +629,7 @@ export const deleteThing = async (mysql: MySQLPromisePool, thingId: number): Pro
 			await connection.query(deleteAllThingNotesQuery, [thingId]);
 			await connection.query(deleteThingSeoQuery, [thingId]);
 			await connection.query(deleteThingInfoQuery, [thingId]);
+			await connection.query(deleteThingReviewQuery, [thingId]);
 			await connection.query(deleteThingQuery, [thingId]);
 			await connection.commit();
 		} catch (error) {

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -207,10 +207,12 @@ export const cmsThingByIdQuery = `
 		DATE_FORMAT(t.editing_done_at, '%Y-%m-%dT%H:%i:%s') AS editingDoneAt,
 		ts.description                 AS seoDescription,
 		ts.keywords                    AS seoKeywords,
-		ti.text                        AS info
+		ti.text                        AS info,
+		tr.text                        AS review
 	FROM thing t
 	LEFT JOIN thing_seo ts ON ts.r_thing_id = t.id
 	LEFT JOIN thing_info ti ON ti.r_thing_id = t.id
+	LEFT JOIN thing_review tr ON tr.r_thing_id = t.id
 	WHERE t.id = ?;
 `;
 

--- a/src/plugins/cms/queries.ts
+++ b/src/plugins/cms/queries.ts
@@ -264,6 +264,16 @@ export const deleteThingInfoQuery = `
 	DELETE FROM thing_info WHERE r_thing_id = ?;
 `;
 
+export const upsertThingReviewQuery = `
+	INSERT INTO thing_review (r_thing_id, text)
+	VALUES (?, ?)
+	ON DUPLICATE KEY UPDATE text = VALUES(text);
+`;
+
+export const deleteThingReviewQuery = `
+	DELETE FROM thing_review WHERE r_thing_id = ?;
+`;
+
 export const insertThingNoteQuery = `
 	INSERT INTO thing_note (r_thing_id, text, \`order\`) VALUES (?, ?, ?);
 `;

--- a/src/plugins/cms/schemas.test.ts
+++ b/src/plugins/cms/schemas.test.ts
@@ -73,6 +73,38 @@ describe('updateThingRequest normalization', () => {
 	});
 });
 
+describe('review field — raw Markdown, no normalization', () => {
+	it('create: stores review verbatim (backticks, ---, -- untouched)', () => {
+		const parsed = createThingRequest.parse({
+			text: 'Body',
+			categoryId: 1,
+			finishDate: '1990',
+			review: 'Черновик: `код`, --- и -- остаются как есть',
+		});
+		expect(parsed.review).toBe('Черновик: `код`, --- и -- остаются как есть');
+	});
+
+	it('create: defaults to null when omitted', () => {
+		const parsed = createThingRequest.parse({ text: 'Body', categoryId: 1, finishDate: '1990' });
+		expect(parsed.review).toBeNull();
+	});
+
+	it('create: whitespace-only becomes null', () => {
+		const parsed = createThingRequest.parse({ text: 'Body', categoryId: 1, finishDate: '1990', review: ' \n\t ' });
+		expect(parsed.review).toBeNull();
+	});
+
+	it('update: stays undefined when omitted', () => {
+		const parsed = updateThingRequest.parse({});
+		expect(parsed.review).toBeUndefined();
+	});
+
+	it('update: empty string becomes null', () => {
+		const parsed = updateThingRequest.parse({ review: '' });
+		expect(parsed.review).toBeNull();
+	});
+});
+
 describe('updateAuthorRequest normalization', () => {
 	it('normalizes text', () => {
 		const parsed = updateAuthorRequest.parse({
@@ -149,7 +181,7 @@ describe('editingDone wire fields', () => {
 			id: 1, title: null, text: 't', categoryId: 1, statusId: 1,
 			startDate: null, finishDate: '2026-01-01', firstLines: null,
 			firstLinesAutoGenerating: false, excludeFromDaily: false,
-			notes: [], seoDescription: null, seoKeywords: null, info: null,
+			notes: [], seoDescription: null, seoKeywords: null, info: null, review: null,
 		};
 		expect(() => cmsThingResponse.parse(base)).toThrow();
 		expect(cmsThingResponse.parse({ ...base, editingDoneAt: null, lastModified: null }).editingDoneAt).toBeNull();

--- a/src/plugins/cms/schemas.test.ts
+++ b/src/plugins/cms/schemas.test.ts
@@ -94,6 +94,11 @@ describe('review field — raw Markdown, no normalization', () => {
 		expect(parsed.review).toBeNull();
 	});
 
+	it('create: preserves surrounding whitespace on non-empty content', () => {
+		const parsed = createThingRequest.parse({ text: 'Body', categoryId: 1, finishDate: '1990', review: ' с пробелами ' });
+		expect(parsed.review).toBe(' с пробелами ');
+	});
+
 	it('update: stays undefined when omitted', () => {
 		const parsed = updateThingRequest.parse({});
 		expect(parsed.review).toBeUndefined();

--- a/src/plugins/cms/schemas.ts
+++ b/src/plugins/cms/schemas.ts
@@ -12,6 +12,12 @@ const norm = <T extends string | null | undefined>(v: T): T =>
 const normInfo = <T extends string | null | undefined>(v: T): T =>
 	typeof v === 'string' ? (normalizeLegacyInfoJson(v) as T) : v;
 
+// Review is raw Markdown — exempt from legacy normalization (backtick / --- /
+// -- carry Markdown syntax there). Whitespace-only means "cleared": the row
+// is deleted, so it must arrive as null, not as a blank string.
+const emptyToNull = <T extends string | null | undefined>(v: T): T | null =>
+	typeof v === 'string' && v.trim() === '' ? null : v;
+
 // --- Section types reference ---
 
 export const sectionTypeItem = z.object({
@@ -174,6 +180,7 @@ export const cmsThingResponse = z.object({
 	seoDescription: z.string().nullable(),
 	seoKeywords: z.string().nullable(),
 	info: z.string().nullable(),
+	review: z.string().nullable(),
 });
 
 export const thingIdParam = z.object({
@@ -195,6 +202,7 @@ export const createThingRequest = z.object({
 	seoDescription: z.string().nullable().default(null),
 	seoKeywords: z.string().nullable().default(null),
 	info: z.string().nullable().default(null).transform(normInfo),
+	review: z.string().nullable().default(null).transform(emptyToNull),
 }).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 export const updateThingRequest = z.object({
@@ -212,6 +220,7 @@ export const updateThingRequest = z.object({
 	seoDescription: z.string().nullable().optional(),
 	seoKeywords: z.string().nullable().optional(),
 	info: z.string().nullable().optional().transform(normInfo),
+	review: z.string().nullable().optional().transform(emptyToNull),
 }).refine(seoFieldsTogether, seoFieldsTogetherMessage);
 
 // --- Things-of-the-day calendar ---


### PR DESCRIPTION
Closes #170. Part of mellonis/poetry#29. Requires the `thing_review` migration (poetry-old2) applied before deploy.

Nullable `review` on the CMS thing detail + create/update, mirroring `info`: LEFT JOIN in the detail query, upsert when truthy, row deleted when cleared (null/empty/whitespace — `emptyToNull` Zod transform), explicit delete in the `deleteThing` transaction. **Raw Markdown — deliberately no `normalizeLegacyText`** (its rewrites collide with Markdown syntax; see the design decision on mellonis/poetry#29). Not exposed publicly, not indexed in Meilisearch.