### PR TITLE
Update dependencies to latest (in-range + safe majors)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
 				"fastify-plugin": "^6.0.0",
 				"fastify-type-provider-zod": "^7.0.0",
 				"jose": "^6.2.3",
-				"meilisearch": "^0.58.0",
+				"meilisearch": "^0.60.0",
 				"nodemailer": "^9.0.3",
 				"pino-pretty": "^13.1.3",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@semantic-release/commit-analyzer": "^13.0.1",
-				"@semantic-release/git": "^10.0.1",
+				"@semantic-release/git": "^11.0.1",
 				"@semantic-release/github": "^12.0.9",
 				"@semantic-release/npm": "^13.1.5",
 				"@semantic-release/release-notes-generator": "^14.1.1",
@@ -1789,36 +1789,36 @@
 			}
 		},
 		"node_modules/@semantic-release/error": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@semantic-release/git": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-			"integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
+			"integrity": "sha512-Zr8BUYCTZMc8V6wDKN2dpR7nJgewd9I6THL3ydLTnp3OEdTo1/4RBLNYaeRucYMsjMv+BXoCNfXA0NADj1kwhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@semantic-release/error": "^3.0.0",
-				"aggregate-error": "^3.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
 				"debug": "^4.0.0",
 				"dir-glob": "^3.0.0",
-				"execa": "^5.0.0",
-				"lodash": "^4.17.4",
+				"execa": "^10.0.0",
+				"lodash-es": "^4.17.21",
 				"micromatch": "^4.0.0",
-				"p-reduce": "^2.0.0"
+				"p-reduce": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": "^22.22.2 || >=24.15"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=18.0.0"
+				"semantic-release": ">=20.1.0"
 			}
 		},
 		"node_modules/@semantic-release/github": {
@@ -1851,75 +1851,6 @@
 			},
 			"peerDependencies": {
 				"semantic-release": ">=24.1.0"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/mime": {
@@ -1968,62 +1899,6 @@
 				"semantic-release": ">=20.1.0"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@semantic-release/npm/node_modules/execa": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -2061,111 +1936,6 @@
 				"@sec-ant/readable-stream": "^0.4.1",
 				"is-stream": "^4.0.1"
 			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/human-signals": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/is-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^4.0.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -2723,17 +2493,20 @@
 			}
 		},
 		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ajv": {
@@ -3025,13 +2798,32 @@
 			}
 		},
 		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clean-stack/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cli-highlight": {
@@ -3756,19 +3548,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/env-ci/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/env-ci/node_modules/strip-final-newline": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -4059,27 +3838,47 @@
 			}
 		},
 		"node_modules/execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+			"integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.1",
+				"human-signals": "^8.0.1",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^6.0.0",
+				"pretty-ms": "^9.3.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"which-command": "^0.1.0",
+				"yoctocolors": "^2.1.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/expect-type": {
@@ -4705,13 +4504,13 @@
 			}
 		},
 		"node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=10.17.0"
+				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -4803,13 +4602,16 @@
 			}
 		},
 		"node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/index-to-position": {
@@ -4936,13 +4738,13 @@
 			"license": "MIT"
 		},
 		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5528,13 +5330,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lodash-es": {
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
@@ -5671,9 +5466,9 @@
 			}
 		},
 		"node_modules/meilisearch": {
-			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.58.0.tgz",
-			"integrity": "sha512-MXFlU+JVG2I3tDI4brS3UHxEv2fjOROP24TPP16c8dGHTulb1kxMgXvKP0x4ImvUcsVVJFi4QXP0JNDS/TaWaw==",
+			"version": "0.60.0",
+			"resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.60.0.tgz",
+			"integrity": "sha512-z32KgxE6/7hRzbVfzUgzlmNl2OS7TwGE6wSWs2tVEuAY9DWrX6zAmt0s7wTyelH36orIaZ3/t1mQsCsExGtVDQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -5723,16 +5518,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -6069,16 +5854,46 @@
 			}
 		},
 		"node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"path-key": "^3.0.0"
+				"path-key": "^4.0.0",
+				"unicorn-magic": "^0.3.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm/node_modules/@gar/promise-retry": {
@@ -7875,22 +7690,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/openapi-types": {
 			"version": "12.1.3",
 			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -8006,13 +7805,16 @@
 			}
 		},
 		"node_modules/p-reduce": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-timeout": {
