### PR TITLE
fix: depth-aware [q] quote pairs in search text stripping

### DIFF
--- a/src/plugins/search/search.ts
+++ b/src/plugins/search/search.ts
@@ -10,7 +10,7 @@ declare module 'fastify' {
 }
 
 const INDEX_NAME = 'things';
-const INDEX_VERSION = 5;
+const INDEX_VERSION = 6;
 
 export { INDEX_NAME as SEARCH_INDEX_NAME };
 

--- a/src/plugins/search/textStripping.test.ts
+++ b/src/plugins/search/textStripping.test.ts
@@ -10,6 +10,14 @@ describe('stripBBCode', () => {
 		expect(stripBBCode('[q]quote[/q]')).toBe('\u00ABquote\u00BB');
 	});
 
+	test('strips nested quote tags to depth-matched pairs (\u00AB\u00BB, \u201E\u201C, \u201A\u2018)', () => {
+		expect(stripBBCode('[q]a [q]b [q]c[/q][/q][/q]')).toBe('\u00ABa \u201Eb \u201Ac\u2018\u201C\u00BB');
+	});
+
+	test('strips an unmatched closing quote tag to \u00BB', () => {
+		expect(stripBBCode('quote[/q]')).toBe('quote\u00BB');
+	});
+
 	test('strips nested tags', () => {
 		expect(stripBBCode('[b][i]text[/i][/b]')).toBe('text');
 	});

--- a/src/plugins/search/textStripping.ts
+++ b/src/plugins/search/textStripping.ts
@@ -1,7 +1,22 @@
+// Quote pairs by [q] nesting depth, mirroring the site renderers' plain-text
+// mode: L1 «», L2 „“, L3+ ‚‘.
+const QUOTE_PAIRS = [['«', '»'], ['„', '“'], ['‚', '‘']] as const;
+
+const replaceQTags = (text: string): string => {
+	let depth = 0;
+	return text.replace(/\[(\/?)q]/g, (_match, closing) => {
+		if (closing) {
+			depth = Math.max(0, depth - 1);
+			return QUOTE_PAIRS[Math.min(depth, QUOTE_PAIRS.length - 1)][1];
+		}
+		const open = QUOTE_PAIRS[Math.min(depth, QUOTE_PAIRS.length - 1)][0];
+		depth += 1;
+		return open;
+	});
+};
+
 const plainTextRules: [RegExp, string][] = [
 	[/<<([^>]*?)>>/g, '$1'],
-	[/\[q]/g, '«'],
-	[/\[\/q]/g, '»'],
 	[/\[img[^\]]*].*?\[\/img]?/igs, ''],
 	[/\[[^[]*]/g, ''],
 	[/\[\/[^[]*]/g, ''],
@@ -10,7 +25,7 @@ const plainTextRules: [RegExp, string][] = [
 export const stripBBCode = (text: string): string =>
 	plainTextRules.reduce(
 		(result, [pattern, replacement]) => result.replace(pattern, replacement),
-		text,
+		replaceQTags(text),
 	);
 
 export const stripNoteMarkers = (text: string): string =>


### PR DESCRIPTION
## Summary

api part of mellonis/poetry#30 — search indexing stripped nested `[q]` to flat «/», producing ««…»» (doubled identical marks, which the typographic references forbid).

- **`textStripping.ts`**: depth-aware `[q]` replacement — level maps to «», „“ (U+201E/U+201C), ‚‘ (U+201A/U+2018); deepest pair repeats beyond level 3; unmatched `[/q]` still yields `»`. +2 tests.
- **`INDEX_VERSION` 5 → 6**: stripping logic changed, so the automatic full reindex kicks in on next deploy startup (per the versioning convention in `search.ts`).

Sibling PRs: mellonis/poetry-nextjs#165, mellonis/poetry-old2#113 (renderers); this one only affects search snippets.

## Testing

- `npm test` — 314 passed (2 new)
- `npm run lint` — clean
