### PR TITLE
CI: cache Docker image layers in the GHA cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+      # buildx, because the default docker driver cannot use the GHA cache
+      # backend the build step below exports layers to.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -69,6 +73,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.10.0
         with:


### PR DESCRIPTION
Adds buildx setup and `cache-from`/`cache-to: type=gha` to the image build. Every merge currently cold-builds the image; with the layer cache, merges that don't move the lockfile reuse the dependency-install layer. Workflow-only change — `check-paths` classifies it as not deployable, so merging this does not redeploy.