@@ -8856,62 +8658,6 @@
 				"node": "^22.14.0 || >= 24.10.0"
 			}
 		},
-		"node_modules/semantic-release/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/semantic-release/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/semantic-release/node_modules/execa": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -8956,85 +8702,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/human-signals": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/semantic-release/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/is-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/npm-run-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^4.0.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/p-reduce": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
-			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/semantic-release/node_modules/read-package-up": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
@@ -9053,32 +8720,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/semantic-release/node_modules/strip-final-newline": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/semantic-release/node_modules/type-fest": {
 			"version": "5.8.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
@@ -9090,19 +8731,6 @@
 			},
 			"engines": {
 				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/unicorn-magic": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9176,11 +8804,17 @@
 			"license": "ISC"
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/signale": {
 			"version": "1.4.0",
@@ -9490,13 +9124,16 @@
 			}
 		},
 		"node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -10283,6 +9920,22 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-command": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+			"integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"which-command": "cli.js"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/which-command?sponsor=1"
 			}
 		},
 		"node_modules/why-is-node-running": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
 			}
 		},
 		"node_modules/@actions/http-client/node_modules/undici": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -126,40 +126,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -605,9 +571,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -662,9 +628,9 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -771,9 +737,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@fastify/cors": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
-			"integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.3.0.tgz",
+			"integrity": "sha512-ggQGua+xHv1MvePbPr0v//xLYEsCXbWspquXCJS9Ot5YoRXq8J8ZWzHnxDBVnbtXosvistXo6LtNzOJswf64Fw==",
 			"funding": [
 				{
 					"type": "github",
@@ -786,25 +752,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fastify-plugin": "^5.0.0",
+				"fastify-plugin": "^6.0.0",
 				"toad-cache": "^3.7.0"
 			}
-		},
-		"node_modules/@fastify/cors/node_modules/fastify-plugin": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-			"integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/@fastify/error": {
 			"version": "4.2.0",
@@ -823,9 +773,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@fastify/fast-json-stringify-compiler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
-			"integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+			"integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
 			"funding": [
 				{
 					"type": "github",
@@ -838,13 +788,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-json-stringify": "^6.0.0"
+				"fast-json-stringify": "^7.0.0"
 			}
 		},
 		"node_modules/@fastify/forwarded": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
-			"integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.2.tgz",
+			"integrity": "sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==",
 			"funding": [
 				{
 					"type": "github",
@@ -933,9 +883,9 @@
 			}
 		},
 		"node_modules/@fastify/rate-limit": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.1.0.tgz",
-			"integrity": "sha512-BeJ9tizLvmTXGD7deYU5G04OtHhwk5uHxbpEPVp09gKvUBIXmau/4Bshxhu9ci54MvVWfGjCEx4RzvsTntojwA==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.2.0.tgz",
+			"integrity": "sha512-X7osJd4XSvMoejYrnJkSZYYjY1eNYoBqhjlzf1RakC2204qExFqZFTKj5+T7VuzA/iUI9Z3UoSqQRkB2HpG0oQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -950,6 +900,7 @@
 			"dependencies": {
 				"@lukeed/ms": "^2.0.2",
 				"fastify-plugin": "^6.0.0",
+				"ip-address": "^10.2.0",
 				"toad-cache": "^3.7.0"
 			}
 		},
@@ -977,9 +928,9 @@
 			}
 		},
 		"node_modules/@fastify/static": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-			"integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+			"version": "10.1.3",
+			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+			"integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -993,33 +944,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/accept-negotiator": "^2.0.0",
+				"@fastify/error": "^4.0.0",
 				"@fastify/send": "^4.0.0",
-				"content-disposition": "^1.0.1",
-				"fastify-plugin": "^5.0.0",
+				"content-disposition": "^2.0.1",
+				"fastify-plugin": "^6.0.0",
 				"fastq": "^1.17.1",
 				"glob": "^13.0.0"
 			}
 		},
-		"node_modules/@fastify/static/node_modules/fastify-plugin": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-			"integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/@fastify/swagger": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.7.0.tgz",
-			"integrity": "sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==",
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.8.1.tgz",
+			"integrity": "sha512-VpHMnqZTY8iBZYJE8WWkbKPrXIYWy2rDfIf5qLr6DzZSpQYZ+KxQVcJFiq/AMlvNwI4gCBd66++iUlxXXGT0IQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -1032,7 +968,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fastify-plugin": "^5.0.0",
+				"fastify-plugin": "^6.0.0",
 				"json-schema-resolver": "^3.0.0",
 				"openapi-types": "^12.1.3",
 				"rfdc": "^1.3.1",
@@ -1040,9 +976,9 @@
 			}
 		},
 		"node_modules/@fastify/swagger-ui": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-6.0.0.tgz",
-			"integrity": "sha512-L9c4CbXj3FnquqpCmn0IfbEeIqDUNi6QwXd23VhQj/bHEjNzDFIAy2W9I3prvSqM+mJWOElIa6uXROmcMDnfUA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-6.1.1.tgz",
+			"integrity": "sha512-RKCLSHASlzS2JZvHWn14NmEpHyl0yNosGvqzhUumm/LGPG6RWQBf4oscTFt83QDvc5O5Tol3Beup8inAl/k4EA==",
 			"funding": [
 				{
 					"type": "github",
@@ -1055,44 +991,12 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@fastify/static": "^9.1.2",
-				"fastify-plugin": "^5.0.0",
+				"@fastify/static": "^10.1.0",
+				"fastify-plugin": "^6.0.0",
 				"openapi-types": "^12.1.3",
 				"rfdc": "^1.3.1",
 				"yaml": "^2.4.1"
 			}
-		},
-		"node_modules/@fastify/swagger-ui/node_modules/fastify-plugin": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-			"integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@fastify/swagger/node_modules/fastify-plugin": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-			"integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/@hexagon/base64": {
 			"version": "1.1.28",
@@ -1188,25 +1092,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.3"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
 		"node_modules/@octokit/auth-token": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -1218,17 +1103,17 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+			"integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.3",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/graphql": "^9.0.4",
+				"@octokit/request": "^10.0.13",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"before-after-hook": "^4.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
@@ -1237,13 +1122,13 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+			"integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -1251,14 +1136,14 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+			"integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
@@ -1266,9 +1151,9 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "27.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1288,15 +1173,32 @@
 				"@octokit/core": ">=6"
 			}
 		},
-		"node_modules/@octokit/plugin-retry": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
-			"integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^27.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+			"integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -1307,13 +1209,13 @@
 			}
 		},
 		"node_modules/@octokit/plugin-throttling": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
-			"integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+			"integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0",
+				"@octokit/types": "^17.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -1324,15 +1226,15 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "10.0.11",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
-			"integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+			"version": "10.0.13",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+			"integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^11.0.3",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"content-type": "^2.0.0",
 				"json-with-bigint": "^3.5.3",
 				"universal-user-agent": "^7.0.2"
@@ -1342,32 +1244,32 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+			"integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0"
+				"@octokit/types": "^17.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^27.0.0"
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.138.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-			"integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1594,9 +1496,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-			"integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+			"integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1611,9 +1513,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-			"integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+			"integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1628,9 +1530,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-			"integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+			"integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
 			"cpu": [
 				"x64"
 			],
@@ -1645,9 +1547,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-			"integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+			"integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
 			"cpu": [
 				"x64"
 			],
@@ -1662,9 +1564,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-			"integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+			"integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
 			"cpu": [
 				"arm"
 			],
@@ -1679,9 +1581,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-			"integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+			"integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1699,9 +1601,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-			"integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+			"integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1719,9 +1621,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-			"integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+			"integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1739,9 +1641,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-			"integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+			"integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1759,9 +1661,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-			"integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+			"integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
 			"cpu": [
 				"x64"
 			],
@@ -1779,9 +1681,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-			"integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+			"integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
 			"cpu": [
 				"x64"
 			],
@@ -1799,9 +1701,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-			"integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+			"integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
 			"cpu": [
 				"arm64"
 			],
@@ -1815,29 +1717,10 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
-		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-			"integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "1.11.1",
-				"@emnapi/runtime": "1.11.1",
-				"@napi-rs/wasm-runtime": "^1.1.6"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-			"integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+			"integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1852,9 +1735,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-			"integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+			"integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
 			"cpu": [
 				"x64"
 			],
@@ -2385,17 +2268,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@types/bcryptjs": {
 			"version": "2.4.6",
 			"resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
@@ -2443,9 +2315,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-			"integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.18.0"
@@ -2469,17 +2341,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-			"integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+			"integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/type-utils": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/scope-manager": "8.66.0",
+				"@typescript-eslint/type-utils": "8.66.0",
+				"@typescript-eslint/utils": "8.66.0",
+				"@typescript-eslint/visitor-keys": "8.66.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2492,15 +2364,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.62.1",
+				"@typescript-eslint/parser": "^8.66.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2508,16 +2380,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-			"integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+			"integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/scope-manager": "8.66.0",
+				"@typescript-eslint/types": "8.66.0",
+				"@typescript-eslint/typescript-estree": "8.66.0",
+				"@typescript-eslint/visitor-keys": "8.66.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2533,14 +2405,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-			"integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+			"integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.62.1",
-				"@typescript-eslint/types": "^8.62.1",
+				"@typescript-eslint/tsconfig-utils": "^8.66.0",
+				"@typescript-eslint/types": "^8.66.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2555,14 +2427,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-			"integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+			"integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1"
+				"@typescript-eslint/types": "8.66.0",
+				"@typescript-eslint/visitor-keys": "8.66.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2573,9 +2445,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-			"integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+			"integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2590,15 +2462,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-			"integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+			"integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1",
+				"@typescript-eslint/types": "8.66.0",
+				"@typescript-eslint/typescript-estree": "8.66.0",
+				"@typescript-eslint/utils": "8.66.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2615,9 +2487,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-			"integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+			"integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2629,16 +2501,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-			"integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+			"integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.62.1",
-				"@typescript-eslint/tsconfig-utils": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/project-service": "8.66.0",
+				"@typescript-eslint/tsconfig-utils": "8.66.0",
+				"@typescript-eslint/types": "8.66.0",
+				"@typescript-eslint/visitor-keys": "8.66.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2657,16 +2529,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-			"integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+			"integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1"
+				"@typescript-eslint/scope-manager": "8.66.0",
+				"@typescript-eslint/types": "8.66.0",
+				"@typescript-eslint/typescript-estree": "8.66.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2681,13 +2553,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-			"integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+			"integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/types": "8.66.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -2699,16 +2571,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.9",
-				"@vitest/utils": "4.1.9",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2717,13 +2589,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.9",
+				"@vitest/spy": "4.1.10",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -2744,9 +2616,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2757,13 +2629,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.9",
+				"@vitest/utils": "4.1.10",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2771,14 +2643,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.9",
-				"@vitest/utils": "4.1.9",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2787,9 +2659,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2797,13 +2669,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.9",
+				"@vitest/pretty-format": "4.1.10",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2818,9 +2690,9 @@
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3024,9 +2896,9 @@
 			}
 		},
 		"node_modules/avvio": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
-			"integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+			"integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
 			"funding": [
 				{
 					"type": "github",
@@ -3085,15 +2957,15 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -3397,9 +3269,9 @@
 			}
 		},
 		"node_modules/content-disposition": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+			"integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3944,9 +3816,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-			"integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4022,9 +3894,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-			"integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+			"version": "10.8.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+			"integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -4034,7 +3906,7 @@
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/config-helpers": "^0.7.0",
 				"@eslint/core": "^1.2.1",
 				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
@@ -4058,7 +3930,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.4",
+				"minimatch": "^10.2.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -4221,9 +4093,9 @@
 			}
 		},
 		"node_modules/fast-copy": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
-			"integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+			"integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
 			"license": "MIT"
 		},
 		"node_modules/fast-decode-uri-component": {
@@ -4246,9 +4118,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-json-stringify": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
-			"integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+			"integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
 			"funding": [
 				{
 					"type": "github",
@@ -4264,7 +4136,7 @@
 				"@fastify/merge-json-schemas": "^0.2.0",
 				"ajv": "^8.12.0",
 				"ajv-formats": "^3.0.1",
-				"fast-uri": "^3.0.0",
+				"fast-uri": "^4.0.0",
 				"json-schema-ref-resolver": "^3.0.0",
 				"rfdc": "^1.2.0"
 			}
@@ -4284,6 +4156,38 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
+		},
+		"node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-json-stringify/node_modules/fast-uri": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+			"integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
@@ -4314,9 +4218,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",
@@ -4330,9 +4234,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.9.0.tgz",
-			"integrity": "sha512-VMS5lE0zj+MZlJpQa3Qv5iGjfun0H2N7VRgoBwpcTNQ2bdIQpv7fDpb+HGteGbicBsGkzGS+X+hdx9mmrfWuHQ==",
+			"version": "5.11.2",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.2.tgz",
+			"integrity": "sha512-i/eJG7nXR9OkbFgoX4jFiPOHoRq0rXqDACVAXELh5Fdg6BFBErIVZ8MyibGCwup9Go1pYrxZJ0ogIub8vVdEcQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -4351,7 +4255,7 @@
 				"@fastify/proxy-addr": "^5.0.0",
 				"abstract-logging": "^2.0.1",
 				"avvio": "^9.0.0",
-				"fast-json-stringify": "^6.0.0",
+				"fast-json-stringify": "^7.0.0",
 				"find-my-way": "^9.6.0",
 				"light-my-request": "^6.0.0",
 				"pino": "^9.14.0 || ^10.1.0",
@@ -4445,9 +4349,9 @@
 			}
 		},
 		"node_modules/find-my-way": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-			"integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+			"integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -4520,16 +4424,16 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-			"integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+			"integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4934,10 +4838,19 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/ip-address": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/ipaddr.js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-			"integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+			"integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
@@ -5090,9 +5003,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+			"integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -5115,9 +5028,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5209,9 +5122,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-with-bigint": {
-			"version": "3.5.8",
-			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-			"integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+			"version": "3.5.10",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+			"integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5290,9 +5203,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lightningcss": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
@@ -5306,23 +5219,23 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.32.0",
-				"lightningcss-darwin-arm64": "1.32.0",
-				"lightningcss-darwin-x64": "1.32.0",
-				"lightningcss-freebsd-x64": "1.32.0",
-				"lightningcss-linux-arm-gnueabihf": "1.32.0",
-				"lightningcss-linux-arm64-gnu": "1.32.0",
-				"lightningcss-linux-arm64-musl": "1.32.0",
-				"lightningcss-linux-x64-gnu": "1.32.0",
-				"lightningcss-linux-x64-musl": "1.32.0",
-				"lightningcss-win32-arm64-msvc": "1.32.0",
-				"lightningcss-win32-x64-msvc": "1.32.0"
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
 			}
 		},
 		"node_modules/lightningcss-android-arm64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5341,9 +5254,9 @@
 			}
 		},
 		"node_modules/lightningcss-darwin-arm64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5362,9 +5275,9 @@
 			}
 		},
 		"node_modules/lightningcss-darwin-x64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
 			"cpu": [
 				"x64"
 			],
@@ -5383,9 +5296,9 @@
 			}
 		},
 		"node_modules/lightningcss-freebsd-x64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
 			"cpu": [
 				"x64"
 			],
@@ -5404,9 +5317,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
 			"cpu": [
 				"arm"
 			],
@@ -5425,9 +5338,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5449,9 +5362,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -5473,9 +5386,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
 			"cpu": [
 				"x64"
 			],
@@ -5497,9 +5410,9 @@
 			}
 		},
 		"node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
 			"cpu": [
 				"x64"
 			],
@@ -5521,9 +5434,9 @@
 			}
 		},
 		"node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
 			"cpu": [
 				"arm64"
 			],
@@ -5542,9 +5455,9 @@
 			}
 		},
 		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
 			"cpu": [
 				"x64"
 			],
@@ -5671,9 +5584,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -5823,12 +5736,12 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.5"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -5862,9 +5775,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mysql2": {
-			"version": "3.22.5",
-			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.5.tgz",
-			"integrity": "sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==",
+			"version": "3.23.2",
+			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.2.tgz",
+			"integrity": "sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==",
 			"license": "MIT",
 			"dependencies": {
 				"aws-ssl-profiles": "^1.1.2",
@@ -5874,7 +5787,7 @@
 				"long": "^5.3.2",
 				"lru.min": "^1.1.4",
 				"named-placeholders": "^1.1.6",
-				"sql-escaper": "^1.3.3"
+				"sql-escaper": "^1.5.1"
 			},
 			"engines": {
 				"node": ">= 8.0"
@@ -5908,9 +5821,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5964,9 +5877,9 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-			"integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
+			"integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
@@ -6001,9 +5914,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "11.18.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
-			"integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
+			"version": "11.19.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
+			"integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -6082,7 +5995,7 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.9.0",
+				"@npmcli/arborist": "^9.9.1",
 				"@npmcli/config": "^10.12.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
@@ -6107,11 +6020,11 @@
 				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.11",
-				"libnpmexec": "^10.3.1",
-				"libnpmfund": "^7.0.25",
+				"libnpmdiff": "^8.1.12",
+				"libnpmexec": "^10.3.2",
+				"libnpmfund": "^7.0.26",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.11",
+				"libnpmpack": "^9.1.12",
 				"libnpmpublish": "^11.2.0",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
@@ -6212,7 +6125,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.9.0",
+			"version": "9.9.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6979,12 +6892,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.11",
+			"version": "8.1.12",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.9.0",
+				"@npmcli/arborist": "^9.9.1",
 				"@npmcli/installed-package-contents": "^4.0.0",
 				"binary-extensions": "^3.0.0",
 				"diff": "^8.0.2",
@@ -6998,13 +6911,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.3.1",
+			"version": "10.3.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.9.0",
+				"@npmcli/arborist": "^9.9.1",
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
@@ -7021,12 +6934,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.25",
+			"version": "7.0.26",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.9.0"
+				"@npmcli/arborist": "^9.9.1"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -7046,12 +6959,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.11",
+			"version": "9.1.12",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.9.0",
+				"@npmcli/arborist": "^9.9.1",
 				"@npmcli/run-script": "^10.0.0",
 				"npm-package-arg": "^13.0.0",
 				"pacote": "^21.0.2"
@@ -7931,9 +7844,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -8080,9 +7993,9 @@
 			}
 		},
 		"node_modules/p-map": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-			"integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+			"integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8415,9 +8328,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8435,7 +8348,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -8477,9 +8390,9 @@
 			"license": "MIT"
 		},
 		"node_modules/process-warning": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+			"integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
 			"funding": [
 				{
 					"type": "github",
@@ -8547,9 +8460,9 @@
 			}
 		},
 		"node_modules/pvutils": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+			"integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.0.0"
@@ -8694,9 +8607,9 @@
 			}
 		},
 		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+			"integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"dependencies": {
@@ -8808,13 +8721,13 @@
 			"license": "MIT"
 		},
 		"node_modules/rolldown": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-			"integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+			"integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.138.0",
+				"@oxc-project/types": "=0.143.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -8824,21 +8737,20 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.1.4",
-				"@rolldown/binding-darwin-arm64": "1.1.4",
-				"@rolldown/binding-darwin-x64": "1.1.4",
-				"@rolldown/binding-freebsd-x64": "1.1.4",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-				"@rolldown/binding-linux-arm64-gnu": "1.1.4",
-				"@rolldown/binding-linux-arm64-musl": "1.1.4",
-				"@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-				"@rolldown/binding-linux-s390x-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-musl": "1.1.4",
-				"@rolldown/binding-openharmony-arm64": "1.1.4",
-				"@rolldown/binding-wasm32-wasi": "1.1.4",
-				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
-				"@rolldown/binding-win32-x64-msvc": "1.1.4"
+				"@rolldown/binding-android-arm64": "1.2.3",
+				"@rolldown/binding-darwin-arm64": "1.2.3",
+				"@rolldown/binding-darwin-x64": "1.2.3",
+				"@rolldown/binding-freebsd-x64": "1.2.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.3",
+				"@rolldown/binding-linux-arm64-musl": "1.2.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.3",
+				"@rolldown/binding-linux-x64-gnu": "1.2.3",
+				"@rolldown/binding-linux-x64-musl": "1.2.3",
+				"@rolldown/binding-openharmony-arm64": "1.2.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.3",
+				"@rolldown/binding-win32-x64-msvc": "1.2.3"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -8902,9 +8814,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/semantic-release": {
-			"version": "25.0.5",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.5.tgz",
-			"integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
+			"version": "25.0.9",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+			"integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9168,9 +9080,9 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/type-fest": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+			"integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"dependencies": {
@@ -9471,9 +9383,9 @@
 			}
 		},
 		"node_modules/sql-escaper": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
-			"integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+			"integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
 			"license": "MIT",
 			"engines": {
 				"bun": ">=1.0.0",
@@ -9502,9 +9414,9 @@
 			}
 		},
 		"node_modules/std-env": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9791,9 +9703,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9849,9 +9761,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9922,9 +9834,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"version": "4.23.11",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+			"integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10009,16 +9921,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-			"integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+			"version": "8.66.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+			"integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.62.1",
-				"@typescript-eslint/parser": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1"
+				"@typescript-eslint/eslint-plugin": "8.66.0",
+				"@typescript-eslint/parser": "8.66.0",
+				"@typescript-eslint/typescript-estree": "8.66.0",
+				"@typescript-eslint/utils": "8.66.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10047,9 +9959,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10157,16 +10069,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.16",
-				"rolldown": "~1.1.3",
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.25",
+				"rolldown": "~1.2.1",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
@@ -10183,7 +10095,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.3.0",
+				"@vitejs/devtools": "^0.4.0",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -10248,19 +10160,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.9",
-				"@vitest/mocker": "4.1.9",
-				"@vitest/pretty-format": "4.1.9",
-				"@vitest/runner": "4.1.9",
-				"@vitest/snapshot": "4.1.9",
-				"@vitest/spy": "4.1.9",
-				"@vitest/utils": "4.1.9",
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -10288,12 +10200,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.9",
-				"@vitest/browser-preview": "4.1.9",
-				"@vitest/browser-webdriverio": "4.1.9",
-				"@vitest/coverage-istanbul": "4.1.9",
-				"@vitest/coverage-v8": "4.1.9",
-				"@vitest/ui": "4.1.9",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -10508,16 +10420,16 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^9.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
-				"string-width": "^7.2.0",
+				"string-width": "^8.2.1",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^22.0.0"
 			},
@@ -10535,26 +10447,18 @@
 				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
-		"node_modules/yargs/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/yargs/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -10590,9 +10494,9 @@
 			}
 		},
 		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
 		"fastify-plugin": "^6.0.0",
 		"fastify-type-provider-zod": "^7.0.0",
 		"jose": "^6.2.3",
-		"meilisearch": "^0.58.0",
+		"meilisearch": "^0.60.0",
 		"nodemailer": "^9.0.3",
 		"pino-pretty": "^13.1.3",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@semantic-release/commit-analyzer": "^13.0.1",
-		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/git": "^11.0.1",
 		"@semantic-release/github": "^12.0.9",
 		"@semantic-release/npm": "^13.1.5",
 		"@semantic-release/release-notes-generator": "^14.1.1",


### PR DESCRIPTION
Chore follow-up after mellonis/poetry#29 landed: `npm update` within existing ranges, then latest majors applied one at a time, keeping only the ones that stayed green.

## Kept

**In-range (`npm update`):** package-lock refresh only, no `package.json` changes — `@fastify/cors`, `@fastify/rate-limit`, `@fastify/swagger`, `@fastify/swagger-ui`, `fastify`, `eslint`, `typescript-eslint`, `@tsconfig/node24`, `jose`, `nodemailer`, `semantic-release`, `tsx`, `vitest` all moved to their latest in-range versions. `npm audit` dropped from 14 to 7 advisories as a side effect.

**Safe majors:**
- `@semantic-release/git` 10 → 11 (Node engine requirement `^22.22.2 || >=24.15`, satisfied by the runtime major)
- `meilisearch` 0.58 → 0.60 (0.x release, treated as major)

## Skipped

- **`typescript` 6 → 7** — reverted. `typescript-eslint` explicitly refuses to run on TS 7.0 (`typescript-eslint does not support TS 7.0`, tracked at typescript-eslint#10940). Real blocker, not a config tweak — leaving for a follow-up once typescript-eslint adds TS 7 support.
- **`@types/bcryptjs` 2 → 3** — skipped. 3.0.0 is a deprecated stub (`This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.`) — `bcryptjs` has shipped its own types since its own 3.x, which is already the installed runtime version. Bumping would add a known-deprecated no-op package; the actual fix is dropping the `@types/bcryptjs` devDependency entirely, which is a removal, not a bump — out of scope here, noted for follow-up.
- **`@types/node` 24 → 26** — skipped per policy. Runtime Node major is pinned to 24 in both CI (`node-version: 24` in `deploy.yml`/`release.yml`) and the Dockerfile (`FROM node:24-alpine`); `@types/node`'s major must track that, not the newest types package available.

## `deps/fastify-majors` note

Checked `origin/deps/fastify-majors` before touching Fastify. Its package.json is now identical to master's except for the version field — its bumps (`@fastify/rate-limit` 11, `fastify-plugin` 6, `fastify-type-provider-zod` 7) already landed via #160 (`7d2b2be`). That branch is fully superseded/stale; this PR did no further Fastify major work since nothing new is available.

Closes #173
